### PR TITLE
feat: implement max-score and weighted-random pickers

### DIFF
--- a/pkg/modelselector/picker/common.go
+++ b/pkg/modelselector/picker/common.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package picker
+
+import (
+	"math/rand/v2"
+	"sync"
+	"time"
+
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/modelselector"
+)
+
+type lockedRand struct {
+	mu   sync.Mutex
+	rand *rand.Rand
+}
+
+func newLockedRand() *lockedRand {
+	seed := uint64(time.Now().UnixNano())
+
+	return &lockedRand{
+		rand: rand.New(rand.NewPCG(seed, seed^0x9e3779b97f4a7c15)),
+	}
+}
+
+func (r *lockedRand) Float64() float64 {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.rand.Float64()
+}
+
+func (r *lockedRand) Shuffle(n int, swap func(i, j int)) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.rand.Shuffle(n, swap)
+}
+
+// PickerRand is a thread-safe random number generator shared by all pickers.
+var PickerRand = newLockedRand()
+
+// ShuffleScoredModels randomizes the order of the given scored models in-place.
+func ShuffleScoredModels(scoredModels []*modelselector.ScoredModel) {
+	PickerRand.Shuffle(len(scoredModels), func(i, j int) {
+		scoredModels[i], scoredModels[j] = scoredModels[j], scoredModels[i]
+	})
+}

--- a/pkg/modelselector/picker/maxscore/picker.go
+++ b/pkg/modelselector/picker/maxscore/picker.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package maxscore
+
+import (
+	"context"
+	"slices"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	logutil "github.com/llm-d/llm-d-inference-payload-processor/pkg/common/observability/logging"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/modelselector"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/modelselector/picker"
+)
+
+const (
+	MaxScorePickerType = "max-score-picker"
+)
+
+var _ modelselector.Picker = &MaxScorePicker{}
+
+// NewMaxScorePicker initializes a new MaxScorePicker and returns its pointer.
+func NewMaxScorePicker() *MaxScorePicker {
+	return &MaxScorePicker{
+		typedName: framework.TypedName{Type: MaxScorePickerType, Name: MaxScorePickerType},
+	}
+}
+
+// MaxScorePicker picks the model with the highest score calculated during the scoring phase.
+type MaxScorePicker struct {
+	typedName framework.TypedName
+}
+
+func (p *MaxScorePicker) TypedName() framework.TypedName {
+	return p.typedName
+}
+
+// Pick selects the model with the highest score.
+func (p *MaxScorePicker) Pick(ctx context.Context, _ *framework.CycleState, scoredModels []*modelselector.ScoredModel) *modelselector.ProfileRunResult {
+	log.FromContext(ctx).V(logutil.DEBUG).Info("Selecting model by max score", "numCandidates", len(scoredModels))
+
+	picker.ShuffleScoredModels(scoredModels)
+
+	slices.SortStableFunc(scoredModels, func(i, j *modelselector.ScoredModel) int {
+		if i.Score > j.Score {
+			return -1
+		}
+		if i.Score < j.Score {
+			return 1
+		}
+		return 0
+	})
+
+	return &modelselector.ProfileRunResult{TargetModel: scoredModels[0].Model}
+}

