### PR TITLE
ci(pr-size): add hold label for large PRs

### DIFF
--- a/.github/workflows/pr-size-labeler.yml
+++ b/.github/workflows/pr-size-labeler.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: size-label
+        id: size
         uses: pascalgn/size-label-action@v0.5.7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -31,3 +32,20 @@ jobs:
               "500": "XL",
               "1000": "XXL"
             }
+
+      - name: Hold large PRs
+        if: contains(steps.size.outputs.sizeLabel, 'XL')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
+            --add-label "do-not-merge/hold"
+          
+          gh pr comment ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
+            --body "⚠️ **Large PR detected**
+
+          Your PR is large. Please consider breaking it into multiple PRs.
+
+          The \`do-not-merge/hold\` label has been added and can be removed by the reviewers based on their judgement."


### PR DESCRIPTION

## What does this PR do?

Extends the PR size labeler to automatically add `do-not-merge/hold` label and post a warning comment when PRs exceed 500 lines (XL/XXL).

## Why is this change needed?

Large PRs are harder to review. This adds a speed bump to encourage contributors to break large changes into smaller, focused PRs.

## How was this tested?

Tested on fork with a 1200-line dummy file to trigger XXL label.


## Related Issues

Fixes #44 