### PR TITLE
fix prow-commands YAML format to prevent empty string matches

### DIFF
--- a/.github/workflows/prow-github.yml
+++ b/.github/workflows/prow-github.yml
@@ -19,7 +19,8 @@ jobs:
       - uses: jpmcb/prow-github-actions@v2.0.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-          prow-commands: "/assign
+          prow-commands: >-
+            /assign
             /unassign
             /approve
             /retitle
@@ -34,4 +35,4 @@ jobs:
             /milestone
             /hold
             /cc
-            /uncc"
+            /uncc


### PR DESCRIPTION
## Summary

Fix the `prow-github.yml` workflow so that prow commands (`/cc`, `/assign`, `/lgtm`, etc.) work correctly on PR and issue comments.

### Resolve 
  https://github.com/llm-d/llm-d-inference-payload-processor/issues/68

### Problem

The `prow-commands` input was written as a YAML double-quoted multi-line string with indentation:

```yaml
prow-commands: "/assign
  /unassign
  /cc
  ..."