--- a/pkg/modelselector/picker/maxscore/picker_test.go
+++ b/pkg/modelselector/picker/maxscore/picker_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package maxscore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/datalayer"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/modelselector"
+)
+
+func TestMaxScorePicker(t *testing.T) {
+	modelA := datalayer.NewModel("model-a")
+	modelB := datalayer.NewModel("model-b")
+	modelC := datalayer.NewModel("model-c")
+
+	tests := []struct {
+		name      string
+		input     []*modelselector.ScoredModel
+		wantModel string
+	}{
+		{
+			name: "picks highest scored model",
+			input: []*modelselector.ScoredModel{
+				{Model: modelA, Score: 10},
+				{Model: modelB, Score: 25},
+				{Model: modelC, Score: 15},
+			},
+			wantModel: "model-b",
+		},
+		{
+			name: "single model returns that model",
+			input: []*modelselector.ScoredModel{
+				{Model: modelA, Score: 5},
+			},
+			wantModel: "model-a",
+		},
+		{
+			name: "equal scores still returns a model",
+			input: []*modelselector.ScoredModel{
+				{Model: modelA, Score: 50},
+				{Model: modelB, Score: 50},
+			},
+			// either model is valid with equal scores
+		},
+		{
+			name: "zero scores still returns a model",
+			input: []*modelselector.ScoredModel{
+				{Model: modelA, Score: 0},
+				{Model: modelB, Score: 0},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewMaxScorePicker()
+			result := p.Pick(context.Background(), framework.NewCycleState(), tt.input)
+
+			if result == nil {
+				t.Fatal("expected result, got nil")
+			}
+			if result.TargetModel == nil {
+				t.Fatal("expected target model, got nil")
+			}
+			if tt.wantModel != "" && result.TargetModel.GetName() != tt.wantModel {
+				t.Errorf("expected %q, got %q", tt.wantModel, result.TargetModel.GetName())
+			}
+		})
+	}
+}
+
+func TestMaxScorePickerTypedName(t *testing.T) {
+	p := NewMaxScorePicker()
+	if p.TypedName().Type != MaxScorePickerType {
+		t.Errorf("expected type %q, got %q", MaxScorePickerType, p.TypedName().Type)
+	}
+}

--- a/pkg/modelselector/picker/weightedrandom/picker.go
+++ b/pkg/modelselector/picker/weightedrandom/picker.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package weightedrandom
+
+import (
+	"context"
+	"math"
+	"sort"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	logutil "github.com/llm-d/llm-d-inference-payload-processor/pkg/common/observability/logging"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/modelselector"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/modelselector/picker"
+)
+
+const (
+	WeightedRandomPickerType = "weighted-random-picker"
+)
+
+var _ modelselector.Picker = &WeightedRandomPicker{}
+
+type weightedScoredModel struct {
+	*modelselector.ScoredModel
+	key float64
+}
+
+// NewWeightedRandomPicker initializes a new WeightedRandomPicker and returns its pointer.
+func NewWeightedRandomPicker() *WeightedRandomPicker {
+	return &WeightedRandomPicker{
+		typedName: framework.TypedName{Type: WeightedRandomPickerType, Name: WeightedRandomPickerType},
+	}
+}
+
+// WeightedRandomPicker picks a model from the list of candidates based on weighted random
+// sampling using the A-Res algorithm.
+// The probability of a model being selected is proportional to its score.
+// Reference: https://utopia.duth.gr/~pefraimi/research/data/2007EncOfAlg.pdf
+type WeightedRandomPicker struct {
+	typedName framework.TypedName
+}
+
+func (p *WeightedRandomPicker) TypedName() framework.TypedName {
+	return p.typedName
+}
+
+// Pick selects a model randomly, where the probability is derived from its weighted score.
+func (p *WeightedRandomPicker) Pick(ctx context.Context, _ *framework.CycleState, scoredModels []*modelselector.ScoredModel) *modelselector.ProfileRunResult {
+	log.FromContext(ctx).V(logutil.DEBUG).Info("Selecting model by weighted random", "numCandidates", len(scoredModels))
+
+	hasPositiveScore := false
+	for _, sm := range scoredModels {
+		if sm.Score > 0 {
+			hasPositiveScore = true
+			break
+		}
+	}
+
+	if !hasPositiveScore {
+		log.FromContext(ctx).V(logutil.DEBUG).Info("All scores are zero, selecting uniformly at random")
+		picker.ShuffleScoredModels(scoredModels)
+		return &modelselector.ProfileRunResult{TargetModel: scoredModels[0].Model}
+	}
+
+	weightedModels := make([]weightedScoredModel, len(scoredModels))
+	for i, sm := range scoredModels {
+		if sm.Score <= 0 {
+			weightedModels[i] = weightedScoredModel{ScoredModel: sm, key: 0}
+			continue
+		}
+
+		u := picker.PickerRand.Float64()
+		if u == 0 {
+			u = 1e-10
+		}
+
+		weightedModels[i] = weightedScoredModel{ScoredModel: sm, key: math.Pow(u, 1.0/sm.Score)}
+	}
+
+	sort.Slice(weightedModels, func(i, j int) bool {
+		return weightedModels[i].key > weightedModels[j].key
+	})
+
+	return &modelselector.ProfileRunResult{TargetModel: weightedModels[0].Model}
+}

