### PR TITLE
feat: build and publish container image

### DIFF
--- a/.github/workflows/ci-build-image.yaml
+++ b/.github/workflows/ci-build-image.yaml
@@ -1,0 +1,40 @@
+name: Build and Push Container Image
+
+on:
+  workflow_call:
+    inputs:
+      image-name:
+        required: true
+        type: string
+        default: "llm-d-inference-payload-processor"
+      tag:
+        required: true
+        type: string
+      prerelease:
+        required: true
+        type: string
+    secrets:
+      GHCR_TOKEN:
+        required: true
+
+jobs:
+  build-and-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Build and push image
+        uses: ./.github/actions/docker-build-and-push
+        with:
+          docker-file: Dockerfile
+          tag: ${{ inputs.tag }}
+          image-name: ${{ inputs.image-name }}
+          registry: ghcr.io/llm-d
+          github-token: ${{ secrets.GHCR_TOKEN }}
+          prerelease: ${{ inputs.prerelease }}
+      
+      - name: Run Trivy scan on image
+        uses: ./.github/actions/trivy-scan
+        with:
+          image: ghcr.io/llm-d/${{ inputs.image-name }}:${{ inputs.tag }}

--- a/.github/workflows/ci-dev.yaml
+++ b/.github/workflows/ci-dev.yaml
@@ -1,11 +1,9 @@
-name: CI - Release
+name: CI - Dev
 
 on:
   push:
-    tags:
-      - 'v*'
-  release:
-    types: [published]
+    branches:
+      - main
 
 permissions:
   contents: read
@@ -31,16 +29,8 @@ jobs:
       - name: Determine tag
         id: tag
         run: |
-          if [[ "${GITHUB_EVENT_NAME}" == "release" ]]; then
-            echo "tag=${GITHUB_REF##refs/tags/}" >> "$GITHUB_OUTPUT"
-            echo "prerelease=${{ github.event.release.prerelease }}" >> "$GITHUB_OUTPUT"
-          elif [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            echo "tag=${GITHUB_REF##refs/tags/}" >> "$GITHUB_OUTPUT"
-            echo "prerelease=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "tag=latest" >> "$GITHUB_OUTPUT"
-            echo "prerelease=false" >> "$GITHUB_OUTPUT"
-          fi
+          echo "tag=latest" >> "$GITHUB_OUTPUT"
+          echo "prerelease=true" >> "$GITHUB_OUTPUT"
         shell: bash
 
   docker-build-and-push:


### PR DESCRIPTION
This PR introduces a centralized GitHub Actions workflow for building and pushing container images, following the principles and structure of the llm-d-inference-scheduler repository.

Closes #35