### PR TITLE
chore: initialize project name from template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -11,7 +11,7 @@ body:
         Thank you for suggesting an improvement! Please fill in the details below.
 
         Before opening a new feature request, please check
-        [existing issues](https://github.com/llm-d/{{PROJECT_NAME}}/issues)
+        [existing issues](https://github.com/llm-d/llm-d-inference-payload-processor/issues)
         to see if a similar request already exists.
 
   - type: textarea

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,14 @@ FROM golang:1.24 AS builder
 
 WORKDIR /workspace
 
-# Cache dependencies
-COPY go.mod go.sum ./
+# Cache dependencies (go.sum is optional until the first dep is added)
+COPY go.mod ./
+COPY go.su[m] ./
 RUN go mod download
 
 # Copy source and build
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /workspace/app .
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /workspace/app ./cmd
 
 # --- Runtime stage ---
 FROM gcr.io/distroless/static:nonroot

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Multi-stage build for {{PROJECT_NAME}}
+# Multi-stage build for llm-d-inference-payload-processor
 # Supports multi-arch: linux/amd64, linux/arm64
 
 # --- Build stage ---

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ help: ## Show this help message
 
 .PHONY: build
 build: ## Build the Go binary
-	go build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o bin/$(PROJECT_NAME) .
+	go build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o bin/$(PROJECT_NAME) ./cmd
 
 .PHONY: test
 test: ## Run tests with race detection

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 # Project configuration
-# TODO: Replace {{PROJECT_NAME}} with your project name
-PROJECT_NAME ?= {{PROJECT_NAME}}
+PROJECT_NAME ?= llm-d-inference-payload-processor
 REGISTRY ?= ghcr.io/llm-d
 IMAGE ?= $(REGISTRY)/$(PROJECT_NAME)
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")

--- a/README.md
+++ b/README.md
@@ -1,12 +1,9 @@
-# {{PROJECT_NAME}}
+# llm-d-inference-payload-processor
 
-<!-- TODO: Replace {{PROJECT_NAME}} with your project name -->
-<!-- TODO: Update badges below with correct repo path -->
-
-[![CI](https://github.com/llm-d/{{PROJECT_NAME}}/actions/workflows/ci-pr-checks.yaml/badge.svg)](https://github.com/llm-d/{{PROJECT_NAME}}/actions/workflows/ci-pr-checks.yaml)
+[![CI](https://github.com/llm-d/llm-d-inference-payload-processor/actions/workflows/ci-pr-checks.yaml/badge.svg)](https://github.com/llm-d/llm-d-inference-payload-processor/actions/workflows/ci-pr-checks.yaml)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
-> **One-line description of what this project does.**
+> **Inference payload processor for llm-d.**
 
 ## Overview
 
@@ -22,8 +19,8 @@
 
 ```bash
 # Clone the repo
-git clone https://github.com/llm-d/{{PROJECT_NAME}}.git
-cd {{PROJECT_NAME}}
+git clone https://github.com/llm-d/llm-d-inference-payload-processor.git
+cd llm-d-inference-payload-processor
 
 # Install pre-commit hooks
 pre-commit install

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/llm-d/{{PROJECT_NAME}}
+module github.com/llm-d/llm-d-inference-payload-processor
 
 go 1.24.0


### PR DESCRIPTION
## Summary
- Replace `{{PROJECT_NAME}}` placeholders with `llm-d-inference-payload-processor` across `go.mod`, `Dockerfile`, `Makefile`, `README.md`, and the feature-request issue template
- Drop the template TODO banners now that the project name is set
- Set the README one-liner to "Inference payload processor for llm-d"

## Test plan
- [x] `go vet ./...` passes
- [x] `go build ./cmd` produces a runnable binary
- [ ] CI (build/lint) green