### PR TITLE
fix/rename bbr to ipp

### DIFF
--- a/cmd/runner/runner.go
+++ b/cmd/runner/runner.go
@@ -130,7 +130,7 @@ func (r *Runner) Run(ctx context.Context) error {
 
 	// --- Setup Metrics Server ---
 	metrics.Register(r.customCollectors...)
-	metrics.RecordBBRInfo(version.CommitSHA, version.BuildRef)
+	metrics.RecordIPPInfo(version.CommitSHA, version.BuildRef)
 	// Register metrics handler.
 	// Metrics endpoint is enabled in 'config/default/kustomization.yaml'. The Metrics options configure the server.
 	// More info:

--- a/pkg/common/error/error.go
+++ b/pkg/common/error/error.go
@@ -24,7 +24,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// Error is an error struct for errors returned by the epp/bbr server.
+// Error is an error struct for errors returned by the epp/ipp server.
 type Error struct {
 	Code string
 	Msg  string

--- a/pkg/config/spec.go
+++ b/pkg/config/spec.go
@@ -22,19 +22,19 @@ import (
 	"strings"
 )
 
-// BBRPluginSpec implements flag.Value interface and defines a repeatable configuration block specified in CLI: --plugin <type>:<name>:<json>
-type BBRPluginSpec struct {
+// IPPPluginSpec implements flag.Value interface and defines a repeatable configuration block specified in CLI: --plugin <type>:<name>:<json>
+type IPPPluginSpec struct {
 	Type string
 	Name string
 	JSON json.RawMessage // raw JSON representing parameters for the plugin factory
 	Raw  string          // original parameters string (for error messages)
 }
 
-// BBRPluginSpecs Slice (because the plugin flag is repeatable)
-type BBRPluginSpecs []BBRPluginSpec
+// IPPPluginSpecs Slice (because the plugin flag is repeatable)
+type IPPPluginSpecs []IPPPluginSpec
 
-func (p *BBRPluginSpecs) Set(s string) error {
-	spec := BBRPluginSpec{Raw: s}
+func (p *IPPPluginSpecs) Set(s string) error {
+	spec := IPPPluginSpec{Raw: s}
 
 	// Accept either:
 	//   <type>:<name>
@@ -47,10 +47,10 @@ func (p *BBRPluginSpecs) Set(s string) error {
 	spec.Name = strings.TrimSpace(segments[1])
 
 	if spec.Type == "" {
-		return errors.New("bbr plugin type cannot be empty")
+		return errors.New("ipp plugin type cannot be empty")
 	}
 	if spec.Name == "" {
-		return errors.New("bbr plugin name cannot be empty")
+		return errors.New("ipp plugin name cannot be empty")
 	}
 
 	// If the third segment is provided, validate JSON if non-empty.
@@ -70,9 +70,9 @@ func (p *BBRPluginSpecs) Set(s string) error {
 }
 
 // Type returns the flag type name for the pflag.Value interface.
-func (p *BBRPluginSpecs) Type() string { return "plugin" }
+func (p *IPPPluginSpecs) Type() string { return "plugin" }
 
-func (p *BBRPluginSpecs) String() string {
+func (p *IPPPluginSpecs) String() string {
 	specs := *p
 	out := make([]string, 0, len(specs)) // preallocate memory
 

--- a/pkg/handlers/request_test.go
+++ b/pkg/handlers/request_test.go
@@ -499,21 +499,21 @@ func TestHandleRequestBody_BuiltInPlugins(t *testing.T) {
 		})
 	}
 
-	// Assert BBR metrics: 1 model not in body, 1 model empty string, 5 successful model-from-body cases.
+	// Assert IPP metrics: 1 model not in body, 1 model empty string, 5 successful model-from-body cases.
 	wantMetrics := `
-	# HELP bbr_body_field_empty_total [ALPHA] Count of times a field was found in a request body but was empty.
-	# TYPE bbr_body_field_empty_total counter
-	bbr_body_field_empty_total{field="model"} 1
-	# HELP bbr_body_field_not_found_total [ALPHA] Count of times a field wasn't found in a request body.
-	# TYPE bbr_body_field_not_found_total counter
-	bbr_body_field_not_found_total{field="model"} 1
-	# HELP bbr_success_total [ALPHA] Count of time the request was processed successfully.
-	# TYPE bbr_success_total counter
-	bbr_success_total{} 5
+	# HELP ipp_body_field_empty_total [ALPHA] Count of times a field was found in a request body but was empty.
+	# TYPE ipp_body_field_empty_total counter
+	ipp_body_field_empty_total{field="model"} 1
+	# HELP ipp_body_field_not_found_total [ALPHA] Count of times a field wasn't found in a request body.
+	# TYPE ipp_body_field_not_found_total counter
+	ipp_body_field_not_found_total{field="model"} 1
+	# HELP ipp_success_total [ALPHA] Count of time the request was processed successfully.
+	# TYPE ipp_success_total counter
+	ipp_success_total{} 5
 	`
 
 	if err := metricsutils.GatherAndCompare(crmetrics.Registry, strings.NewReader(wantMetrics),
-		"bbr_body_field_empty_total", "bbr_body_field_not_found_total", "bbr_success_total"); err != nil {
+		"ipp_body_field_empty_total", "ipp_body_field_not_found_total", "ipp_success_total"); err != nil {
 		t.Error(err)
 	}
 }
@@ -546,7 +546,7 @@ func TestHandleRequestBodyWithPluginMetrics(t *testing.T) {
 
 	pluginsWithMetrics := 0
 	for _, mf := range mfs {
-		if mf.GetName() == "bbr_plugin_duration_seconds" {
+		if mf.GetName() == "ipp_plugin_duration_seconds" {
 			for _, m := range mf.GetMetric() {
 				labels := map[string]string{}
 				for _, lp := range m.GetLabel() {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -27,15 +27,15 @@ import (
 	metricsutil "github.com/llm-d/llm-d-inference-payload-processor/pkg/common/observability/metrics"
 )
 
-const component = "bbr"
+const component = "ipp"
 
 var (
 	// --- Info Metrics ---
-	bbrInfo = prometheus.NewGaugeVec(
+	ippInfo = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: component,
 			Name:      "info",
-			Help:      metricsutil.HelpMsgWithStability("General information of the current build of BBR.", compbasemetrics.ALPHA),
+			Help:      metricsutil.HelpMsgWithStability("General information of the current build of IPP.", compbasemetrics.ALPHA),
 		},
 		[]string{"commit", "build_ref"},
 	)
@@ -85,7 +85,7 @@ var registerMetrics sync.Once
 // Register all metrics.
 func Register(customCollectors ...prometheus.Collector) {
 	registerMetrics.Do(func() {
-		metrics.Registry.MustRegister(bbrInfo)
+		metrics.Registry.MustRegister(ippInfo)
 		metrics.Registry.MustRegister(successCounter)
 		metrics.Registry.MustRegister(bodyFieldNotFoundCounter)
 		metrics.Registry.MustRegister(bodyFieldEmptyCounter)
@@ -96,9 +96,9 @@ func Register(customCollectors ...prometheus.Collector) {
 	})
 }
 
-// RecordBBRInfo records bbr build info.
-func RecordBBRInfo(commitSha, buildRef string) {
-	bbrInfo.WithLabelValues(commitSha, buildRef).Set(1)
+// RecordIPPInfo records ipp build info.
+func RecordIPPInfo(commitSha, buildRef string) {
+	ippInfo.WithLabelValues(commitSha, buildRef).Set(1)
 }
 
 // RecordSuccessCounter records the number of times the request was processed successfully.
@@ -116,7 +116,7 @@ func RecordBodyFieldEmpty(fieldName string) {
 	bodyFieldEmptyCounter.WithLabelValues(fieldName).Inc()
 }
 
-// RecordPluginProcessingLatency records the processing latency for a BBR plugin.
+// RecordPluginProcessingLatency records the processing latency for an IPP plugin.
 func RecordPluginProcessingLatency(extensionPoint, pluginType, pluginName string, duration time.Duration) {
 	pluginProcessingLatencies.WithLabelValues(extensionPoint, pluginType, pluginName).Observe(duration.Seconds())
 }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -72,7 +72,7 @@ func TestPluginProcessingLatency(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if err := testutil.GatherAndCompare(crmetrics.Registry, wantPluginLatencies, "bbr_plugin_duration_seconds"); err != nil {
+			if err := testutil.GatherAndCompare(crmetrics.Registry, wantPluginLatencies, "ipp_plugin_duration_seconds"); err != nil {
 				t.Error(err)
 			}
 		})

--- a/pkg/metrics/testdata/plugin_processing_latencies_metric
+++ b/pkg/metrics/testdata/plugin_processing_latencies_metric
@@ -1,28 +1,28 @@
-# HELP bbr_plugin_duration_seconds [ALPHA] Plugin processing latency distribution in seconds for each extension point, plugin type and plugin name.
-# TYPE bbr_plugin_duration_seconds histogram
-bbr_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginA",plugin_type="TestPluginA",le="0.0001"} 0
-bbr_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginA",plugin_type="TestPluginA",le="0.0002"} 0
-bbr_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginA",plugin_type="TestPluginA",le="0.0005"} 0
-bbr_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginA",plugin_type="TestPluginA",le="0.001"} 0
-bbr_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginA",plugin_type="TestPluginA",le="0.002"} 0
-bbr_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginA",plugin_type="TestPluginA",le="0.005"} 1
-bbr_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginA",plugin_type="TestPluginA",le="0.01"} 1
-bbr_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginA",plugin_type="TestPluginA",le="0.02"} 1
-bbr_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginA",plugin_type="TestPluginA",le="0.05"} 1
-bbr_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginA",plugin_type="TestPluginA",le="0.1"} 1
-bbr_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginA",plugin_type="TestPluginA",le="+Inf"} 1
-bbr_plugin_duration_seconds_sum{extension_point="Request",plugin_name="PluginA",plugin_type="TestPluginA"} 0.005
-bbr_plugin_duration_seconds_count{extension_point="Request",plugin_name="PluginA",plugin_type="TestPluginA"} 1
-bbr_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginB",plugin_type="TestPluginB",le="0.0001"} 1
-bbr_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginB",plugin_type="TestPluginB",le="0.0002"} 1
-bbr_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginB",plugin_type="TestPluginB",le="0.0005"} 1
-bbr_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginB",plugin_type="TestPluginB",le="0.001"} 1
-bbr_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginB",plugin_type="TestPluginB",le="0.002"} 1
-bbr_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginB",plugin_type="TestPluginB",le="0.005"} 1
-bbr_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginB",plugin_type="TestPluginB",le="0.01"} 1
-bbr_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginB",plugin_type="TestPluginB",le="0.02"} 1
-bbr_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginB",plugin_type="TestPluginB",le="0.05"} 1
-bbr_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginB",plugin_type="TestPluginB",le="0.1"} 1
-bbr_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginB",plugin_type="TestPluginB",le="+Inf"} 1
-bbr_plugin_duration_seconds_sum{extension_point="Request",plugin_name="PluginB",plugin_type="TestPluginB"} 1e-05
-bbr_plugin_duration_seconds_count{extension_point="Request",plugin_name="PluginB",plugin_type="TestPluginB"} 1
+# HELP ipp_plugin_duration_seconds [ALPHA] Plugin processing latency distribution in seconds for each extension point, plugin type and plugin name.
+# TYPE ipp_plugin_duration_seconds histogram
+ipp_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginA",plugin_type="TestPluginA",le="0.0001"} 0
+ipp_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginA",plugin_type="TestPluginA",le="0.0002"} 0
+ipp_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginA",plugin_type="TestPluginA",le="0.0005"} 0
+ipp_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginA",plugin_type="TestPluginA",le="0.001"} 0
+ipp_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginA",plugin_type="TestPluginA",le="0.002"} 0
+ipp_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginA",plugin_type="TestPluginA",le="0.005"} 1
+ipp_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginA",plugin_type="TestPluginA",le="0.01"} 1
+ipp_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginA",plugin_type="TestPluginA",le="0.02"} 1
+ipp_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginA",plugin_type="TestPluginA",le="0.05"} 1
+ipp_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginA",plugin_type="TestPluginA",le="0.1"} 1
+ipp_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginA",plugin_type="TestPluginA",le="+Inf"} 1
+ipp_plugin_duration_seconds_sum{extension_point="Request",plugin_name="PluginA",plugin_type="TestPluginA"} 0.005
+ipp_plugin_duration_seconds_count{extension_point="Request",plugin_name="PluginA",plugin_type="TestPluginA"} 1
+ipp_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginB",plugin_type="TestPluginB",le="0.0001"} 1
+ipp_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginB",plugin_type="TestPluginB",le="0.0002"} 1
+ipp_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginB",plugin_type="TestPluginB",le="0.0005"} 1
+ipp_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginB",plugin_type="TestPluginB",le="0.001"} 1
+ipp_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginB",plugin_type="TestPluginB",le="0.002"} 1
+ipp_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginB",plugin_type="TestPluginB",le="0.005"} 1
+ipp_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginB",plugin_type="TestPluginB",le="0.01"} 1
+ipp_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginB",plugin_type="TestPluginB",le="0.02"} 1
+ipp_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginB",plugin_type="TestPluginB",le="0.05"} 1
+ipp_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginB",plugin_type="TestPluginB",le="0.1"} 1
+ipp_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginB",plugin_type="TestPluginB",le="+Inf"} 1
+ipp_plugin_duration_seconds_sum{extension_point="Request",plugin_name="PluginB",plugin_type="TestPluginB"} 1e-05
+ipp_plugin_duration_seconds_count{extension_point="Request",plugin_name="PluginB",plugin_type="TestPluginB"} 1

--- a/pkg/plugins/basemodelextractor/base_model_to_header.go
+++ b/pkg/plugins/basemodelextractor/base_model_to_header.go
@@ -77,7 +77,7 @@ func (p *BaseModelToHeaderPlugin) TypedName() framework.TypedName {
 	return p.typedName
 }
 
-// WithName sets the name of the BBR plugin instance.
+// WithName sets the name of the IPP plugin instance.
 func (p *BaseModelToHeaderPlugin) WithName(name string) *BaseModelToHeaderPlugin {
 	p.typedName.Name = name
 	return p

--- a/pkg/server/options.go
+++ b/pkg/server/options.go
@@ -30,7 +30,7 @@ const (
 	DefaultGrpcHealthPort = 9005
 )
 
-// Options contains the command-line configuration for the BBR server.
+// Options contains the command-line configuration for the IPP server.
 type Options struct {
 	//
 	// ext_proc configuration.
@@ -41,7 +41,7 @@ type Options struct {
 	//
 	logging.LoggingOptions      // Logging configuration.
 	Tracing                bool // Enable emitting traces
-	MetricsPort            int  // The metrics port exposed by BBR.
+	MetricsPort            int  // The metrics port exposed by IPP.
 	GRPCHealthPort         int  // The port for gRPC liveness and readiness probes.
 	EnablePprof            bool // Enables pprof handlers.
 	SecureServing          bool // Enables secure serving.
@@ -49,7 +49,7 @@ type Options struct {
 	//
 	// Plugins.
 	//
-	PluginSpecs config.BBRPluginSpecs // Repeatable --plugin <type>:<name>[:<json>] flag values.
+	PluginSpecs config.IPPPluginSpecs // Repeatable --plugin <type>:<name>[:<json>] flag values.
 
 	// internal
 	fs *pflag.FlagSet // FlagSet used in AddFlags()
@@ -82,7 +82,7 @@ func (opts *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&opts.GRPCHealthPort, "grpc-health-port", opts.GRPCHealthPort,
 		"The port used for gRPC liveness and readiness probes.")
 	fs.IntVar(&opts.MetricsPort, "metrics-port", opts.MetricsPort,
-		"The metrics port exposed by BBR.")
+		"The metrics port exposed by IPP.")
 	fs.BoolVar(&opts.Tracing, "tracing", opts.Tracing, "Enables emitting traces.")
 	fs.BoolVar(&opts.MetricsEndpointAuth, "metrics-endpoint-auth", opts.MetricsEndpointAuth,
 		"Enables authentication and authorization of the metrics endpoint.")


### PR DESCRIPTION
## Summary
This PR replaces the deprecated `bbr` acronym with `ipp` (Inference-Payload-Processor) across the codebase, reflecting the project's identity after migration from the Kubernetes GIE project.
### Changes
#### Metrics (`pkg/metrics/`)
- Prometheus component label: `"bbr"` → `"ipp"` — renames all emitted metric names (e.g. `bbr_success_total` → `ipp_success_total`)
- Variable `bbrInfo` → `ippInfo`
- Function `RecordBBRInfo` → `RecordIPPInfo`
- Updated testdata file and test assertions to use new `ipp_` prefixed metric names
#### Config (`pkg/config/spec.go`)
- `BBRPluginSpec` → `IPPPluginSpec`
- `BBRPluginSpecs` → `IPPPluginSpecs`
- Error messages: `"bbr plugin type/name cannot be empty"` → `"ipp plugin ..."`
#### Server Options (`pkg/server/options.go`)
- `BBRPluginSpecs` field type → `IPPPluginSpecs`
- Updated comments and flag description strings
#### Call Sites
- `cmd/runner/runner.go`: `metrics.RecordBBRInfo` → `metrics.RecordIPPInfo`
#### Comments
- `pkg/common/error/error.go`: `epp/bbr server` → `epp/ipp server`
- `pkg/plugins/basemodelextractor/base_model_to_header.go`: `BBR plugin instance` → `IPP plugin instance`
### Impact
- **Breaking change for existing Prometheus dashboards/alerts** — all metric names are prefixed with `ipp_` instead of `bbr_`. Dashboards and alerting rules referencing `bbr_*` metrics must be updated.
- No functional logic changes.
### Files Changed
- `pkg/metrics/metrics.go`
- `pkg/metrics/metrics_test.go`
- `pkg/metrics/testdata/plugin_processing_latencies_metric`
- `pkg/config/spec.go`
- `pkg/server/options.go`
- `cmd/runner/runner.go`
- `pkg/handlers/request_test.go`
- `pkg/common/error/error.go`
- `pkg/plugins/basemodelextractor/base_model_to_header.go`
### Resolve 
https://github.com/llm-d/llm-d-inference-payload-processor/issues/66