### PR TITLE
Adds a simple lowest price model scorer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ Thumbs.db
 .envrc
 .secrets.env
 vendor/
+
+#agent
+.bob/

--- a/pkg/framework/modelselector/scorer/costaware/plugin.go
+++ b/pkg/framework/modelselector/scorer/costaware/plugin.go
@@ -47,8 +47,8 @@ type PriceValue struct {
 }
 
 // Clone implements the Cloneable interface
-func (p PriceValue) Clone() datalayer.Cloneable {
-	return PriceValue{Value: p.Value}
+func (p *PriceValue) Clone() datalayer.Cloneable {
+	return &PriceValue{Value: p.Value}
 }
 
 // compile-time type assertion

--- a/pkg/framework/modelselector/scorer/costaware/plugin.go
+++ b/pkg/framework/modelselector/scorer/costaware/plugin.go
@@ -54,8 +54,8 @@ func (p *PriceValue) Clone() datalayer.Cloneable {
 // compile-time type assertion
 var _ modelselector.Scorer = &CostScorer{}
 
-// Factory defines the factory function for the CostScorer scorer
-func CostScorerFactory(name string, _ json.RawMessage) (framework.Plugin, error) {
+// CostScorerFactory defines the factory function for the CostScorer scorer
+func CostScorerFactory(name string, _ json.RawMessage, _ framework.Handle) (framework.Plugin, error) {
 	return NewCostScorer().WithName(name), nil
 }
 
@@ -83,42 +83,49 @@ func (s *CostScorer) WithName(name string) *CostScorer {
 	return s
 }
 
-// Score scores the given models in range of [0.0-1.0] based on their price.
+// Score scores the given models in range of [0.0-1.0] based on their price using inverted sum normalization.
 // Scoring behavior:
-//   - Cheapest model gets score 1.0, most expensive gets 0.0
-//   - If all models have same price, all receive score 0.5
-//   - Score formula: 1.0 - (price - minPrice) / (maxPrice - minPrice)
+//   - Lower-priced models receive higher scores
+//   - Score formula: 1.0 - price / sum(prices)
+//   - Higher score indicates better (cheaper) model
+//   - If only one model, it receives neutral score 0.5
+//   - If all models have zero price, each receives score 1.0
+//
+// Note: When combining with other scorers using different normalization methods (e.g., Min-Max),
+// be aware that sum normalization may not preserve the intended weight proportions due to scale sensitivity.
+// For consistent multi-criteria scoring, consider using the same normalization method across all scorers.
 func (s *CostScorer) Score(_ context.Context, _ *framework.CycleState, _ *framework.InferenceRequest, models []datalayer.Model) map[datalayer.Model]float64 {
-	priceValue, _ := models[0].GetAttributes().Get(PriceAttributeKey)
-	minPrice := priceValue.(*PriceValue).Value
-	maxPrice := minPrice
-
-	for _, model := range models {
-		priceValue, _ := model.GetAttributes().Get(PriceAttributeKey)
-		price := priceValue.(*PriceValue).Value
-		if price < minPrice {
-			minPrice = price
-		}
-		if price > maxPrice {
-			maxPrice = price
-		}
-	}
-
-	modelScoreFunc := func(model datalayer.Model) float64 {
-		if maxPrice == minPrice {
-			// All models have the same price, assign neutral score
-			return 0.5
-		}
-		priceValue, _ := model.GetAttributes().Get(PriceAttributeKey)
-		price := priceValue.(*PriceValue).Value
-		// Invert the score so that lower price = higher score
-		return 1.0 - (price-minPrice)/(maxPrice-minPrice)
-	}
-
 	// Create a map to hold the score of each model candidate
 	scores := make(map[datalayer.Model]float64, len(models))
-	for _, model := range models {
-		scores[model] = modelScoreFunc(model)
+
+	// Special case: single model gets neutral score
+	if len(models) == 1 {
+		scores[models[0]] = 0.5
+		return scores
 	}
+
+	// Calculate the sum of all prices
+	var sumPrices float64
+	for _, model := range models {
+		priceValue, _ := model.GetAttributes().Get(PriceAttributeKey)
+		price := priceValue.(*PriceValue).Value
+		sumPrices += price
+	}
+
+	// If sum is zero (all prices are zero), all models are free - assign perfect score
+	if sumPrices == 0 {
+		for _, model := range models {
+			scores[model] = 1.0
+		}
+		return scores
+	}
+
+	// Calculate scores using inverted sum normalization: 1 - price/sum(prices)
+	for _, model := range models {
+		priceValue, _ := model.GetAttributes().Get(PriceAttributeKey)
+		price := priceValue.(*PriceValue).Value
+		scores[model] = 1.0 - price/sumPrices
+	}
+
 	return scores
 }

--- a/pkg/framework/modelselector/scorer/costaware/plugin.go
+++ b/pkg/framework/modelselector/scorer/costaware/plugin.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package costaware
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/datalayer"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/modelselector"
+)
+
+// Package costaware provides a scorer that scores candidate models based on expected cost
+// for an inference request, by ranking nominal prices of the models.
+// Model prices are expressed in USD per 1M tokens.
+// Each model in the model selector has a valid price.
+// The actual cost is calculated as the product of the number of tokens and the price per 1M tokens.
+// This scorer assumes that there are no price reversals and the lowest nominal price of a model
+// results in the lowest cost for the request.
+
+const (
+	// CostScorerType is the type of the CostScorer scorer
+	CostScorerType = "cost-scorer"
+
+	// PriceAttributeKey is the key used to retrieve the price from model attributes
+	PriceAttributeKey = "price"
+)
+
+// PriceValue is a Cloneable wrapper for float64 price values
+type PriceValue struct {
+	Value float64
+}
+
+// Clone implements the Cloneable interface
+func (p PriceValue) Clone() datalayer.Cloneable {
+	return PriceValue{Value: p.Value}
+}
+
+// compile-time type assertion
+var _ modelselector.Scorer = &CostScorer{}
+
+// Factory defines the factory function for the CostScorer scorer
+func CostScorerFactory(name string, _ json.RawMessage) (framework.Plugin, error) {
+	return NewCostScorer().WithName(name), nil
+}
+
+// NewCostScorer creates a new lowest price scorer
+func NewCostScorer() *CostScorer {
+	return &CostScorer{
+		typedName: framework.TypedName{Type: CostScorerType},
+	}
+}
+
+// CostScorer scorer that scores models based on their price
+// Lower-priced models receive higher scores
+type CostScorer struct {
+	typedName framework.TypedName
+}
+
+// TypedName returns the typed name of the plugin.
+func (s *CostScorer) TypedName() framework.TypedName {
+	return s.typedName
+}
+
+// WithName sets the name of the plugin.
+func (s *CostScorer) WithName(name string) *CostScorer {
+	s.typedName.Name = name
+	return s
+}
+
+// Score scores the given models in range of [0.0-1.0] based on their price.
+// Scoring behavior:
+//   - Cheapest model gets score 1.0, most expensive gets 0.0
+//   - If all models have same price, all receive score 0.5
+//   - Score formula: 1.0 - (price - minPrice) / (maxPrice - minPrice)
+func (s *CostScorer) Score(_ context.Context, _ *framework.CycleState, _ *framework.InferenceRequest, models []datalayer.Model) map[datalayer.Model]float64 {
+	priceValue, _ := models[0].GetAttributes().Get(PriceAttributeKey)
+	minPrice := priceValue.(PriceValue).Value
+	maxPrice := minPrice
+
+	for _, model := range models {
+		priceValue, _ := model.GetAttributes().Get(PriceAttributeKey)
+		price := priceValue.(PriceValue).Value
+		if price < minPrice {
+			minPrice = price
+		}
+		if price > maxPrice {
+			maxPrice = price
+		}
+	}
+
+	modelScoreFunc := func(model datalayer.Model) float64 {
+		if maxPrice == minPrice {
+			// All models have the same price, assign neutral score
+			return 0.5
+		}
+		priceValue, _ := model.GetAttributes().Get(PriceAttributeKey)
+		price := priceValue.(PriceValue).Value
+		// Invert the score so that lower price = higher score
+		return 1.0 - (price-minPrice)/(maxPrice-minPrice)
+	}
+
+	// Create a map to hold the score of each model candidate
+	scores := make(map[datalayer.Model]float64, len(models))
+	for _, model := range models {
+		scores[model] = modelScoreFunc(model)
+	}
+	return scores
+}

--- a/pkg/framework/modelselector/scorer/costaware/plugin.go
+++ b/pkg/framework/modelselector/scorer/costaware/plugin.go
@@ -90,12 +90,12 @@ func (s *CostScorer) WithName(name string) *CostScorer {
 //   - Score formula: 1.0 - (price - minPrice) / (maxPrice - minPrice)
 func (s *CostScorer) Score(_ context.Context, _ *framework.CycleState, _ *framework.InferenceRequest, models []datalayer.Model) map[datalayer.Model]float64 {
 	priceValue, _ := models[0].GetAttributes().Get(PriceAttributeKey)
-	minPrice := priceValue.(PriceValue).Value
+	minPrice := priceValue.(*PriceValue).Value
 	maxPrice := minPrice
 
 	for _, model := range models {
 		priceValue, _ := model.GetAttributes().Get(PriceAttributeKey)
-		price := priceValue.(PriceValue).Value
+		price := priceValue.(*PriceValue).Value
 		if price < minPrice {
 			minPrice = price
 		}
@@ -110,7 +110,7 @@ func (s *CostScorer) Score(_ context.Context, _ *framework.CycleState, _ *framew
 			return 0.5
 		}
 		priceValue, _ := model.GetAttributes().Get(PriceAttributeKey)
-		price := priceValue.(PriceValue).Value
+		price := priceValue.(*PriceValue).Value
 		// Invert the score so that lower price = higher score
 		return 1.0 - (price-minPrice)/(maxPrice-minPrice)
 	}

--- a/pkg/framework/modelselector/scorer/costaware/plugin_test.go
+++ b/pkg/framework/modelselector/scorer/costaware/plugin_test.go
@@ -1,0 +1,254 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package costaware
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/datalayer"
+)
+
+// TestFactory tests the Factory function
+func TestFactory(t *testing.T) {
+	tests := []struct {
+		name          string
+		pluginName    string
+		rawParameters json.RawMessage
+		expectError   bool
+	}{
+		{
+			name:          "factory with nil parameters",
+			pluginName:    "test-scorer",
+			rawParameters: nil,
+			expectError:   false,
+		},
+		{
+			name:          "factory with empty parameters",
+			pluginName:    "my-scorer",
+			rawParameters: json.RawMessage(`{}`),
+			expectError:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plugin, err := CostScorerFactory(tt.pluginName, tt.rawParameters)
+			if (err != nil) != tt.expectError {
+				t.Errorf("Factory() error = %v, expectError %v", err, tt.expectError)
+				return
+			}
+			if err == nil && plugin == nil {
+				t.Error("Factory() returned nil plugin without error")
+			}
+		})
+	}
+}
+
+// TestNewCostScorer tests the constructor
+func TestNewCostScorer(t *testing.T) {
+	scorer := NewCostScorer()
+	if scorer == nil {
+		t.Fatal("NewCostScorer() returned nil")
+	}
+}
+
+// TestWithName tests the WithName method
+func TestWithName(t *testing.T) {
+	scorer := NewCostScorer()
+	result := scorer.WithName("custom-name")
+
+	if result != scorer {
+		t.Error("WithName() should return the same instance for method chaining")
+	}
+}
+
+// TestScore tests the Score method with various scenarios
+func TestScore(t *testing.T) {
+	ctx := context.Background()
+	cycleState := framework.NewCycleState()
+	request := framework.NewInferenceRequest()
+
+	tests := []struct {
+		name           string
+		models         []datalayer.Model
+		expectedScores map[string]float64
+		description    string
+	}{
+		{
+			name: "single model with price",
+			models: []datalayer.Model{
+				createModelWithPrice("model1", 10.0),
+			},
+			expectedScores: map[string]float64{
+				"model1": 0.5,
+			},
+			description: "single model should get neutral score 0.5",
+		},
+		{
+			name: "two models with different prices",
+			models: []datalayer.Model{
+				createModelWithPrice("model1", 10.0),
+				createModelWithPrice("model2", 20.0),
+			},
+			expectedScores: map[string]float64{
+				"model1": 1.0, // cheapest
+				"model2": 0.0, // most expensive
+			},
+			description: "cheapest gets 1.0, most expensive gets 0.0",
+		},
+		{
+			name: "three models with different prices",
+			models: []datalayer.Model{
+				createModelWithPrice("model1", 10.0),
+				createModelWithPrice("model2", 20.0),
+				createModelWithPrice("model3", 15.0),
+			},
+			expectedScores: map[string]float64{
+				"model1": 1.0, // cheapest
+				"model2": 0.0, // most expensive
+				"model3": 0.5, // middle
+			},
+			description: "middle-priced model gets 0.5",
+		},
+		{
+			name: "all models same price",
+			models: []datalayer.Model{
+				createModelWithPrice("model1", 10.0),
+				createModelWithPrice("model2", 10.0),
+				createModelWithPrice("model3", 10.0),
+			},
+			expectedScores: map[string]float64{
+				"model1": 0.5,
+				"model2": 0.5,
+				"model3": 0.5,
+			},
+			description: "all models with same price get neutral score 0.5",
+		},
+		{
+			name: "models with zero price",
+			models: []datalayer.Model{
+				createModelWithPrice("model1", 0.0),
+				createModelWithPrice("model2", 10.0),
+			},
+			expectedScores: map[string]float64{
+				"model1": 1.0,
+				"model2": 0.0,
+			},
+			description: "zero price is valid and should be the cheapest",
+		},
+		{
+			name: "models with very close prices",
+			models: []datalayer.Model{
+				createModelWithPrice("model1", 10.0),
+				createModelWithPrice("model2", 10.1),
+			},
+			expectedScores: map[string]float64{
+				"model1": 1.0,
+				"model2": 0.0,
+			},
+			description: "should handle small price differences",
+		},
+		{
+			name: "models with large price range",
+			models: []datalayer.Model{
+				createModelWithPrice("model1", 1.0),
+				createModelWithPrice("model2", 1000.0),
+				createModelWithPrice("model3", 500.5),
+			},
+			expectedScores: map[string]float64{
+				"model1": 1.0,
+				"model2": 0.0,
+				"model3": 0.5,
+			},
+			description: "should handle large price ranges correctly",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scorer := NewCostScorer()
+			scores := scorer.Score(ctx, cycleState, request, tt.models)
+
+			// Check that we got the expected number of scores
+			if len(scores) != len(tt.expectedScores) {
+				t.Errorf("Score() returned %d scores, want %d. Description: %s",
+					len(scores), len(tt.expectedScores), tt.description)
+			}
+
+			// Check each expected score
+			for _, model := range tt.models {
+				modelName := model.GetName()
+				expectedScore, shouldBeScored := tt.expectedScores[modelName]
+				actualScore, wasScored := scores[model]
+
+				if shouldBeScored != wasScored {
+					t.Errorf("Model %s: scored=%v, want scored=%v. Description: %s",
+						modelName, wasScored, shouldBeScored, tt.description)
+					continue
+				}
+
+				if shouldBeScored {
+					// Allow small floating point differences
+					if !floatEquals(actualScore, expectedScore, 0.0001) {
+						t.Errorf("Model %s: score=%v, want %v. Description: %s",
+							modelName, actualScore, expectedScore, tt.description)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestPriceValueClone tests the Clone method of PriceValue
+func TestPriceValueClone(t *testing.T) {
+	original := PriceValue{Value: 42.5}
+	cloned := original.Clone()
+
+	clonedPrice, ok := cloned.(PriceValue)
+	if !ok {
+		t.Fatal("Clone() did not return PriceValue type")
+	}
+
+	if clonedPrice.Value != original.Value {
+		t.Errorf("Clone() value = %v, want %v", clonedPrice.Value, original.Value)
+	}
+
+	// Verify it's a copy, not a reference
+	clonedPrice.Value = 100.0
+	if original.Value == 100.0 {
+		t.Error("Clone() did not create an independent copy")
+	}
+}
+
+// Helper functions
+
+func createModelWithPrice(name string, price float64) datalayer.Model {
+	model := datalayer.NewModel(name)
+	model.GetAttributes().Put(PriceAttributeKey, PriceValue{Value: price})
+	return model
+}
+
+func floatEquals(a, b, epsilon float64) bool {
+	diff := a - b
+	if diff < 0 {
+		diff = -diff
+	}
+	return diff < epsilon
+}

--- a/pkg/framework/modelselector/scorer/costaware/plugin_test.go
+++ b/pkg/framework/modelselector/scorer/costaware/plugin_test.go
@@ -49,7 +49,7 @@ func TestFactory(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			plugin, err := CostScorerFactory(tt.pluginName, tt.rawParameters)
+			plugin, err := CostScorerFactory(tt.pluginName, tt.rawParameters, nil)
 			if (err != nil) != tt.expectError {
 				t.Errorf("Factory() error = %v, expectError %v", err, tt.expectError)
 				return
@@ -108,10 +108,10 @@ func TestScore(t *testing.T) {
 				createModelWithPrice("model2", 20.0),
 			},
 			expectedScores: map[string]float64{
-				"model1": 1.0, // cheapest
-				"model2": 0.0, // most expensive
+				"model1": 0.6667, // 1 - 10/30 = 0.6667
+				"model2": 0.3333, // 1 - 20/30 = 0.3333
 			},
-			description: "cheapest gets 1.0, most expensive gets 0.0",
+			description: "inverted sum normalization: 1 - price/sum(prices)",
 		},
 		{
 			name: "three models with different prices",
@@ -121,11 +121,11 @@ func TestScore(t *testing.T) {
 				createModelWithPrice("model3", 15.0),
 			},
 			expectedScores: map[string]float64{
-				"model1": 1.0, // cheapest
-				"model2": 0.0, // most expensive
-				"model3": 0.5, // middle
+				"model1": 0.7778, // 1 - 10/45 = 0.7778
+				"model2": 0.5556, // 1 - 20/45 = 0.5556
+				"model3": 0.6667, // 1 - 15/45 = 0.6667
 			},
-			description: "middle-priced model gets 0.5",
+			description: "sum=45: cheapest gets highest score",
 		},
 		{
 			name: "all models same price",
@@ -135,11 +135,11 @@ func TestScore(t *testing.T) {
 				createModelWithPrice("model3", 10.0),
 			},
 			expectedScores: map[string]float64{
-				"model1": 0.5,
-				"model2": 0.5,
-				"model3": 0.5,
+				"model1": 0.6667, // 1 - 10/30 = 0.6667
+				"model2": 0.6667,
+				"model3": 0.6667,
 			},
-			description: "all models with same price get neutral score 0.5",
+			description: "all same price: each gets 1 - 10/30 = 0.6667",
 		},
 		{
 			name: "models with zero price",
@@ -160,10 +160,10 @@ func TestScore(t *testing.T) {
 				createModelWithPrice("model2", 10.1),
 			},
 			expectedScores: map[string]float64{
-				"model1": 1.0,
-				"model2": 0.0,
+				"model1": 0.5025, // 1 - 10.0/20.1 = 0.5025
+				"model2": 0.4975, // 1 - 10.1/20.1 = 0.4975
 			},
-			description: "should handle small price differences",
+			description: "close prices produce close scores",
 		},
 		{
 			name: "models with large price range",
@@ -173,11 +173,25 @@ func TestScore(t *testing.T) {
 				createModelWithPrice("model3", 500.5),
 			},
 			expectedScores: map[string]float64{
-				"model1": 1.0,
-				"model2": 0.0,
-				"model3": 0.5,
+				"model1": 0.9993, // 1 - 1.0/1501.5 = 0.9993
+				"model2": 0.3340, // 1 - 1000.0/1501.5 = 0.3340
+				"model3": 0.6666, // 1 - 500.5/1501.5 = 0.6666
 			},
-			description: "should handle large price ranges correctly",
+			description: "large range: cheapest gets highest score",
+		},
+		{
+			name: "all models with zero price",
+			models: []datalayer.Model{
+				createModelWithPrice("model1", 0.0),
+				createModelWithPrice("model2", 0.0),
+				createModelWithPrice("model3", 0.0),
+			},
+			expectedScores: map[string]float64{
+				"model1": 1.0,
+				"model2": 1.0,
+				"model3": 1.0,
+			},
+			description: "all free models get perfect score 1.0",
 		},
 	}
 

--- a/pkg/framework/modelselector/scorer/costaware/plugin_test.go
+++ b/pkg/framework/modelselector/scorer/costaware/plugin_test.go
@@ -218,12 +218,12 @@ func TestScore(t *testing.T) {
 
 // TestPriceValueClone tests the Clone method of PriceValue
 func TestPriceValueClone(t *testing.T) {
-	original := PriceValue{Value: 42.5}
+	original := &PriceValue{Value: 42.5}
 	cloned := original.Clone()
 
-	clonedPrice, ok := cloned.(PriceValue)
+	clonedPrice, ok := cloned.(*PriceValue)
 	if !ok {
-		t.Fatal("Clone() did not return PriceValue type")
+		t.Fatal("Clone() did not return *PriceValue type")
 	}
 
 	if clonedPrice.Value != original.Value {
@@ -241,7 +241,7 @@ func TestPriceValueClone(t *testing.T) {
 
 func createModelWithPrice(name string, price float64) datalayer.Model {
 	model := datalayer.NewModel(name)
-	model.GetAttributes().Put(PriceAttributeKey, PriceValue{Value: price})
+	model.GetAttributes().Put(PriceAttributeKey, &PriceValue{Value: price})
 	return model
 }
 


### PR DESCRIPTION
## What does this PR do?

Adds a simple model scorer that scores models based on their price attributes, assigning a normalized rank in [0.0 - 1.0] with the most expensive model getting a score 0.0 and the cheapest one getting 1.0

## Why is this change needed?

Implements the feature request of Issue #53 
Part of implementing the architecture of the inference processing pipeline of PR #43 

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

Fixes Issue #53 