--- a/pkg/modelselector/picker/weightedrandom/picker_test.go
+++ b/pkg/modelselector/picker/weightedrandom/picker_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package weightedrandom
+
+import (
+	"context"
+	"testing"
+
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/datalayer"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/modelselector"
+)
+
+func TestWeightedRandomPicker(t *testing.T) {
+	modelA := datalayer.NewModel("model-a")
+	modelB := datalayer.NewModel("model-b")
+
+	t.Run("returns a model", func(t *testing.T) {
+		p := NewWeightedRandomPicker()
+		input := []*modelselector.ScoredModel{
+			{Model: modelA, Score: 0.9},
+			{Model: modelB, Score: 0.1},
+		}
+
+		result := p.Pick(context.Background(), framework.NewCycleState(), input)
+		if result == nil {
+			t.Fatal("expected result, got nil")
+		}
+		if result.TargetModel == nil {
+			t.Fatal("expected target model, got nil")
+		}
+	})
+
+	t.Run("single model returns that model", func(t *testing.T) {
+		p := NewWeightedRandomPicker()
+		input := []*modelselector.ScoredModel{
+			{Model: modelA, Score: 1.0},
+		}
+
+		result := p.Pick(context.Background(), framework.NewCycleState(), input)
+		if result.TargetModel.GetName() != "model-a" {
+			t.Errorf("expected model-a, got %q", result.TargetModel.GetName())
+		}
+	})
+
+	t.Run("zero scores selects uniformly at random", func(t *testing.T) {
+		p := NewWeightedRandomPicker()
+		input := []*modelselector.ScoredModel{
+			{Model: modelA, Score: 0},
+			{Model: modelB, Score: 0},
+		}
+
+		result := p.Pick(context.Background(), framework.NewCycleState(), input)
+		if result == nil || result.TargetModel == nil {
+			t.Fatal("expected a result even with zero scores")
+		}
+	})
+
+	t.Run("higher score model selected more often", func(t *testing.T) {
+		p := NewWeightedRandomPicker()
+		counts := map[string]int{}
+		iterations := 1000
+
+		for range iterations {
+			input := []*modelselector.ScoredModel{
+				{Model: modelA, Score: 0.99},
+				{Model: modelB, Score: 0.01},
+			}
+			result := p.Pick(context.Background(), framework.NewCycleState(), input)
+			counts[result.TargetModel.GetName()]++
+		}
+
+		if counts["model-a"] <= counts["model-b"] {
+			t.Errorf("expected model-a (score 0.99) to be selected more often than model-b (score 0.01), got a=%d b=%d", counts["model-a"], counts["model-b"])
+		}
+	})
+}
+
+func TestWeightedRandomPickerTypedName(t *testing.T) {
+	p := NewWeightedRandomPicker()
+	if p.TypedName().Type != WeightedRandomPickerType {
+		t.Errorf("expected type %q, got %q", WeightedRandomPickerType, p.TypedName().Type)
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Implements two picker plugins for the model selector framework:

- **MaxScorePicker** — selects the model with the highest weighted score. Shuffles before sorting for random tie-breaking on equal scores.
- **WeightedRandomPicker** — selects a model randomly with probability proportional to its score, using the A-Res reservoir sampling algorithm. Falls back to uniform random when all scores are zero.

Shared utilities (thread-safe RNG, shuffle) in `pkg/modelselector/picker/common.go`.

### New files:
- `pkg/modelselector/picker/common.go` — shared RNG and shuffle utilities
- `pkg/modelselector/picker/maxscore/picker.go` — MaxScorePicker implementation
- `pkg/modelselector/picker/maxscore/picker_test.go` — tests
- `pkg/modelselector/picker/weightedrandom/picker.go` — WeightedRandomPicker implementation
- `pkg/modelselector/picker/weightedrandom/picker_test.go` — tests

## Why is this change needed?

Implements issue #73 — the picker plugins that the model selector profile uses to make final model selection decisions.

## How was this tested?

- [x] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [x] Manual testing performed

10 test cases covering:
- Highest score selection
- Single model input
- Equal score tie-breaking
- Zero score handling
- Weighted probability distribution (statistical test over 1000 iterations)
- TypedName validation

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

Closes #73