### PR TITLE
ci: add PR size labeler workflow

### DIFF
--- a/.github/workflows/pr-size-labeler.yml
+++ b/.github/workflows/pr-size-labeler.yml
@@ -1,0 +1,33 @@
+name: PR Size Labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  size-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: size-label
+        uses: pascalgn/size-label-action@v0.5.7
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IGNORED: |
+            go.sum
+            go.mod
+            *.generated.go
+            vendor/**
+        with:
+          sizes: >
+            {
+              "0": "size/XS",
+              "10": "size/S",
+              "30": "size/M",
+              "100": "size/L",
+              "500": "size/XL",
+              "1000": "size/XXL"
+            }


### PR DESCRIPTION


## What does this PR do?

Adds a GitHub Actions workflow that automatically labels PRs based on the number of lines changed (`size/XS`, `size/S`, `size/M`, `size/L`, `size/XL`), using the same thresholds as Kubernetes Prow.

## Why is this change needed?

Helps reviewers quickly assess PR complexity at a glance, similar to how Kubernetes projects label PRs. This enables better prioritization of code reviews.

## How was this tested?

- [ ] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [x] Manual testing performed

Tested on fork: https://github.com/yehuditkerido/llm-d-inference-payload-processor/pull/1

## Prerequisites
Before merging, create these labels in the repository:
```bash
gh label create "size/XS" --color "3CBF00" --description "Denotes a PR that changes 0-9 lines"
gh label create "size/S" --color "5D9801" --description "Denotes a PR that changes 10-29 lines"
gh label create "size/M" --color "7F7203" --description "Denotes a PR that changes 30-99 lines"
gh label create "size/L" --color "A14C05" --description "Denotes a PR that changes 100-499 lines"
gh label create "size/XL" --color "C32607" --description "Denotes a PR that changes 500+ lines"
gh label create "size/XXL" --color "D93F0B" --description "Denotes a PR that changes 1000+ lines"

```

Resolves #32