### PR TITLE
fix: use llm-d.ai domain in ipp-managed label

### DIFF
--- a/pkg/plugins/basemodelextractor/configmap_reconciler.go
+++ b/pkg/plugins/basemodelextractor/configmap_reconciler.go
@@ -29,14 +29,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
-const ippManagedLabel = "inference.llm-d.io/ipp-managed"
+const ippManagedLabel = "inference.llm-d.ai/ipp-managed"
 
 func hasIPPManagedLabel(object client.Object) bool {
 	return object.GetLabels()[ippManagedLabel] == "true"
 }
 
 // ippManagedPredicate filters events to only ConfigMaps labeled with
-// "inference.llm-d.io/ipp-managed" = "true".
+// "inference.llm-d.ai/ipp-managed" = "true".
 func ippManagedPredicate() predicate.Predicate {
 	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool { return hasIPPManagedLabel(e.Object) },

--- a/test/integration/harness.go
+++ b/test/integration/harness.go
@@ -63,7 +63,7 @@ func NewHarness(t *testing.T, ctx context.Context, streaming bool) *Harness {
 			Name:      "test-model-mappings",
 			Namespace: "default",
 			Labels: map[string]string{
-				"inference.llm-d.io/ipp-managed": "true",
+				"inference.llm-d.ai/ipp-managed": "true",
 			},
 		},
 		Data: map[string]string{


### PR DESCRIPTION

## What does this PR do?

Updates the ConfigMap label from `inference.llm-d.io/ipp-managed` to `inference.llm-d.ai/ipp-managed` to use the correct domain.