### PR TITLE
Add Scorer interface

### DIFF
--- a/pkg/framework/plugins.go
+++ b/pkg/framework/plugins.go
@@ -18,6 +18,30 @@ package framework
 
 import (
 	"context"
+
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/datalayer"
+)
+
+// ScorerCategory indicates the preference a scorer applies when scoring candidate models
+type ScorerCategory string
+
+const (
+	// Cheapest indicates a scorer that prefers models with the lowest USD/(1M tokens) price
+	Cheapest ScorerCategory = "Cheapest"
+
+	// TODO: Add other cost-related scorer categories here after the simplest "Cheapest" category scorer is implemented
+	// Value indicates a scorer that prefers models sitting on the efficiency curve
+	// A model is better than another model only if it is both more accurate and cheaper
+	// Value = (normalized accuracy rank)/(actual total cost)
+	// Value ScorerCategory = "Value"
+
+	// PredictiveCost indicates a scorer that prefers models for which predicted cost is lowest
+	// PredictiveCost ScorerCategory = "PredictiveCost"
+
+	// PredictiveValue indicates a scorer that prefers models for which predicted value is highest
+	// PredictiveValue ScorerCategory = "PredictiveValue"
+
+	// TODO: Add other scorer categories here for other types of scoring
 )
 
 // Plugin defines the interface for a plugin.
@@ -39,4 +63,14 @@ type ResponseProcessor interface {
 	// ProcessResponse runs the ResponseProcessor plugin.
 	// ResponseProcessor can mutate the headers and/or the body of the response.
 	ProcessResponse(ctx context.Context, cycleState *CycleState, response *InferenceResponse) error
+}
+
+// Scorer defines the interface for a scorer plugin that scores a list of models based on the category and context.
+// Scorer implementation MUST return a score in [0,1] with 1 being the highest score
+type Scorer interface {
+	Plugin
+	// Category returns the category of the scorer
+	Category() ScorerCategory
+	// Score returns a score for each input model
+	Score(ctx context.Context, cycleState *CycleState, models []*datalayer.Model) map[string]float64
 }


### PR DESCRIPTION
## What does this PR do?

Adds Scorer interface

## Why is this change needed?

The Scorer interface should be implemented by all scorers

## How was this tested?

This is only the interface. Nothing is wired into an actual implementation yet. 

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [NA ] Documentation updated (if applicable)

## Related Issues

Related to Issue #53 , related to the model selector architecture proposal PR #43 
