### PR TITLE
refactor(extproc): remove buffered mode, use streaming only

### DIFF
--- a/cmd/runner/runner.go
+++ b/cmd/runner/runner.go
@@ -222,7 +222,6 @@ func (r *Runner) Run(ctx context.Context) error {
 	serverRunner := &runserver.ExtProcServerRunner{
 		GrpcPort:        opts.GRPCPort,
 		SecureServing:   opts.SecureServing,
-		Streaming:       opts.Streaming,
 		RequestPlugins:  r.requestPlugins,
 		ResponsePlugins: r.responsePlugins,
 	}

--- a/config/charts/payload-processor/templates/payload-processor.yaml
+++ b/config/charts/payload-processor/templates/payload-processor.yaml
@@ -19,7 +19,6 @@ spec:
         image: {{ .Values.payloadProcessor.image.registry }}/{{ .Values.payloadProcessor.image.repository }}:{{ .Values.payloadProcessor.image.tag }}
         imagePullPolicy: {{ .Values.payloadProcessor.image.pullPolicy }}
         args:
-        - "--streaming"
         # Pass additional flags via the payloadProcessor.flags field in values.yaml.
         {{- range $key, $value := .Values.payloadProcessor.flags }}
         - --{{ $key }}={{ $value }}

--- a/pkg/handlers/request.go
+++ b/pkg/handlers/request.go
@@ -35,7 +35,7 @@ import (
 
 // HandleRequestHeaders extracts request headers into reqCtx and returns
 // the ext-proc header response.
-func (s *Server) HandleRequestHeaders(ctx context.Context, reqCtx *RequestContext, headers *eppb.HttpHeaders, streaming bool) []*eppb.ProcessingResponse {
+func (s *Server) HandleRequestHeaders(ctx context.Context, reqCtx *RequestContext, headers *eppb.HttpHeaders) []*eppb.ProcessingResponse {
 	reqCtx.RequestReceivedTimestamp = time.Now()
 
 	if headers != nil && headers.Headers != nil {
@@ -44,12 +44,11 @@ func (s *Server) HandleRequestHeaders(ctx context.Context, reqCtx *RequestContex
 		}
 	}
 
-	if streaming && !headers.GetEndOfStream() {
+	if !headers.GetEndOfStream() {
 		log.FromContext(ctx).V(logutil.VERBOSE).Info("captured request headers, deferring response until body arrives...")
 		return nil
 	}
-	// if we're here, that means we're in non-streaming, or we're in streaming and got end of stream(means no body).
-	// in both cases we can return HeadersResponse
+	// EndOfStream means no body is expected, return HeadersResponse immediately
 	return []*eppb.ProcessingResponse{
 		{
 			Response: &eppb.ProcessingResponse_RequestHeaders{
@@ -80,61 +79,32 @@ func (s *Server) HandleRequestBody(ctx context.Context, reqCtx *RequestContext, 
 			return nil, err
 		}
 		reqCtx.Request.SetHeader(contentLengthHeader, strconv.Itoa(len(mutatedBodyBytes)))
-	} else if s.streaming {
-		// In streaming mode, always set Content-Length even if body is not mutated
-		// to inform Envoy of the body size that will follow
+	} else {
+		// Always set Content-Length to inform Envoy of the body size that will follow
 		reqCtx.Request.SetHeader(contentLengthHeader, strconv.Itoa(len(requestBodyBytes)))
 	}
 
 	metrics.RecordSuccessCounter()
 
-	if s.streaming {
-		ret = append(ret, &eppb.ProcessingResponse{
-			Response: &eppb.ProcessingResponse_RequestHeaders{
-				RequestHeaders: &eppb.HeadersResponse{
-					Response: &eppb.CommonResponse{
-						ClearRouteCache: true,
-						HeaderMutation: &eppb.HeaderMutation{
-							SetHeaders:    envoy.GenerateHeadersMutation(reqCtx.Request.MutatedHeaders()),
-							RemoveHeaders: reqCtx.Request.RemovedHeaders(),
-						},
+	ret = append(ret, &eppb.ProcessingResponse{
+		Response: &eppb.ProcessingResponse_RequestHeaders{
+			RequestHeaders: &eppb.HeadersResponse{
+				Response: &eppb.CommonResponse{
+					ClearRouteCache: true,
+					HeaderMutation: &eppb.HeaderMutation{
+						SetHeaders:    envoy.GenerateHeadersMutation(reqCtx.Request.MutatedHeaders()),
+						RemoveHeaders: reqCtx.Request.RemovedHeaders(),
 					},
 				},
 			},
-		})
-		if bodyMutated {
-			ret = addStreamedBodyResponse(ret, mutatedBodyBytes)
-		} else {
-			ret = addStreamedBodyResponse(ret, requestBodyBytes)
-		}
-		return ret, nil
-	}
-
-	// Necessary so that the new headers are used in the routing decision.
-	response := &eppb.CommonResponse{
-		ClearRouteCache: true,
-		HeaderMutation: &eppb.HeaderMutation{
-			SetHeaders:    envoy.GenerateHeadersMutation(reqCtx.Request.MutatedHeaders()),
-			RemoveHeaders: reqCtx.Request.RemovedHeaders(),
 		},
-	}
+	})
 	if bodyMutated {
-		response.BodyMutation = &eppb.BodyMutation{
-			Mutation: &eppb.BodyMutation_Body{
-				Body: mutatedBodyBytes,
-			},
-		}
+		ret = addStreamedBodyResponse(ret, mutatedBodyBytes)
+	} else {
+		ret = addStreamedBodyResponse(ret, requestBodyBytes)
 	}
-
-	return []*eppb.ProcessingResponse{
-		{
-			Response: &eppb.ProcessingResponse_RequestBody{
-				RequestBody: &eppb.BodyResponse{
-					Response: response,
-				},
-			},
-		},
-	}, nil
+	return ret, nil
 }
 
 // runRequestPlugins executes request plugins in the order they were registered.

--- a/pkg/handlers/request_test.go
+++ b/pkg/handlers/request_test.go
@@ -46,12 +46,11 @@ func TestHandleRequestHeaders(t *testing.T) {
 	tests := []struct {
 		name         string
 		headers      *extProcPb.HttpHeaders
-		streaming    bool
 		wantHeaders  map[string]string
 		wantResponse []*extProcPb.ProcessingResponse
 	}{
 		{
-			name: "headers response in non-streaming",
+			name: "extracts headers, defers response when not end of stream",
 			headers: &extProcPb.HttpHeaders{
 				Headers: &basepb.HeaderMap{
 					Headers: []*basepb.HeaderValue{
@@ -60,26 +59,6 @@ func TestHandleRequestHeaders(t *testing.T) {
 					},
 				},
 			},
-			streaming: false,
-			wantHeaders: map[string]string{
-				"content-type": "application/json",
-				"x-request-id": "abc-123",
-			},
-			wantResponse: []*extProcPb.ProcessingResponse{
-				{Response: &extProcPb.ProcessingResponse_RequestHeaders{RequestHeaders: &extProcPb.HeadersResponse{}}},
-			},
-		},
-		{
-			name: "extracts headers in streaming, but not end of stream",
-			headers: &extProcPb.HttpHeaders{
-				Headers: &basepb.HeaderMap{
-					Headers: []*basepb.HeaderValue{
-						{Key: "content-type", RawValue: []byte("application/json")},
-						{Key: "x-request-id", RawValue: []byte("abc-123")},
-					},
-				},
-			},
-			streaming: true,
 			wantHeaders: map[string]string{
 				"content-type": "application/json",
 				"x-request-id": "abc-123",
@@ -87,7 +66,7 @@ func TestHandleRequestHeaders(t *testing.T) {
 			wantResponse: nil,
 		},
 		{
-			name: "extracts headers in streaming and end of stream",
+			name: "extracts headers and returns response when end of stream",
 			headers: &extProcPb.HttpHeaders{
 				Headers: &basepb.HeaderMap{
 					Headers: []*basepb.HeaderValue{
@@ -97,7 +76,6 @@ func TestHandleRequestHeaders(t *testing.T) {
 				},
 				EndOfStream: true,
 			},
-			streaming: true,
 			wantHeaders: map[string]string{
 				"content-type": "application/json",
 				"x-request-id": "abc-123",
@@ -114,8 +92,8 @@ func TestHandleRequestHeaders(t *testing.T) {
 						{Key: "x-test", RawValue: []byte("raw"), Value: "plain"},
 					},
 				},
+				EndOfStream: true,
 			},
-			streaming: false,
 			wantHeaders: map[string]string{
 				"x-test": "raw",
 			},
@@ -131,8 +109,8 @@ func TestHandleRequestHeaders(t *testing.T) {
 						{Key: "x-test", Value: "plain"},
 					},
 				},
+				EndOfStream: true,
 			},
-			streaming: false,
 			wantHeaders: map[string]string{
 				"x-test": "plain",
 			},
@@ -141,32 +119,25 @@ func TestHandleRequestHeaders(t *testing.T) {
 			},
 		},
 		{
-			name:        "nil headers",
-			headers:     nil,
-			streaming:   false,
-			wantHeaders: map[string]string{},
-			wantResponse: []*extProcPb.ProcessingResponse{
-				{Response: &extProcPb.ProcessingResponse_RequestHeaders{RequestHeaders: &extProcPb.HeadersResponse{}}},
-			},
+			name:         "nil headers returns response when EndOfStream would be false",
+			headers:      nil,
+			wantHeaders:  map[string]string{},
+			wantResponse: nil,
 		},
 		{
-			name:        "nil header map",
-			headers:     &extProcPb.HttpHeaders{},
-			streaming:   false,
-			wantHeaders: map[string]string{},
-			wantResponse: []*extProcPb.ProcessingResponse{
-				{Response: &extProcPb.ProcessingResponse_RequestHeaders{RequestHeaders: &extProcPb.HeadersResponse{}}},
-			},
+			name:         "nil header map defers response",
+			headers:      &extProcPb.HttpHeaders{},
+			wantHeaders:  map[string]string{},
+			wantResponse: nil,
 		},
-
 		{
-			name: "empty header map",
+			name: "empty header map with end of stream",
 			headers: &extProcPb.HttpHeaders{
 				Headers: &basepb.HeaderMap{
 					Headers: []*basepb.HeaderValue{},
 				},
+				EndOfStream: true,
 			},
-			streaming:   false,
 			wantHeaders: map[string]string{},
 			wantResponse: []*extProcPb.ProcessingResponse{
 				{Response: &extProcPb.ProcessingResponse_RequestHeaders{RequestHeaders: &extProcPb.HeadersResponse{}}},
@@ -176,12 +147,12 @@ func TestHandleRequestHeaders(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			server := NewServer(false, []framework.RequestProcessor{}, []framework.ResponseProcessor{})
+			server := NewServer([]framework.RequestProcessor{}, []framework.ResponseProcessor{})
 			reqCtx := &RequestContext{
 				Request: framework.NewInferenceRequest(),
 			}
 
-			resp := server.HandleRequestHeaders(context.Background(), reqCtx, tc.headers, tc.streaming)
+			resp := server.HandleRequestHeaders(context.Background(), reqCtx, tc.headers)
 			if reqCtx.RequestReceivedTimestamp.IsZero() {
 				t.Error("RequestReceivedTimestamp was not set")
 			}
@@ -199,37 +170,19 @@ func TestHandleRequestHeaders(t *testing.T) {
 
 // === Request Body Tests (built-in plugins) ===
 
-func TestHandleRequestBody(t *testing.T) {
+func TestHandleRequestBody_BuiltInPlugins(t *testing.T) {
 	metrics.Register()
 	ctx := logutil.NewTestLoggerIntoContext(context.Background())
 
 	tests := []struct {
-		name      string
-		body      map[string]any
-		streaming bool
-		want      []*extProcPb.ProcessingResponse
-		wantErr   bool
+		name    string
+		body    map[string]any
+		want    []*extProcPb.ProcessingResponse
+		wantErr bool
 	}{
 		{
 			name: "model not found - skips gracefully",
 			body: map[string]any{"prompt": "Tell me a joke"},
-			want: []*extProcPb.ProcessingResponse{
-				{
-					Response: &extProcPb.ProcessingResponse_RequestBody{
-						RequestBody: &extProcPb.BodyResponse{
-							Response: &extProcPb.CommonResponse{
-								ClearRouteCache: true,
-								HeaderMutation:  &extProcPb.HeaderMutation{},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name:      "model not found with streaming - skips gracefully",
-			body:      map[string]any{"prompt": "Tell me a joke"},
-			streaming: true,
 			want: []*extProcPb.ProcessingResponse{
 				{
 					Response: &extProcPb.ProcessingResponse_RequestHeaders{
@@ -271,17 +224,26 @@ func TestHandleRequestBody(t *testing.T) {
 		{
 			name: "model in body but empty - skips gracefully",
 			body: map[string]any{"model": "", "prompt": "Tell me a joke"},
-			want: []*extProcPb.ProcessingResponse{
-				{
-					Response: &extProcPb.ProcessingResponse_RequestBody{
-						RequestBody: &extProcPb.BodyResponse{
-							Response: &extProcPb.CommonResponse{
-								ClearRouteCache: true,
-								HeaderMutation: &extProcPb.HeaderMutation{
-									SetHeaders: []*basepb.HeaderValueOption{
-										{
-											Header: &basepb.HeaderValue{
-												Key: basemodelextractor.BaseModelHeader,
+			want: func() []*extProcPb.ProcessingResponse {
+				b, _ := json.Marshal(map[string]any{"model": "", "prompt": "Tell me a joke"})
+				return []*extProcPb.ProcessingResponse{
+					{
+						Response: &extProcPb.ProcessingResponse_RequestHeaders{
+							RequestHeaders: &extProcPb.HeadersResponse{
+								Response: &extProcPb.CommonResponse{
+									ClearRouteCache: true,
+									HeaderMutation: &extProcPb.HeaderMutation{
+										SetHeaders: []*basepb.HeaderValueOption{
+											{
+												Header: &basepb.HeaderValue{
+													Key:      "Content-Length",
+													RawValue: []byte(strconv.Itoa(len(b))),
+												},
+											},
+											{
+												Header: &basepb.HeaderValue{
+													Key: basemodelextractor.BaseModelHeader,
+												},
 											},
 										},
 									},
@@ -289,8 +251,24 @@ func TestHandleRequestBody(t *testing.T) {
 							},
 						},
 					},
-				},
-			},
+					{
+						Response: &extProcPb.ProcessingResponse_RequestBody{
+							RequestBody: &extProcPb.BodyResponse{
+								Response: &extProcPb.CommonResponse{
+									BodyMutation: &extProcPb.BodyMutation{
+										Mutation: &extProcPb.BodyMutation_StreamedResponse{
+											StreamedResponse: &extProcPb.StreamedBodyResponse{
+												Body:        b,
+												EndOfStream: true,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+			}(),
 		},
 		{
 			name: "model is not string, success after it's being auto converted to string",
@@ -298,24 +276,33 @@ func TestHandleRequestBody(t *testing.T) {
 				"model":  1,
 				"prompt": "Tell me a joke",
 			},
-			want: []*extProcPb.ProcessingResponse{
-				{
-					Response: &extProcPb.ProcessingResponse_RequestBody{
-						RequestBody: &extProcPb.BodyResponse{
-							Response: &extProcPb.CommonResponse{
-								ClearRouteCache: true,
-								HeaderMutation: &extProcPb.HeaderMutation{
-									SetHeaders: []*basepb.HeaderValueOption{
-										{
-											Header: &basepb.HeaderValue{
-												Key:      bodyfieldtoheader.ModelHeader,
-												RawValue: []byte("1"),
+			want: func() []*extProcPb.ProcessingResponse {
+				b, _ := json.Marshal(map[string]any{"model": 1, "prompt": "Tell me a joke"})
+				return []*extProcPb.ProcessingResponse{
+					{
+						Response: &extProcPb.ProcessingResponse_RequestHeaders{
+							RequestHeaders: &extProcPb.HeadersResponse{
+								Response: &extProcPb.CommonResponse{
+									ClearRouteCache: true,
+									HeaderMutation: &extProcPb.HeaderMutation{
+										SetHeaders: []*basepb.HeaderValueOption{
+											{
+												Header: &basepb.HeaderValue{
+													Key:      "Content-Length",
+													RawValue: []byte(strconv.Itoa(len(b))),
+												},
 											},
-										},
-										{
-											Header: &basepb.HeaderValue{
-												Key:      basemodelextractor.BaseModelHeader,
-												RawValue: []byte(""),
+											{
+												Header: &basepb.HeaderValue{
+													Key:      bodyfieldtoheader.ModelHeader,
+													RawValue: []byte("1"),
+												},
+											},
+											{
+												Header: &basepb.HeaderValue{
+													Key:      basemodelextractor.BaseModelHeader,
+													RawValue: []byte(""),
+												},
 											},
 										},
 									},
@@ -323,8 +310,24 @@ func TestHandleRequestBody(t *testing.T) {
 							},
 						},
 					},
-				},
-			},
+					{
+						Response: &extProcPb.ProcessingResponse_RequestBody{
+							RequestBody: &extProcPb.BodyResponse{
+								Response: &extProcPb.CommonResponse{
+									BodyMutation: &extProcPb.BodyMutation{
+										Mutation: &extProcPb.BodyMutation_StreamedResponse{
+											StreamedResponse: &extProcPb.StreamedBodyResponse{
+												Body:        b,
+												EndOfStream: true,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+			}(),
 		},
 		{
 			name: "success",
@@ -332,41 +335,6 @@ func TestHandleRequestBody(t *testing.T) {
 				"model":  "foo",
 				"prompt": "Tell me a joke",
 			},
-			want: []*extProcPb.ProcessingResponse{
-				{
-					Response: &extProcPb.ProcessingResponse_RequestBody{
-						RequestBody: &extProcPb.BodyResponse{
-							Response: &extProcPb.CommonResponse{
-								ClearRouteCache: true,
-								HeaderMutation: &extProcPb.HeaderMutation{
-									SetHeaders: []*basepb.HeaderValueOption{
-										{
-											Header: &basepb.HeaderValue{
-												Key:      bodyfieldtoheader.ModelHeader,
-												RawValue: []byte("foo"),
-											},
-										},
-										{
-											Header: &basepb.HeaderValue{
-												Key:      basemodelextractor.BaseModelHeader,
-												RawValue: []byte(""),
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "success-with-streaming",
-			body: map[string]any{
-				"model":  "foo",
-				"prompt": "Tell me a joke",
-			},
-			streaming: true,
 			want: func() []*extProcPb.ProcessingResponse {
 				b, _ := json.Marshal(map[string]any{"model": "foo", "prompt": "Tell me a joke"})
 				return []*extProcPb.ProcessingResponse{
@@ -421,14 +389,13 @@ func TestHandleRequestBody(t *testing.T) {
 			}(),
 		},
 		{
-			name: "success-with-streaming-large-body",
+			name: "success-large-body",
 			body: func() map[string]any {
 				return map[string]any{
 					"model":  "foo",
 					"prompt": strings.Repeat("a", 70000),
 				}
 			}(),
-			streaming: true,
 			want: func() []*extProcPb.ProcessingResponse {
 				m := map[string]any{
 					"model":  "foo",
@@ -509,7 +476,7 @@ func TestHandleRequestBody(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			modelToHeaderPlugin, _ := bodyfieldtoheader.NewBodyFieldToHeaderPlugin(modelField, bodyfieldtoheader.ModelHeader)
-			server := NewServer(test.streaming, []framework.RequestProcessor{modelToHeaderPlugin, baseModelToHeaderPlugin}, []framework.ResponseProcessor{})
+			server := NewServer([]framework.RequestProcessor{modelToHeaderPlugin, baseModelToHeaderPlugin}, []framework.ResponseProcessor{})
 			reqCtx := &RequestContext{
 				CycleState: framework.NewCycleState(),
 				Request:    framework.NewInferenceRequest(),
@@ -532,17 +499,17 @@ func TestHandleRequestBody(t *testing.T) {
 		})
 	}
 
-	// Assert BBR metrics: 2 model not in body, 1 model empty string, 7 successful model-from-body cases.
+	// Assert BBR metrics: 1 model not in body, 1 model empty string, 5 successful model-from-body cases.
 	wantMetrics := `
 	# HELP bbr_body_field_empty_total [ALPHA] Count of times a field was found in a request body but was empty.
 	# TYPE bbr_body_field_empty_total counter
 	bbr_body_field_empty_total{field="model"} 1
 	# HELP bbr_body_field_not_found_total [ALPHA] Count of times a field wasn't found in a request body.
 	# TYPE bbr_body_field_not_found_total counter
-	bbr_body_field_not_found_total{field="model"} 2
+	bbr_body_field_not_found_total{field="model"} 1
 	# HELP bbr_success_total [ALPHA] Count of time the request was processed successfully.
 	# TYPE bbr_success_total counter
-	bbr_success_total{} 7
+	bbr_success_total{} 5
 	`
 
 	if err := metricsutils.GatherAndCompare(crmetrics.Registry, strings.NewReader(wantMetrics),
@@ -557,7 +524,7 @@ func TestHandleRequestBodyWithPluginMetrics(t *testing.T) {
 
 	modelToHeaderPlugin, _ := bodyfieldtoheader.NewBodyFieldToHeaderPlugin(modelField, bodyfieldtoheader.ModelHeader)
 	baseModelToHeaderPlugin := &basemodelextractor.BaseModelToHeaderPlugin{AdaptersStore: basemodelextractor.NewAdaptersStore()}
-	server := NewServer(false, []framework.RequestProcessor{modelToHeaderPlugin, baseModelToHeaderPlugin}, []framework.ResponseProcessor{})
+	server := NewServer([]framework.RequestProcessor{modelToHeaderPlugin, baseModelToHeaderPlugin}, []framework.ResponseProcessor{})
 	reqCtx := &RequestContext{
 		CycleState: framework.NewCycleState(),
 		Request:    framework.NewInferenceRequest(),
@@ -828,7 +795,7 @@ func TestHandleRequestBody_MultiPluginHeaderMutations(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			server := NewServer(false, tc.plugins, []framework.ResponseProcessor{})
+			server := NewServer(tc.plugins, []framework.ResponseProcessor{})
 			reqCtx := &RequestContext{
 				Request:    framework.NewInferenceRequest(),
 				CycleState: framework.NewCycleState(),
@@ -847,7 +814,7 @@ func TestHandleRequestBody_MultiPluginHeaderMutations(t *testing.T) {
 				t.Fatalf("HandleRequestBody returned unexpected error: %v", err)
 			}
 
-			want := buildNonStreamingResponse(tc.wantSetHeaders, tc.wantRemoved)
+			want := buildStreamingResponse(bodyBytes, tc.wantSetHeaders, tc.wantRemoved)
 			envoytest.SortSetHeadersInResponses(want)
 			envoytest.SortSetHeadersInResponses(resp)
 
@@ -858,10 +825,17 @@ func TestHandleRequestBody_MultiPluginHeaderMutations(t *testing.T) {
 	}
 }
 
-// buildNonStreamingResponse constructs the expected ProcessingResponse for a
-// non-streaming HandleRequestBody call with the given header mutations.
-func buildNonStreamingResponse(setHeaders map[string]string, removeHeaders []string) []*extProcPb.ProcessingResponse {
-	setHeaderOpts := make([]*basepb.HeaderValueOption, 0, len(setHeaders))
+// buildStreamingResponse constructs the expected ProcessingResponse for a
+// streaming HandleRequestBody call with the given header mutations.
+func buildStreamingResponse(bodyBytes []byte, setHeaders map[string]string, removeHeaders []string) []*extProcPb.ProcessingResponse {
+	setHeaderOpts := make([]*basepb.HeaderValueOption, 0, len(setHeaders)+1)
+	// Content-Length is always added in streaming mode
+	setHeaderOpts = append(setHeaderOpts, &basepb.HeaderValueOption{
+		Header: &basepb.HeaderValue{
+			Key:      contentLengthHeader,
+			RawValue: []byte(strconv.Itoa(len(bodyBytes))),
+		},
+	})
 	for k, v := range setHeaders {
 		setHeaderOpts = append(setHeaderOpts, &basepb.HeaderValueOption{
 			Header: &basepb.HeaderValue{
@@ -873,13 +847,29 @@ func buildNonStreamingResponse(setHeaders map[string]string, removeHeaders []str
 
 	return []*extProcPb.ProcessingResponse{
 		{
-			Response: &extProcPb.ProcessingResponse_RequestBody{
-				RequestBody: &extProcPb.BodyResponse{
+			Response: &extProcPb.ProcessingResponse_RequestHeaders{
+				RequestHeaders: &extProcPb.HeadersResponse{
 					Response: &extProcPb.CommonResponse{
 						ClearRouteCache: true,
 						HeaderMutation: &extProcPb.HeaderMutation{
 							SetHeaders:    setHeaderOpts,
 							RemoveHeaders: removeHeaders,
+						},
+					},
+				},
+			},
+		},
+		{
+			Response: &extProcPb.ProcessingResponse_RequestBody{
+				RequestBody: &extProcPb.BodyResponse{
+					Response: &extProcPb.CommonResponse{
+						BodyMutation: &extProcPb.BodyMutation{
+							Mutation: &extProcPb.BodyMutation_StreamedResponse{
+								StreamedResponse: &extProcPb.StreamedBodyResponse{
+									Body:        bodyBytes,
+									EndOfStream: true,
+								},
+							},
 						},
 					},
 				},
@@ -917,115 +907,61 @@ func TestHandleRequestBody_BodyMutation(t *testing.T) {
 		},
 	}
 
-	tests := []struct {
-		name      string
-		streaming bool
-		body      map[string]any
-		want      []*extProcPb.ProcessingResponse
-	}{
+	body := map[string]any{"prompt": "test"}
+	b, _ := json.Marshal(map[string]any{"prompt": "test", "injected": "value"})
+	want := []*extProcPb.ProcessingResponse{
 		{
-			name: "unary with body mutation",
-			body: map[string]any{
-				"prompt": "test",
-			},
-			want: func() []*extProcPb.ProcessingResponse {
-				b, _ := json.Marshal(map[string]any{"prompt": "test", "injected": "value"})
-				return []*extProcPb.ProcessingResponse{
-					{
-						Response: &extProcPb.ProcessingResponse_RequestBody{
-							RequestBody: &extProcPb.BodyResponse{
-								Response: &extProcPb.CommonResponse{
-									ClearRouteCache: true,
-									HeaderMutation: &extProcPb.HeaderMutation{
-										SetHeaders: []*basepb.HeaderValueOption{
-											{
-												Header: &basepb.HeaderValue{
-													Key:      contentLengthHeader,
-													RawValue: []byte(strconv.Itoa(len(b))),
-												},
-											},
-										},
-									},
-									BodyMutation: &extProcPb.BodyMutation{
-										Mutation: &extProcPb.BodyMutation_Body{
-											Body: b,
-										},
+			Response: &extProcPb.ProcessingResponse_RequestHeaders{
+				RequestHeaders: &extProcPb.HeadersResponse{
+					Response: &extProcPb.CommonResponse{
+						ClearRouteCache: true,
+						HeaderMutation: &extProcPb.HeaderMutation{
+							SetHeaders: []*basepb.HeaderValueOption{
+								{
+									Header: &basepb.HeaderValue{
+										Key:      contentLengthHeader,
+										RawValue: []byte(strconv.Itoa(len(b))),
 									},
 								},
 							},
 						},
 					},
-				}
-			}(),
+				},
+			},
 		},
 		{
-			name:      "streaming with body mutation",
-			streaming: true,
-			body: map[string]any{
-				"prompt": "test",
+			Response: &extProcPb.ProcessingResponse_RequestBody{
+				RequestBody: &extProcPb.BodyResponse{
+					Response: &extProcPb.CommonResponse{
+						BodyMutation: &extProcPb.BodyMutation{
+							Mutation: &extProcPb.BodyMutation_StreamedResponse{
+								StreamedResponse: &extProcPb.StreamedBodyResponse{
+									Body:        b,
+									EndOfStream: true,
+								},
+							},
+						},
+					},
+				},
 			},
-			want: func() []*extProcPb.ProcessingResponse {
-				b, _ := json.Marshal(map[string]any{"prompt": "test", "injected": "value"})
-				return []*extProcPb.ProcessingResponse{
-					{
-						Response: &extProcPb.ProcessingResponse_RequestHeaders{
-							RequestHeaders: &extProcPb.HeadersResponse{
-								Response: &extProcPb.CommonResponse{
-									ClearRouteCache: true,
-									HeaderMutation: &extProcPb.HeaderMutation{
-										SetHeaders: []*basepb.HeaderValueOption{
-											{
-												Header: &basepb.HeaderValue{
-													Key:      contentLengthHeader,
-													RawValue: []byte(strconv.Itoa(len(b))),
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-					{
-						Response: &extProcPb.ProcessingResponse_RequestBody{
-							RequestBody: &extProcPb.BodyResponse{
-								Response: &extProcPb.CommonResponse{
-									BodyMutation: &extProcPb.BodyMutation{
-										Mutation: &extProcPb.BodyMutation_StreamedResponse{
-											StreamedResponse: &extProcPb.StreamedBodyResponse{
-												Body:        b,
-												EndOfStream: true,
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				}
-			}(),
 		},
 	}
 
 	baseModelPlugin := &basemodelextractor.BaseModelToHeaderPlugin{AdaptersStore: basemodelextractor.NewAdaptersStore()}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			server := NewServer(tc.streaming, []framework.RequestProcessor{plugin, baseModelPlugin}, []framework.ResponseProcessor{})
-			reqCtx := &RequestContext{
-				CycleState: framework.NewCycleState(),
-				Request:    framework.NewInferenceRequest(),
-			}
-			bodyBytes, _ := json.Marshal(tc.body)
-			resp, err := server.HandleRequestBody(ctx, reqCtx, bodyBytes)
-			if err != nil {
-				t.Fatalf("HandleRequestBody returned unexpected error: %v", err)
-			}
+	server := NewServer([]framework.RequestProcessor{plugin, baseModelPlugin}, []framework.ResponseProcessor{})
+	reqCtx := &RequestContext{
+		CycleState: framework.NewCycleState(),
+		Request:    framework.NewInferenceRequest(),
+	}
+	bodyBytes, _ := json.Marshal(body)
+	resp, err := server.HandleRequestBody(ctx, reqCtx, bodyBytes)
+	if err != nil {
+		t.Fatalf("HandleRequestBody returned unexpected error: %v", err)
+	}
 
-			envoytest.SortSetHeadersInResponses(tc.want)
-			envoytest.SortSetHeadersInResponses(resp)
-			if diff := cmp.Diff(tc.want, resp, protocmp.Transform()); diff != "" {
-				t.Errorf("HandleRequestBody returned unexpected response, diff(-want, +got): %v", diff)
-			}
-		})
+	envoytest.SortSetHeadersInResponses(want)
+	envoytest.SortSetHeadersInResponses(resp)
+	if diff := cmp.Diff(want, resp, protocmp.Transform()); diff != "" {
+		t.Errorf("HandleRequestBody returned unexpected response, diff(-want, +got): %v", diff)
 	}
 }

--- a/pkg/handlers/response.go
+++ b/pkg/handlers/response.go
@@ -34,19 +34,18 @@ import (
 
 // HandleResponseHeaders extracts response headers into reqCtx and returns
 // the ext-proc header response.
-func (s *Server) HandleResponseHeaders(ctx context.Context, reqCtx *RequestContext, headers *eppb.HttpHeaders, streaming bool) []*eppb.ProcessingResponse {
+func (s *Server) HandleResponseHeaders(ctx context.Context, reqCtx *RequestContext, headers *eppb.HttpHeaders) []*eppb.ProcessingResponse {
 	if headers != nil && headers.Headers != nil {
 		for _, header := range headers.Headers.Headers {
 			reqCtx.Response.Headers[header.Key] = envoy.GetHeaderValue(header)
 		}
 	}
 
-	if streaming && !headers.GetEndOfStream() {
+	if !headers.GetEndOfStream() {
 		log.FromContext(ctx).V(logutil.VERBOSE).Info("captured response headers, deferring response until body arrives...")
 		return nil
 	}
-	// if we're here, that means we're in non-streaming, or we're in streaming and got end of stream(means no body).
-	// in both cases we can return HeadersResponse
+	// EndOfStream means no body is expected, return HeadersResponse immediately
 	return []*eppb.ProcessingResponse{
 		{
 			Response: &eppb.ProcessingResponse_ResponseHeaders{
@@ -60,30 +59,12 @@ func (s *Server) HandleResponseHeaders(ctx context.Context, reqCtx *RequestConte
 func (s *Server) HandleResponseBody(ctx context.Context, reqCtx *RequestContext, responseBodyBytes []byte) ([]*eppb.ProcessingResponse, error) {
 	logger := log.FromContext(ctx)
 	if len(s.responsePlugins) == 0 {
-		if s.streaming {
-			return s.generateEmptyResponseBodyResponse(responseBodyBytes), nil
-		}
-		return []*eppb.ProcessingResponse{
-			{
-				Response: &eppb.ProcessingResponse_ResponseBody{
-					ResponseBody: &eppb.BodyResponse{},
-				},
-			},
-		}, nil
+		return s.generateEmptyResponseBodyResponse(responseBodyBytes), nil
 	}
 
 	if err := json.Unmarshal(responseBodyBytes, &reqCtx.Response.Body); err != nil {
 		logger.Error(err, "Failed to parse response body as JSON, skipping response plugins")
-		if s.streaming {
-			return s.generateEmptyResponseBodyResponse(responseBodyBytes), nil
-		}
-		return []*eppb.ProcessingResponse{
-			{
-				Response: &eppb.ProcessingResponse_ResponseBody{
-					ResponseBody: &eppb.BodyResponse{},
-				},
-			},
-		}, nil
+		return s.generateEmptyResponseBodyResponse(responseBodyBytes), nil
 	}
 
 	if err := s.runResponsePlugins(ctx, reqCtx.CycleState, reqCtx.Response); err != nil {
@@ -101,53 +82,26 @@ func (s *Server) HandleResponseBody(ctx context.Context, reqCtx *RequestContext,
 		reqCtx.Response.SetHeader(contentLengthHeader, strconv.Itoa(len(mutatedBytes)))
 	}
 
-	if s.streaming {
-		var ret []*eppb.ProcessingResponse
-		ret = append(ret, &eppb.ProcessingResponse{
-			Response: &eppb.ProcessingResponse_ResponseHeaders{
-				ResponseHeaders: &eppb.HeadersResponse{
-					Response: &eppb.CommonResponse{
-						ClearRouteCache: true,
-						HeaderMutation: &eppb.HeaderMutation{
-							SetHeaders:    envoy.GenerateHeadersMutation(reqCtx.Response.MutatedHeaders()),
-							RemoveHeaders: reqCtx.Response.RemovedHeaders(),
-						},
+	var ret []*eppb.ProcessingResponse
+	ret = append(ret, &eppb.ProcessingResponse{
+		Response: &eppb.ProcessingResponse_ResponseHeaders{
+			ResponseHeaders: &eppb.HeadersResponse{
+				Response: &eppb.CommonResponse{
+					ClearRouteCache: true,
+					HeaderMutation: &eppb.HeaderMutation{
+						SetHeaders:    envoy.GenerateHeadersMutation(reqCtx.Response.MutatedHeaders()),
+						RemoveHeaders: reqCtx.Response.RemovedHeaders(),
 					},
 				},
 			},
-		})
-		if bodyMutated {
-			ret = envoy.AddStreamedResponseBody(ret, mutatedBytes)
-		} else {
-			ret = envoy.AddStreamedResponseBody(ret, responseBodyBytes)
-		}
-		return ret, nil
-	}
-
-	response := &eppb.CommonResponse{
-		ClearRouteCache: true,
-		HeaderMutation: &eppb.HeaderMutation{
-			SetHeaders:    envoy.GenerateHeadersMutation(reqCtx.Response.MutatedHeaders()),
-			RemoveHeaders: reqCtx.Response.RemovedHeaders(),
 		},
-	}
+	})
 	if bodyMutated {
-		response.BodyMutation = &eppb.BodyMutation{
-			Mutation: &eppb.BodyMutation_Body{
-				Body: mutatedBytes,
-			},
-		}
+		ret = envoy.AddStreamedResponseBody(ret, mutatedBytes)
+	} else {
+		ret = envoy.AddStreamedResponseBody(ret, responseBodyBytes)
 	}
-
-	return []*eppb.ProcessingResponse{
-		{
-			Response: &eppb.ProcessingResponse_ResponseBody{
-				ResponseBody: &eppb.BodyResponse{
-					Response: response,
-				},
-			},
-		},
-	}, nil
+	return ret, nil
 }
 
 // generateEmptyResponseBodyResponse builds a streaming response with an empty

--- a/pkg/handlers/response_test.go
+++ b/pkg/handlers/response_test.go
@@ -62,63 +62,40 @@ func newTestRequestContext() *RequestContext {
 func TestHandleResponseBody_NoPlugins(t *testing.T) {
 	ctx := logutil.NewTestLoggerIntoContext(context.Background())
 
-	t.Run("unary", func(t *testing.T) {
-		server := NewServer(false, []framework.RequestProcessor{}, []framework.ResponseProcessor{})
-		responseBody := []byte(`{"choices":[{"text":"Hello!"}]}`)
-		resp, err := server.HandleResponseBody(ctx, newTestRequestContext(), responseBody)
-		if err != nil {
-			t.Fatalf("HandleResponseBody returned unexpected error: %v", err)
-		}
+	server := NewServer([]framework.RequestProcessor{}, []framework.ResponseProcessor{})
+	responseBody := []byte(`{"choices":[{"text":"Hello!"}]}`)
+	resp, err := server.HandleResponseBody(ctx, newTestRequestContext(), responseBody)
+	if err != nil {
+		t.Fatalf("HandleResponseBody returned unexpected error: %v", err)
+	}
 
-		want := []*extProcPb.ProcessingResponse{
-			{
-				Response: &extProcPb.ProcessingResponse_ResponseBody{
-					ResponseBody: &extProcPb.BodyResponse{},
-				},
+	want := []*extProcPb.ProcessingResponse{
+		{
+			Response: &extProcPb.ProcessingResponse_ResponseHeaders{
+				ResponseHeaders: &extProcPb.HeadersResponse{},
 			},
-		}
-
-		if diff := cmp.Diff(want, resp, protocmp.Transform()); diff != "" {
-			t.Errorf("HandleResponseBody returned unexpected response, diff(-want, +got): %v", diff)
-		}
-	})
-
-	t.Run("streaming", func(t *testing.T) {
-		server := NewServer(true, []framework.RequestProcessor{}, []framework.ResponseProcessor{})
-		responseBody := []byte(`{"choices":[{"text":"Hello!"}]}`)
-		resp, err := server.HandleResponseBody(ctx, newTestRequestContext(), responseBody)
-		if err != nil {
-			t.Fatalf("HandleResponseBody returned unexpected error: %v", err)
-		}
-
-		want := []*extProcPb.ProcessingResponse{
-			{
-				Response: &extProcPb.ProcessingResponse_ResponseHeaders{
-					ResponseHeaders: &extProcPb.HeadersResponse{},
-				},
-			},
-			{
-				Response: &extProcPb.ProcessingResponse_ResponseBody{
-					ResponseBody: &extProcPb.BodyResponse{
-						Response: &extProcPb.CommonResponse{
-							BodyMutation: &extProcPb.BodyMutation{
-								Mutation: &extProcPb.BodyMutation_StreamedResponse{
-									StreamedResponse: &extProcPb.StreamedBodyResponse{
-										Body:        responseBody,
-										EndOfStream: true,
-									},
+		},
+		{
+			Response: &extProcPb.ProcessingResponse_ResponseBody{
+				ResponseBody: &extProcPb.BodyResponse{
+					Response: &extProcPb.CommonResponse{
+						BodyMutation: &extProcPb.BodyMutation{
+							Mutation: &extProcPb.BodyMutation_StreamedResponse{
+								StreamedResponse: &extProcPb.StreamedBodyResponse{
+									Body:        responseBody,
+									EndOfStream: true,
 								},
 							},
 						},
 					},
 				},
 			},
-		}
+		},
+	}
 
-		if diff := cmp.Diff(want, resp, protocmp.Transform()); diff != "" {
-			t.Errorf("HandleResponseBody returned unexpected response, diff(-want, +got): %v", diff)
-		}
-	})
+	if diff := cmp.Diff(want, resp, protocmp.Transform()); diff != "" {
+		t.Errorf("HandleResponseBody returned unexpected response, diff(-want, +got): %v", diff)
+	}
 }
 
 func TestHandleResponseBody_SinglePlugin(t *testing.T) {
@@ -132,7 +109,7 @@ func TestHandleResponseBody_SinglePlugin(t *testing.T) {
 		},
 	}
 
-	server := NewServer(false, []framework.RequestProcessor{}, []framework.ResponseProcessor{mutatePlugin})
+	server := NewServer([]framework.RequestProcessor{}, []framework.ResponseProcessor{mutatePlugin})
 	responseBody := []byte(`{"choices":[{"text":"Hello!"}]}`)
 	resp, err := server.HandleResponseBody(ctx, newTestRequestContext(), responseBody)
 	if err != nil {
@@ -143,9 +120,7 @@ func TestHandleResponseBody_SinglePlugin(t *testing.T) {
 		"choices": []any{map[string]any{"text": "Hello!"}},
 		"mutated": true,
 	})
-	want := []*extProcPb.ProcessingResponse{
-		expectedResponseBodyMutation(wantBody),
-	}
+	want := expectedStreamedResponseBodyMutation(wantBody)
 
 	envoytest.SortSetHeadersInResponses(want)
 	envoytest.SortSetHeadersInResponses(resp)
@@ -172,7 +147,7 @@ func TestHandleResponseBody_MultiplePlugins(t *testing.T) {
 		},
 	}
 
-	server := NewServer(false, []framework.RequestProcessor{}, []framework.ResponseProcessor{plugin1, plugin2})
+	server := NewServer([]framework.RequestProcessor{}, []framework.ResponseProcessor{plugin1, plugin2})
 	responseBody := []byte(`{"original":true}`)
 	resp, err := server.HandleResponseBody(ctx, newTestRequestContext(), responseBody)
 	if err != nil {
@@ -184,9 +159,7 @@ func TestHandleResponseBody_MultiplePlugins(t *testing.T) {
 		"p1":       testPluginValue,
 		"p2":       testPluginValue,
 	})
-	want := []*extProcPb.ProcessingResponse{
-		expectedResponseBodyMutation(wantBody),
-	}
+	want := expectedStreamedResponseBodyMutation(wantBody)
 
 	envoytest.SortSetHeadersInResponses(want)
 	envoytest.SortSetHeadersInResponses(resp)
@@ -205,7 +178,7 @@ func TestHandleResponseBody_PluginError(t *testing.T) {
 		},
 	}
 
-	server := NewServer(false, []framework.RequestProcessor{}, []framework.ResponseProcessor{failingPlugin})
+	server := NewServer([]framework.RequestProcessor{}, []framework.ResponseProcessor{failingPlugin})
 	responseBody := []byte(`{"choices":[{"text":"some response"}]}`)
 	_, err := server.HandleResponseBody(ctx, newTestRequestContext(), responseBody)
 	if err == nil {
@@ -228,7 +201,7 @@ func TestHandleResponseBody_StreamingWithPlugin(t *testing.T) {
 		},
 	}
 
-	server := NewServer(true, []framework.RequestProcessor{}, []framework.ResponseProcessor{mutatePlugin})
+	server := NewServer([]framework.RequestProcessor{}, []framework.ResponseProcessor{mutatePlugin})
 	responseBody := []byte(`{"choices":[{"text":"Hello!"}]}`)
 	resp, err := server.HandleResponseBody(ctx, newTestRequestContext(), responseBody)
 	if err != nil {
@@ -259,27 +232,19 @@ func TestHandleResponseBody_PluginNoBodyMutation(t *testing.T) {
 		},
 	}
 
-	tests := []struct {
-		name      string
-		streaming bool
-		want      []*extProcPb.ProcessingResponse
-	}{
+	responseBody := []byte(`{"choices":[{"text":"Hello!"}]}`)
+	want := []*extProcPb.ProcessingResponse{
 		{
-			name: "unary - header-only plugin skips body mutation",
-			want: []*extProcPb.ProcessingResponse{
-				{
-					Response: &extProcPb.ProcessingResponse_ResponseBody{
-						ResponseBody: &extProcPb.BodyResponse{
-							Response: &extProcPb.CommonResponse{
-								ClearRouteCache: true,
-								HeaderMutation: &extProcPb.HeaderMutation{
-									SetHeaders: []*basepb.HeaderValueOption{
-										{
-											Header: &basepb.HeaderValue{
-												Key:      "X-Custom-Response",
-												RawValue: []byte("added"),
-											},
-										},
+			Response: &extProcPb.ProcessingResponse_ResponseHeaders{
+				ResponseHeaders: &extProcPb.HeadersResponse{
+					Response: &extProcPb.CommonResponse{
+						ClearRouteCache: true,
+						HeaderMutation: &extProcPb.HeaderMutation{
+							SetHeaders: []*basepb.HeaderValueOption{
+								{
+									Header: &basepb.HeaderValue{
+										Key:      "X-Custom-Response",
+										RawValue: []byte("added"),
 									},
 								},
 							},
@@ -289,95 +254,33 @@ func TestHandleResponseBody_PluginNoBodyMutation(t *testing.T) {
 			},
 		},
 		{
-			name:      "streaming - header-only plugin passes original body",
-			streaming: true,
-			want: func() []*extProcPb.ProcessingResponse {
-				responseBody := []byte(`{"choices":[{"text":"Hello!"}]}`)
-				return []*extProcPb.ProcessingResponse{
-					{
-						Response: &extProcPb.ProcessingResponse_ResponseHeaders{
-							ResponseHeaders: &extProcPb.HeadersResponse{
-								Response: &extProcPb.CommonResponse{
-									ClearRouteCache: true,
-									HeaderMutation: &extProcPb.HeaderMutation{
-										SetHeaders: []*basepb.HeaderValueOption{
-											{
-												Header: &basepb.HeaderValue{
-													Key:      "X-Custom-Response",
-													RawValue: []byte("added"),
-												},
-											},
-										},
-									},
+			Response: &extProcPb.ProcessingResponse_ResponseBody{
+				ResponseBody: &extProcPb.BodyResponse{
+					Response: &extProcPb.CommonResponse{
+						BodyMutation: &extProcPb.BodyMutation{
+							Mutation: &extProcPb.BodyMutation_StreamedResponse{
+								StreamedResponse: &extProcPb.StreamedBodyResponse{
+									Body:        responseBody,
+									EndOfStream: true,
 								},
 							},
-						},
-					},
-					{
-						Response: &extProcPb.ProcessingResponse_ResponseBody{
-							ResponseBody: &extProcPb.BodyResponse{
-								Response: &extProcPb.CommonResponse{
-									BodyMutation: &extProcPb.BodyMutation{
-										Mutation: &extProcPb.BodyMutation_StreamedResponse{
-											StreamedResponse: &extProcPb.StreamedBodyResponse{
-												Body:        responseBody,
-												EndOfStream: true,
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				}
-			}(),
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			server := NewServer(tc.streaming, []framework.RequestProcessor{}, []framework.ResponseProcessor{headerOnlyPlugin})
-			responseBody := []byte(`{"choices":[{"text":"Hello!"}]}`)
-			resp, err := server.HandleResponseBody(ctx, newTestRequestContext(), responseBody)
-			if err != nil {
-				t.Fatalf("HandleResponseBody returned unexpected error: %v", err)
-			}
-
-			envoytest.SortSetHeadersInResponses(tc.want)
-			envoytest.SortSetHeadersInResponses(resp)
-			if diff := cmp.Diff(tc.want, resp, protocmp.Transform()); diff != "" {
-				t.Errorf("HandleResponseBody returned unexpected response, diff(-want, +got): %v", diff)
-			}
-		})
-	}
-}
-
-// expectedResponseBodyMutation builds the expected unary response for a mutated body,
-// including the content-length header mutation.
-func expectedResponseBodyMutation(bodyBytes []byte) *extProcPb.ProcessingResponse {
-	return &extProcPb.ProcessingResponse{
-		Response: &extProcPb.ProcessingResponse_ResponseBody{
-			ResponseBody: &extProcPb.BodyResponse{
-				Response: &extProcPb.CommonResponse{
-					ClearRouteCache: true,
-					HeaderMutation: &extProcPb.HeaderMutation{
-						SetHeaders: []*basepb.HeaderValueOption{
-							{
-								Header: &basepb.HeaderValue{
-									Key:      contentLengthHeader,
-									RawValue: []byte(strconv.Itoa(len(bodyBytes))),
-								},
-							},
-						},
-					},
-					BodyMutation: &extProcPb.BodyMutation{
-						Mutation: &extProcPb.BodyMutation_Body{
-							Body: bodyBytes,
 						},
 					},
 				},
 			},
 		},
+	}
+
+	server := NewServer([]framework.RequestProcessor{}, []framework.ResponseProcessor{headerOnlyPlugin})
+	resp, err := server.HandleResponseBody(ctx, newTestRequestContext(), responseBody)
+	if err != nil {
+		t.Fatalf("HandleResponseBody returned unexpected error: %v", err)
+	}
+
+	envoytest.SortSetHeadersInResponses(want)
+	envoytest.SortSetHeadersInResponses(resp)
+	if diff := cmp.Diff(want, resp, protocmp.Transform()); diff != "" {
+		t.Errorf("HandleResponseBody returned unexpected response, diff(-want, +got): %v", diff)
 	}
 }
 

--- a/pkg/handlers/server.go
+++ b/pkg/handlers/server.go
@@ -45,9 +45,8 @@ const (
 	responsePluginExtensionPoint = "response"
 )
 
-func NewServer(streaming bool, requestPlugins []framework.RequestProcessor, responsePlugins []framework.ResponseProcessor) *Server {
+func NewServer(requestPlugins []framework.RequestProcessor, responsePlugins []framework.ResponseProcessor) *Server {
 	return &Server{
-		streaming:       streaming,
 		requestPlugins:  requestPlugins,
 		responsePlugins: responsePlugins,
 	}
@@ -56,7 +55,6 @@ func NewServer(streaming bool, requestPlugins []framework.RequestProcessor, resp
 // Server implements the Envoy external processing server.
 // https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/ext_proc/v3/external_processor.proto
 type Server struct {
-	streaming       bool
 	requestPlugins  []framework.RequestProcessor
 	responsePlugins []framework.ResponseProcessor
 }
@@ -123,12 +121,12 @@ func (s *Server) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
 				loggerVerbose = logger.V(logutil.VERBOSE)
 				ctx = log.IntoContext(ctx, logger)
 			}
-			responses = s.HandleRequestHeaders(ctx, reqCtx, v.RequestHeaders, s.streaming)
+			responses = s.HandleRequestHeaders(ctx, reqCtx, v.RequestHeaders)
 			loggerVerbose.Info("processing request headers complete")
 		case *extProcPb.ProcessingRequest_RequestBody:
 			loggerVerbose.Info("Incoming request body chunk", "EoS", v.RequestBody.EndOfStream)
 			requestBody = append(requestBody, v.RequestBody.Body...)
-			if s.streaming && !v.RequestBody.EndOfStream {
+			if !v.RequestBody.EndOfStream {
 				continue
 			}
 			responses, err = s.HandleRequestBody(ctx, reqCtx, requestBody)
@@ -136,12 +134,12 @@ func (s *Server) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
 		case *extProcPb.ProcessingRequest_RequestTrailers:
 			responses, err = s.HandleRequestTrailers(v.RequestTrailers)
 		case *extProcPb.ProcessingRequest_ResponseHeaders:
-			responses = s.HandleResponseHeaders(ctx, reqCtx, v.ResponseHeaders, s.streaming)
+			responses = s.HandleResponseHeaders(ctx, reqCtx, v.ResponseHeaders)
 			loggerVerbose.Info("processing response headers complete")
 		case *extProcPb.ProcessingRequest_ResponseBody:
 			loggerVerbose.Info("Incoming response body chunk", "EoS", v.ResponseBody.EndOfStream)
 			responseBody = append(responseBody, v.ResponseBody.Body...)
-			if s.streaming && !v.ResponseBody.EndOfStream {
+			if !v.ResponseBody.EndOfStream {
 				continue
 			}
 			responses, err = s.HandleResponseBody(ctx, reqCtx, responseBody)

--- a/pkg/handlers/server_test.go
+++ b/pkg/handlers/server_test.go
@@ -35,39 +35,34 @@ import (
 	"github.com/llm-d/llm-d-inference-payload-processor/test/utils"
 )
 
-func TestHandleRequestBodyStreaming(t *testing.T) {
+func TestHandleRequestBody(t *testing.T) {
 	ctx := logutil.NewTestLoggerIntoContext(context.Background())
 
 	b, _ := json.Marshal(map[string]any{"model": "foo"})
-	cases := []struct {
-		desc      string
-		streaming bool
-		body      []byte
-		want      []*extProcPb.ProcessingResponse
-	}{
+	want := []*extProcPb.ProcessingResponse{
 		{
-			desc: "no-streaming",
-			body: b,
-			want: []*extProcPb.ProcessingResponse{
-				{
-					Response: &extProcPb.ProcessingResponse_RequestBody{
-						RequestBody: &extProcPb.BodyResponse{
-							Response: &extProcPb.CommonResponse{
-								ClearRouteCache: true,
-								HeaderMutation: &extProcPb.HeaderMutation{
-									SetHeaders: []*basepb.HeaderValueOption{
-										{
-											Header: &basepb.HeaderValue{
-												Key:      bodyfieldtoheader.ModelHeader,
-												RawValue: []byte("foo"),
-											},
-										},
-										{
-											Header: &basepb.HeaderValue{
-												Key:      basemodelextractor.BaseModelHeader,
-												RawValue: []byte(""),
-											},
-										},
+			Response: &extProcPb.ProcessingResponse_RequestHeaders{
+				RequestHeaders: &extProcPb.HeadersResponse{
+					Response: &extProcPb.CommonResponse{
+						ClearRouteCache: true,
+						HeaderMutation: &extProcPb.HeaderMutation{
+							SetHeaders: []*basepb.HeaderValueOption{
+								{
+									Header: &basepb.HeaderValue{
+										Key:      contentLengthHeader,
+										RawValue: []byte(strconv.Itoa(len(b))),
+									},
+								},
+								{
+									Header: &basepb.HeaderValue{
+										Key:      bodyfieldtoheader.ModelHeader,
+										RawValue: []byte("foo"),
+									},
+								},
+								{
+									Header: &basepb.HeaderValue{
+										Key:      basemodelextractor.BaseModelHeader,
+										RawValue: []byte(""),
 									},
 								},
 							},
@@ -77,52 +72,14 @@ func TestHandleRequestBodyStreaming(t *testing.T) {
 			},
 		},
 		{
-			desc:      "streaming",
-			streaming: true,
-			body:      b,
-			want: []*extProcPb.ProcessingResponse{
-				{
-					Response: &extProcPb.ProcessingResponse_RequestHeaders{
-						RequestHeaders: &extProcPb.HeadersResponse{
-							Response: &extProcPb.CommonResponse{
-								ClearRouteCache: true,
-								HeaderMutation: &extProcPb.HeaderMutation{
-									SetHeaders: []*basepb.HeaderValueOption{
-										{
-											Header: &basepb.HeaderValue{
-												Key:      contentLengthHeader,
-												RawValue: []byte(strconv.Itoa(len(b))),
-											},
-										},
-										{
-											Header: &basepb.HeaderValue{
-												Key:      bodyfieldtoheader.ModelHeader,
-												RawValue: []byte("foo"),
-											},
-										},
-										{
-											Header: &basepb.HeaderValue{
-												Key:      basemodelextractor.BaseModelHeader,
-												RawValue: []byte(""),
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-				{
-					Response: &extProcPb.ProcessingResponse_RequestBody{
-						RequestBody: &extProcPb.BodyResponse{
-							Response: &extProcPb.CommonResponse{
-								BodyMutation: &extProcPb.BodyMutation{
-									Mutation: &extProcPb.BodyMutation_StreamedResponse{
-										StreamedResponse: &extProcPb.StreamedBodyResponse{
-											Body:        b,
-											EndOfStream: true,
-										},
-									},
+			Response: &extProcPb.ProcessingResponse_RequestBody{
+				RequestBody: &extProcPb.BodyResponse{
+					Response: &extProcPb.CommonResponse{
+						BodyMutation: &extProcPb.BodyMutation{
+							Mutation: &extProcPb.BodyMutation_StreamedResponse{
+								StreamedResponse: &extProcPb.StreamedBodyResponse{
+									Body:        b,
+									EndOfStream: true,
 								},
 							},
 						},
@@ -131,27 +88,24 @@ func TestHandleRequestBodyStreaming(t *testing.T) {
 			},
 		},
 	}
-	baseModelToHeaderPlugin := &basemodelextractor.BaseModelToHeaderPlugin{AdaptersStore: basemodelextractor.NewAdaptersStore()}
-	for _, tc := range cases {
-		t.Run(tc.desc, func(t *testing.T) {
-			modelToHeaderPlugin, _ := bodyfieldtoheader.NewBodyFieldToHeaderPlugin(modelField, bodyfieldtoheader.ModelHeader)
-			srv := NewServer(tc.streaming, []framework.RequestProcessor{modelToHeaderPlugin, baseModelToHeaderPlugin}, []framework.ResponseProcessor{})
-			reqCtx := &RequestContext{
-				CycleState: framework.NewCycleState(),
-				Request:    framework.NewInferenceRequest(),
-			}
-			got, err := srv.HandleRequestBody(ctx, reqCtx, tc.body)
-			if err != nil {
-				t.Fatalf("HandleRequestBody(): %v", err)
-			}
 
-			// sort headers in responses for deterministic tests
-			envoytest.SortSetHeadersInResponses(tc.want)
-			envoytest.SortSetHeadersInResponses(got)
-			if diff := cmp.Diff(tc.want, got, protocmp.Transform()); diff != "" {
-				t.Errorf("HandleRequestBody returned unexpected response, diff(-want, +got): %v", diff)
-			}
-		})
+	baseModelToHeaderPlugin := &basemodelextractor.BaseModelToHeaderPlugin{AdaptersStore: basemodelextractor.NewAdaptersStore()}
+	modelToHeaderPlugin, _ := bodyfieldtoheader.NewBodyFieldToHeaderPlugin(modelField, bodyfieldtoheader.ModelHeader)
+	srv := NewServer([]framework.RequestProcessor{modelToHeaderPlugin, baseModelToHeaderPlugin}, []framework.ResponseProcessor{})
+	reqCtx := &RequestContext{
+		CycleState: framework.NewCycleState(),
+		Request:    framework.NewInferenceRequest(),
+	}
+	got, err := srv.HandleRequestBody(ctx, reqCtx, b)
+	if err != nil {
+		t.Fatalf("HandleRequestBody(): %v", err)
+	}
+
+	// sort headers in responses for deterministic tests
+	envoytest.SortSetHeadersInResponses(want)
+	envoytest.SortSetHeadersInResponses(got)
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Errorf("HandleRequestBody returned unexpected response, diff(-want, +got): %v", diff)
 	}
 }
 
@@ -159,7 +113,7 @@ func TestHandleResponseBody_Streaming(t *testing.T) {
 	ctx := logutil.NewTestLoggerIntoContext(context.Background())
 	wantFullBody := []byte(`{"choices":[{"text":"Hello!"}]}`)
 
-	ref := NewServer(true, []framework.RequestProcessor{}, []framework.ResponseProcessor{})
+	ref := NewServer([]framework.RequestProcessor{}, []framework.ResponseProcessor{})
 	want, err := ref.HandleResponseBody(ctx, newTestRequestContext(), wantFullBody)
 	if err != nil {
 		t.Fatalf("reference HandleResponseBody: %v", err)
@@ -199,7 +153,7 @@ func TestHandleResponseBody_Streaming(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			streamCtx, cancel := context.WithCancel(logutil.NewTestLoggerIntoContext(context.Background()))
-			srv := NewServer(true, []framework.RequestProcessor{}, []framework.ResponseProcessor{})
+			srv := NewServer([]framework.RequestProcessor{}, []framework.ResponseProcessor{})
 			testListener, errChan := utils.SetupTestStreamingServer(t, streamCtx, srv)
 			process, conn := utils.GetStreamingServerClient(streamCtx, t)
 			defer conn.Close()

--- a/pkg/server/options.go
+++ b/pkg/server/options.go
@@ -35,8 +35,7 @@ type Options struct {
 	//
 	// ext_proc configuration.
 	//
-	GRPCPort  int  // gRPC port for communicating with Envoy proxy.
-	Streaming bool // Enables streaming support for Envoy full-duplex streaming mode.
+	GRPCPort int // gRPC port for communicating with Envoy proxy.
 	//
 	// Diagnostics.
 	//
@@ -87,8 +86,6 @@ func (opts *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&opts.Tracing, "tracing", opts.Tracing, "Enables emitting traces.")
 	fs.BoolVar(&opts.MetricsEndpointAuth, "metrics-endpoint-auth", opts.MetricsEndpointAuth,
 		"Enables authentication and authorization of the metrics endpoint.")
-	fs.BoolVar(&opts.Streaming, "streaming", opts.Streaming,
-		"Enables streaming support for Envoy full-duplex streaming mode.")
 	fs.BoolVar(&opts.SecureServing, "secure-serving", opts.SecureServing,
 		"Enables secure serving.")
 	fs.BoolVar(&opts.EnablePprof, "enable-pprof", opts.EnablePprof,

--- a/pkg/server/options_test.go
+++ b/pkg/server/options_test.go
@@ -36,7 +36,6 @@ func TestNewOptionsDefaults(t *testing.T) {
 		{"GRPCHealthPort", opts.GRPCHealthPort, DefaultGrpcHealthPort},
 		{"MetricsPort", opts.MetricsPort, 9090},
 		{"MetricsEndpointAuth", opts.MetricsEndpointAuth, true},
-		{"Streaming", opts.Streaming, false},
 		{"SecureServing", opts.SecureServing, true},
 		{"EnablePprof", opts.EnablePprof, true},
 		{"LogVerbosity", opts.LogVerbosity, 2}, // logging.DEFAULT
@@ -57,7 +56,6 @@ func TestAddFlagsOverridesDefaults(t *testing.T) {
 		"--grpc-port", "5000",
 		"--grpc-health-port", "5001",
 		"--metrics-port", "5002",
-		"--streaming",
 		"--secure-serving=false",
 		"--metrics-endpoint-auth=false",
 		"--enable-pprof=false",
@@ -75,7 +73,6 @@ func TestAddFlagsOverridesDefaults(t *testing.T) {
 		{"GRPCPort", opts.GRPCPort, 5000},
 		{"GRPCHealthPort", opts.GRPCHealthPort, 5001},
 		{"MetricsPort", opts.MetricsPort, 5002},
-		{"Streaming", opts.Streaming, true},
 		{"SecureServing", opts.SecureServing, false},
 		{"MetricsEndpointAuth", opts.MetricsEndpointAuth, false},
 		{"EnablePprof", opts.EnablePprof, false},

--- a/pkg/server/runserver.go
+++ b/pkg/server/runserver.go
@@ -37,18 +37,15 @@ import (
 type ExtProcServerRunner struct {
 	GrpcPort        int
 	SecureServing   bool
-	Streaming       bool
 	RequestPlugins  []framework.RequestProcessor
 	ResponsePlugins []framework.ResponseProcessor
 }
 
-func NewDefaultExtProcServerRunner(port int, streaming bool) *ExtProcServerRunner {
+func NewDefaultExtProcServerRunner(port int) *ExtProcServerRunner {
 	return &ExtProcServerRunner{
 		GrpcPort:      port,
 		SecureServing: true,
-		Streaming:     streaming,
 	}
-	// Dependencies can be assigned later.
 }
 
 // AsRunnable returns a Runnable that can be used to start the ext-proc gRPC server.
@@ -70,7 +67,7 @@ func (r *ExtProcServerRunner) AsRunnable(logger logr.Logger) manager.Runnable {
 			srv = grpc.NewServer()
 		}
 
-		extProcPb.RegisterExternalProcessorServer(srv, handlers.NewServer(r.Streaming, r.RequestPlugins, r.ResponsePlugins))
+		extProcPb.RegisterExternalProcessorServer(srv, handlers.NewServer(r.RequestPlugins, r.ResponsePlugins))
 
 		// Forward to the gRPC runnable.
 		return runnable.GRPCServer("ext-proc", srv, r.GrpcPort).Start(ctx)

--- a/test/integration/body_mutation_test.go
+++ b/test/integration/body_mutation_test.go
@@ -51,76 +51,15 @@ func (p *bodyMutatingPlugin) ProcessRequest(_ context.Context, _ *framework.Cycl
 
 var _ framework.RequestProcessor = &bodyMutatingPlugin{}
 
-// TestBodyMutation_Unary verifies that when a plugin mutates the body, the response
-// includes a BodyMutation with the serialized body and an updated Content-Length header.
-func TestBodyMutation_Unary(t *testing.T) {
-	t.Parallel()
-	ctx := context.Background()
-
-	plugin := &bodyMutatingPlugin{fieldName: "injected", fieldValue: "test-value"}
-	baseModelToHeaderPlugin := &basemodelextractor.BaseModelToHeaderPlugin{AdaptersStore: basemodelextractor.NewAdaptersStore()}
-	h := NewHarnessWithPlugins(t, ctx, false, []framework.RequestProcessor{plugin, baseModelToHeaderPlugin}, []framework.ResponseProcessor{})
-
-	body := map[string]any{"prompt": "hello"}
-	bodyBytes, _ := json.Marshal(body)
-
-	req := &extProcPb.ProcessingRequest{
-		Request: &extProcPb.ProcessingRequest_RequestBody{
-			RequestBody: &extProcPb.HttpBody{
-				Body:        bodyBytes,
-				EndOfStream: true,
-			},
-		},
-	}
-
-	resp, err := integration.SendRequest(t, h.Client, req)
-	require.NoError(t, err, "unexpected error during request processing")
-
-	wantBody, _ := json.Marshal(map[string]any{
-		"prompt":   "hello",
-		"injected": "test-value",
-	})
-	want := &extProcPb.ProcessingResponse{
-		Response: &extProcPb.ProcessingResponse_RequestBody{
-			RequestBody: &extProcPb.BodyResponse{
-				Response: &extProcPb.CommonResponse{
-					ClearRouteCache: true,
-					HeaderMutation: &extProcPb.HeaderMutation{
-						SetHeaders: []*envoyCorev3.HeaderValueOption{
-							{
-								Header: &envoyCorev3.HeaderValue{
-									Key:      "Content-Length",
-									RawValue: []byte(strconv.Itoa(len(wantBody))),
-								},
-							},
-						},
-					},
-					BodyMutation: &extProcPb.BodyMutation{
-						Mutation: &extProcPb.BodyMutation_Body{
-							Body: wantBody,
-						},
-					},
-				},
-			},
-		},
-	}
-
-	envoytest.SortSetHeadersInResponses([]*extProcPb.ProcessingResponse{want})
-	envoytest.SortSetHeadersInResponses([]*extProcPb.ProcessingResponse{resp})
-	if diff := cmp.Diff(want, resp, protocmp.Transform()); diff != "" {
-		t.Errorf("Response mismatch (-want +got): %v", diff)
-	}
-}
-
-// TestBodyMutation_Streaming verifies the streaming path: when a plugin mutates the body,
+// TestBodyMutation verifies that when a plugin mutates the body,
 // the header response includes Content-Length and the body response carries the mutated bytes.
-func TestBodyMutation_Streaming(t *testing.T) {
+func TestBodyMutation(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
 	plugin := &bodyMutatingPlugin{fieldName: "injected", fieldValue: "test-value"}
 	baseModelToHeaderPlugin := &basemodelextractor.BaseModelToHeaderPlugin{AdaptersStore: basemodelextractor.NewAdaptersStore()}
-	h := NewHarnessWithPlugins(t, ctx, true, []framework.RequestProcessor{plugin, baseModelToHeaderPlugin}, []framework.ResponseProcessor{})
+	h := NewHarnessWithPlugins(t, ctx, []framework.RequestProcessor{plugin, baseModelToHeaderPlugin}, []framework.ResponseProcessor{})
 
 	body := map[string]any{"prompt": "hello"}
 	bodyBytes, _ := json.Marshal(body)

--- a/test/integration/harness.go
+++ b/test/integration/harness.go
@@ -53,7 +53,7 @@ type Harness struct {
 
 // NewHarness boots up an isolated payload processor server on a random port with the default
 // BodyFieldToHeaderPlugin for model extraction and no response plugins.
-func NewHarness(t *testing.T, ctx context.Context, streaming bool) *Harness {
+func NewHarness(t *testing.T, ctx context.Context) *Harness {
 	t.Helper()
 	modelToHeaderPlugin, err := bodyfieldtoheader.NewBodyFieldToHeaderPlugin(modelField, bodyfieldtoheader.ModelHeader)
 	require.NoError(t, err, "failed to create body-field-to-header plugin")
@@ -94,7 +94,7 @@ func NewHarness(t *testing.T, ctx context.Context, streaming bool) *Harness {
 
 	baseModelToHeaderPlugin := &basemodelextractor.BaseModelToHeaderPlugin{AdaptersStore: store}
 
-	return NewHarnessWithPlugins(t, ctx, streaming, []framework.RequestProcessor{modelToHeaderPlugin, baseModelToHeaderPlugin}, []framework.ResponseProcessor{})
+	return NewHarnessWithPlugins(t, ctx, []framework.RequestProcessor{modelToHeaderPlugin, baseModelToHeaderPlugin}, []framework.ResponseProcessor{})
 }
 
 // NewHarnessWithPlugins boots up an isolated payload processor server on a random port
@@ -102,7 +102,6 @@ func NewHarness(t *testing.T, ctx context.Context, streaming bool) *Harness {
 func NewHarnessWithPlugins(
 	t *testing.T,
 	ctx context.Context,
-	streaming bool,
 	requestPlugins []framework.RequestProcessor,
 	responsePlugins []framework.ResponseProcessor,
 ) *Harness {
@@ -113,9 +112,8 @@ func NewHarnessWithPlugins(
 	require.NoError(t, err, "failed to acquire free port for payload processor server")
 
 	// 2. Configure payload processor server with plugins
-	runner := runserver.NewDefaultExtProcServerRunner(port, false)
+	runner := runserver.NewDefaultExtProcServerRunner(port)
 	runner.SecureServing = false
-	runner.Streaming = streaming
 	runner.RequestPlugins = requestPlugins
 	runner.ResponsePlugins = responsePlugins
 

--- a/test/integration/hermetic_test.go
+++ b/test/integration/hermetic_test.go
@@ -19,7 +19,6 @@ package integration
 
 import (
 	"context"
-	"encoding/json"
 	"strings"
 	"testing"
 
@@ -31,182 +30,12 @@ import (
 	"google.golang.org/protobuf/testing/protocmp"
 
 	envoytest "github.com/llm-d/llm-d-inference-payload-processor/pkg/common/envoy/test"
-	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
-	"github.com/llm-d/llm-d-inference-payload-processor/pkg/plugins/basemodelextractor"
-	"github.com/llm-d/llm-d-inference-payload-processor/pkg/plugins/bodyfieldtoheader"
 	"sigs.k8s.io/gateway-api-inference-extension/test/integration"
 )
 
-// TestBodyBasedRouting validates the "Unary" (Non-Streaming) request-phase behavior of the payload processor.
-// This simulates scenarios where Envoy buffers the body before sending it to ext_proc.
-func TestBodyBasedRouting(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name             string
-		req              *extProcPb.ProcessingRequest
-		wantResponse     *extProcPb.ProcessingResponse
-		wantStatusCode   envoyTypePb.StatusCode
-		wantBodyContains string
-	}{
-		{
-			name:         "success: extracts model and sets header",
-			req:          integration.ReqLLMUnary(logger, "test", "qwen"),
-			wantResponse: ExpectUnaryResponse("qwen", "qwen"),
-		},
-		{
-			name: "no model parameter in body - skips gracefully",
-			req:  integration.ReqLLMUnary(logger, "test1", ""),
-			wantResponse: &extProcPb.ProcessingResponse{
-				Response: &extProcPb.ProcessingResponse_RequestBody{
-					RequestBody: &extProcPb.BodyResponse{
-						Response: &extProcPb.CommonResponse{
-							ClearRouteCache: true,
-							HeaderMutation:  &extProcPb.HeaderMutation{},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			ctx := context.Background()
-			h := NewHarness(t, ctx, false)
-
-			res, err := integration.SendRequest(t, h.Client, tc.req)
-			require.NoError(t, err, "unexpected error during request processing")
-
-			if tc.wantStatusCode != 0 {
-				ir := res.GetImmediateResponse()
-				require.NotNil(t, ir, "expected ImmediateResponse")
-				require.Equal(t, tc.wantStatusCode, ir.GetStatus().GetCode())
-				if tc.wantBodyContains != "" {
-					require.True(t, strings.Contains(string(ir.GetBody()), tc.wantBodyContains),
-						"ImmediateResponse body %s should contain %s", string(ir.GetBody()), tc.wantBodyContains)
-				}
-				return
-			}
-
-			envoytest.SortSetHeadersInResponses([]*extProcPb.ProcessingResponse{tc.wantResponse})
-			envoytest.SortSetHeadersInResponses([]*extProcPb.ProcessingResponse{res})
-			if diff := cmp.Diff(tc.wantResponse, res, protocmp.Transform()); diff != "" {
-				t.Errorf("Response mismatch (-want +got): %v", diff)
-			}
-		})
-	}
-}
-
-// TestResponsePlugins validates the full request→response lifecycle in unary mode,
-// testing that response plugins can mutate the response body and that responses
-// pass through unchanged when no response plugins are configured.
-func TestResponsePlugins(t *testing.T) {
-	t.Parallel()
-
-	responsePlugin := &testResponsePlugin{
-		name: "guardrail",
-		mutateFn: func(_ context.Context, response *framework.InferenceResponse) error {
-			response.SetBodyField("guardrail", "applied")
-			return nil
-		},
-	}
-
-	respHeaders := &extProcPb.ProcessingRequest{
-		Request: &extProcPb.ProcessingRequest_ResponseHeaders{
-			ResponseHeaders: &extProcPb.HttpHeaders{
-				Headers: &envoyCorev3.HeaderMap{
-					Headers: []*envoyCorev3.HeaderValue{
-						{Key: "content-type", Value: "application/json"},
-					},
-				},
-			},
-		},
-	}
-	respBodyReq := func(body map[string]any) *extProcPb.ProcessingRequest {
-		b, _ := json.Marshal(body)
-		return &extProcPb.ProcessingRequest{
-			Request: &extProcPb.ProcessingRequest_ResponseBody{
-				ResponseBody: &extProcPb.HttpBody{Body: b, EndOfStream: true},
-			},
-		}
-	}
-
-	tests := []struct {
-		name          string
-		createHarness func(t *testing.T, ctx context.Context) *Harness
-		reqs          []*extProcPb.ProcessingRequest
-		wantResponses []*extProcPb.ProcessingResponse
-	}{
-		{
-			name: "no plugins: response passes through unchanged",
-			createHarness: func(t *testing.T, ctx context.Context) *Harness {
-				return NewHarness(t, ctx, false)
-			},
-			reqs: []*extProcPb.ProcessingRequest{
-				integration.ReqLLMUnary(logger, "test", "qwen"),
-				respHeaders,
-				respBodyReq(map[string]any{"choices": []any{map[string]any{"text": "Hi there!"}}}),
-			},
-			wantResponses: []*extProcPb.ProcessingResponse{
-				ExpectUnaryResponse("qwen", "qwen"),
-				ExpectResponseHeadersPassThrough(),
-				ExpectResponseBodyPassThrough(),
-			},
-		},
-		{
-			name: "response plugin mutates response body",
-			createHarness: func(t *testing.T, ctx context.Context) *Harness {
-				t.Helper()
-				modelToHeaderPlugin, err := bodyfieldtoheader.NewBodyFieldToHeaderPlugin(modelField, bodyfieldtoheader.ModelHeader)
-				require.NoError(t, err, "failed to create body-field-to-header plugin")
-				baseModelPlugin := &basemodelextractor.BaseModelToHeaderPlugin{AdaptersStore: basemodelextractor.NewAdaptersStore()}
-				return NewHarnessWithPlugins(t, ctx, false,
-					[]framework.RequestProcessor{modelToHeaderPlugin, baseModelPlugin},
-					[]framework.ResponseProcessor{responsePlugin},
-				)
-			},
-			reqs: []*extProcPb.ProcessingRequest{
-				integration.ReqLLMUnary(logger, "hello", "test-model"),
-				respHeaders,
-				respBodyReq(map[string]any{"choices": []any{map[string]any{"text": "Hello!"}}}),
-			},
-			wantResponses: []*extProcPb.ProcessingResponse{
-				ExpectUnaryResponse("test-model", ""),
-				ExpectResponseHeadersPassThrough(),
-				ExpectResponseBodyMutation(map[string]any{
-					"choices":   []any{map[string]any{"text": "Hello!"}},
-					"guardrail": "applied",
-				}),
-			},
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			ctx := context.Background()
-			h := tc.createHarness(t, ctx)
-
-			responses, err := integration.StreamedRequest(t, h.Client, tc.reqs, len(tc.wantResponses))
-			require.NoError(t, err, "unexpected error during streamed request")
-			require.Len(t, responses, len(tc.wantResponses))
-
-			envoytest.SortSetHeadersInResponses(tc.wantResponses)
-			envoytest.SortSetHeadersInResponses(responses)
-			if diff := cmp.Diff(tc.wantResponses, responses, protocmp.Transform()); diff != "" {
-				t.Errorf("Response mismatch (-want +got): %v", diff)
-			}
-		})
-	}
-}
-
-// TestFullDuplexStreamed_BodyBasedRouting validates the "Streaming" behavior of the payload processor.
+// TestBodyBasedRouting validates the full-duplex streaming behavior of the payload processor.
 // This validates that the payload processor correctly buffers streamed chunks, inspects the body, and injects the header.
-func TestFullDuplexStreamed_BodyBasedRouting(t *testing.T) {
+func TestBodyBasedRouting(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -270,7 +99,7 @@ func TestFullDuplexStreamed_BodyBasedRouting(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
-			h := NewHarness(t, ctx, true)
+			h := NewHarness(t, ctx)
 
 			expectedCount := len(tc.wantResponses)
 			if tc.wantStatusCode != 0 || tc.wantErr {
@@ -306,19 +135,3 @@ func TestFullDuplexStreamed_BodyBasedRouting(t *testing.T) {
 		})
 	}
 }
-
-// testResponsePlugin implements framework.ResponseProcessor for integration tests.
-type testResponsePlugin struct {
-	name     string
-	mutateFn func(ctx context.Context, response *framework.InferenceResponse) error
-}
-
-func (p *testResponsePlugin) TypedName() framework.TypedName {
-	return framework.TypedName{Type: "test", Name: p.name}
-}
-
-func (p *testResponsePlugin) ProcessResponse(ctx context.Context, _ *framework.CycleState, response *framework.InferenceResponse) error {
-	return p.mutateFn(ctx, response)
-}
-
-var _ framework.ResponseProcessor = &testResponsePlugin{}

--- a/test/integration/util.go
+++ b/test/integration/util.go
@@ -18,7 +18,6 @@ package integration
 
 import (
 	"encoding/json"
-	"strconv"
 
 	envoyCorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
@@ -89,94 +88,4 @@ func ExpectBodyPassThrough(prompt, model string) *extProcPb.ProcessingResponse {
 			},
 		},
 	}
-}
-
-// --- Response Phase Expectations ---
-
-// ExpectResponseHeadersPassThrough asserts that the payload processor passed response headers through with no mutations.
-func ExpectResponseHeadersPassThrough() *extProcPb.ProcessingResponse {
-	return &extProcPb.ProcessingResponse{
-		Response: &extProcPb.ProcessingResponse_ResponseHeaders{
-			ResponseHeaders: &extProcPb.HeadersResponse{},
-		},
-	}
-}
-
-// ExpectResponseBodyPassThrough asserts that the payload processor passed the response body through with no mutations
-// (i.e., no response plugins configured).
-func ExpectResponseBodyPassThrough() *extProcPb.ProcessingResponse {
-	return &extProcPb.ProcessingResponse{
-		Response: &extProcPb.ProcessingResponse_ResponseBody{
-			ResponseBody: &extProcPb.BodyResponse{},
-		},
-	}
-}
-
-// ExpectResponseBodyMutation asserts that a response plugin mutated the response body (unary mode).
-// Includes the Content-Length header mutation.
-func ExpectResponseBodyMutation(body map[string]any) *extProcPb.ProcessingResponse {
-	b, _ := json.Marshal(body)
-	return &extProcPb.ProcessingResponse{
-		Response: &extProcPb.ProcessingResponse_ResponseBody{
-			ResponseBody: &extProcPb.BodyResponse{
-				Response: &extProcPb.CommonResponse{
-					ClearRouteCache: true,
-					HeaderMutation: &extProcPb.HeaderMutation{
-						SetHeaders: []*envoyCorev3.HeaderValueOption{
-							{
-								Header: &envoyCorev3.HeaderValue{
-									Key:      "Content-Length",
-									RawValue: []byte(strconv.Itoa(len(b))),
-								},
-							},
-						},
-					},
-					BodyMutation: &extProcPb.BodyMutation{
-						Mutation: &extProcPb.BodyMutation_Body{
-							Body: b,
-						},
-					},
-				},
-			},
-		},
-	}
-}
-
-// --- Request Phase Expectations (Unary) ---
-
-// ExpectUnaryResponse creates expected response for unary tests where the body is mutated directly.
-// baseModelName is the expected base model name (e.g., "qwen" for both "qwen" and "sql-lora-sheddable")
-func ExpectUnaryResponse(modelName, baseModelName string) *extProcPb.ProcessingResponse {
-	resp := &extProcPb.ProcessingResponse{}
-
-	if modelName != "" {
-		resp.Response = &extProcPb.ProcessingResponse_RequestBody{
-			RequestBody: &extProcPb.BodyResponse{
-				Response: &extProcPb.CommonResponse{
-					ClearRouteCache: true,
-					HeaderMutation: &extProcPb.HeaderMutation{
-						SetHeaders: []*envoyCorev3.HeaderValueOption{
-							{
-								Header: &envoyCorev3.HeaderValue{
-									Key:      "X-Gateway-Model-Name",
-									RawValue: []byte(modelName),
-								},
-							},
-							{
-								Header: &envoyCorev3.HeaderValue{
-									Key:      "X-Gateway-Base-Model-Name",
-									RawValue: []byte(baseModelName),
-								},
-							},
-						},
-					},
-				},
-			},
-		}
-	} else {
-		resp.Response = &extProcPb.ProcessingResponse_RequestBody{
-			RequestBody: &extProcPb.BodyResponse{},
-		}
-	}
-	return resp
 }


### PR DESCRIPTION
## What does this PR do?

Removes buffered (unary) mode from the ext-proc server, making full-duplex streaming the only mode.

- Remove `--streaming` CLI flag and all `if streaming` conditionals
- Simplify `NewServer()` and handler signatures
- Update Helm chart and tests for streaming-only

## Why is this change needed?

- Streaming mode is more efficient and recommended for production
- Eliminates code duplication and reduces maintenance burden

## How was this tested?

- [x] Unit tests added/updated
- [x] Integration/e2e tests added/updated
- [x] Manual testing performed

Verified:
- `go test ./... -race` passes
- `--streaming` flag rejected with "unknown flag" error
- Integration tests confirm `StreamedBodyResponse` format in responses

Resloves: #11 