### PR TITLE
fix: return error for unknown plugin type instead of nil

### DIFF
--- a/cmd/runner/runner.go
+++ b/cmd/runner/runner.go
@@ -201,7 +201,8 @@ func (r *Runner) Run(ctx context.Context) error {
 		for _, s := range opts.PluginSpecs {
 			factory, ok := framework.Registry[s.Type]
 			if !ok {
-				setupLog.Error(err, fmt.Sprintf("unknown plugin type %q (no factory registered)\n", s.Type))
+				err := fmt.Errorf("unknown plugin type %q (no factory registered)", s.Type)
+				setupLog.Error(err, "Failed to find plugin factory", "pluginType", s.Type)
 				return err
 			}
 			instance, err := factory(s.Name, s.JSON, handle)


### PR DESCRIPTION
## What does this PR do?

In `cmd/runner/runner.go`, when a configured plugin type is not found in the registry, the code logs the error and returns `err`, but `err` is `nil` at that point.

This PR replaces `return err` with `return fmt.Errorf(...)` so the error is properly surfaced.

## Why is this change needed?

Found this while reading through the codebase. It is a minor bug .

If a user misconfigures a plugin type via `--plugin` flags, the process starts successfully without the intended plugin, with no indication of the misconfiguration beyond a log line with a nil error.

## How was this tested?

- [x] Code compiles (`go build ./...`)
- [ ] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)