### PR TITLE
Adds generic helper to read model keys with automated type assertion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ Thumbs.db
 .envrc
 .secrets.env
 vendor/
+
+# Agents
+.bob

--- a/pkg/framework/datalayer/attributemap.go
+++ b/pkg/framework/datalayer/attributemap.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package datalayer
 
-import "sync"
+import (
+	"fmt"
+	"sync"
+)
 
 // Cloneable types support cloning of the value.
 // All values stored in AttributeMap must implement this interface
@@ -111,4 +114,33 @@ func (a *Attributes) Clone() AttributeMap {
 		return true
 	})
 	return clone
+}
+
+// ReadAttributeKey reads an attribute by key and asserts the value to type T.
+// Returns an error if the key is not found or the type assertion fails.
+//
+// This is a convenience function for type-safe attribute retrieval.
+// The returned value is a clone (as per AttributeMap.Get behavior).
+//
+// Type Parameter T:
+//   - Can be a value type (e.g., MyType) or pointer type (e.g., *MyType)
+//   - Must match the concrete type returned by the stored value's Clone() method
+//   - For types implementing Cloneable, use the same type as Clone() returns
+func ReadAttributeKey[T any](attrs AttributeMap, key string) (T, error) {
+	var zero T
+
+	raw, ok := attrs.Get(key)
+	if !ok {
+		return zero, fmt.Errorf("attribute %q: not found", key)
+	}
+
+	// Attempt direct type assertion to T
+	// This works for both value types and pointer types because
+	// Get() returns the result of Clone(), which returns the concrete type
+	val, ok := raw.(T)
+	if !ok {
+		return zero, fmt.Errorf("unexpected type for key %q: got %T, want %T", key, raw, zero)
+	}
+
+	return val, nil
 }

--- a/pkg/framework/datalayer/attributemap_test.go
+++ b/pkg/framework/datalayer/attributemap_test.go
@@ -186,3 +186,99 @@ func TestConcurrentAccess(t *testing.T) {
 	wg.Wait()
 	// Test passes if no panics or race conditions occurred
 }
+
+// TestReadAttributeKey verifies success case: key is found and value is of expected type.
+// Verifies error case: key is not found.
+// Verifies error case: value is not of expected type.
+func TestReadAttributeKey(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		attrs := NewAttributes()
+		expected := testCloneableValue{Value: 42}
+		attrs.Put("score", expected)
+
+		got, err := ReadAttributeKey[testCloneableValue](attrs, "score")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if got != expected {
+			t.Fatalf("expected value %+v, got %+v", expected, got)
+		}
+	})
+
+	t.Run("missing key", func(t *testing.T) {
+		attrs := NewAttributes()
+
+		got, err := ReadAttributeKey[testCloneableValue](attrs, "missing")
+		if err == nil {
+			t.Fatal("expected error for missing key")
+		}
+		if got != (testCloneableValue{}) {
+			t.Fatalf("expected zero value, got %+v", got)
+		}
+		if err.Error() != `attribute "missing": not found` {
+			t.Fatalf("expected not found error, got %v", err)
+		}
+	})
+
+	t.Run("wrong type", func(t *testing.T) {
+		attrs := NewAttributes()
+		attrs.Put("score", testCloneableValue{Value: 42})
+
+		got, err := ReadAttributeKey[*testCloneableValue](attrs, "score")
+		if err == nil {
+			t.Fatal("expected error for wrong type")
+		}
+		if got != nil {
+			t.Fatalf("expected zero value nil, got %+v", got)
+		}
+		expectedErrPrefix := `unexpected type for key "score": got`
+		if len(err.Error()) < len(expectedErrPrefix) || err.Error()[:len(expectedErrPrefix)] != expectedErrPrefix {
+			t.Fatalf("expected type error, got %v", err)
+		}
+	})
+
+	t.Run("pointer type", func(t *testing.T) {
+		attrs := NewAttributes()
+		// Store a pointer type that implements Cloneable
+		expected := &testCloneablePointer{Value: 99}
+		attrs.Put("ptr", expected)
+
+		got, err := ReadAttributeKey[*testCloneablePointer](attrs, "ptr")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if got == nil {
+			t.Fatal("expected non-nil pointer")
+		}
+		if got.Value != 99 {
+			t.Fatalf("expected value 99, got %d", got.Value)
+		}
+	})
+
+	t.Run("value type from pointer storage", func(t *testing.T) {
+		attrs := NewAttributes()
+		// Store a pointer, but Clone() returns value type
+		attrs.Put("mixed", &testCloneablePointer{Value: 42})
+
+		// This should work if Clone() returns the value type
+		// But will fail if Clone() returns pointer type
+		// This test documents the expected behavior
+		_, err := ReadAttributeKey[testCloneablePointer](attrs, "mixed")
+		// We expect this to fail because Clone() returns *testCloneablePointer
+		if err == nil {
+			t.Fatal("expected error when type mismatch between stored and requested")
+		}
+	})
+}
+
+// testCloneablePointer is a pointer type that implements Cloneable
+type testCloneablePointer struct {
+	Value int
+}
+
+func (t *testCloneablePointer) Clone() Cloneable {
+	if t == nil {
+		return nil
+	}
+	return &testCloneablePointer{Value: t.Value}
+}

--- a/pkg/framework/datalayer/model.go
+++ b/pkg/framework/datalayer/model.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package datalayer
 
+import "fmt"
+
 type Model interface {
 	GetName() string
 	GetAttributes() AttributeMap
@@ -42,4 +44,22 @@ func (m *model) GetName() string {
 
 func (m *model) GetAttributes() AttributeMap {
 	return m.attributes
+}
+
+// Reads model attribute by a given key and asserts the value to the type T.
+// Returns an error if the key is not found or the type assertion fails.
+func ReadModelKey[T any](m Model, key string) (T, error) {
+	var zero T
+
+	raw, ok := m.GetAttributes().Get(key)
+	if !ok {
+		return zero, fmt.Errorf("attribute %q: not found", key)
+	}
+
+	val, ok := raw.(T)
+	if !ok {
+		return zero, fmt.Errorf("unexpected type for key %q: got %T", key, raw)
+	}
+
+	return val, nil
 }

--- a/pkg/framework/datalayer/model.go
+++ b/pkg/framework/datalayer/model.go
@@ -16,8 +16,6 @@ limitations under the License.
 
 package datalayer
 
-import "fmt"
-
 type Model interface {
 	GetName() string
 	GetAttributes() AttributeMap
@@ -44,22 +42,4 @@ func (m *model) GetName() string {
 
 func (m *model) GetAttributes() AttributeMap {
 	return m.attributes
-}
-
-// Reads model attribute by a given key and asserts the value to the type T.
-// Returns an error if the key is not found or the type assertion fails.
-func ReadModelKey[T any](m Model, key string) (T, error) {
-	var zero T
-
-	raw, ok := m.GetAttributes().Get(key)
-	if !ok {
-		return zero, fmt.Errorf("attribute %q: not found", key)
-	}
-
-	val, ok := raw.(T)
-	if !ok {
-		return zero, fmt.Errorf("unexpected type for key %q: got %T", key, raw)
-	}
-
-	return val, nil
 }

--- a/pkg/framework/datalayer/model_test.go
+++ b/pkg/framework/datalayer/model_test.go
@@ -16,10 +16,7 @@ limitations under the License.
 
 package datalayer
 
-import (
-	"strings"
-	"testing"
-)
+import "testing"
 
 // Verifies non-nil model
 // Verifies name is preserved
@@ -36,54 +33,4 @@ func TestNewModel(t *testing.T) {
 	if m.GetAttributes() == nil {
 		t.Fatal("expected model attributes to be initialized")
 	}
-}
-
-// Verifies success case: key is found and value is of expected type.
-// Verifies error case: key is not found.
-// Verifies error case: value is not of expected type.
-func TestReadModelKey(t *testing.T) {
-	t.Run("success", func(t *testing.T) {
-		m := NewModel("test-model")
-		expected := testCloneableValue{Value: 42}
-		m.GetAttributes().Put("score", expected)
-
-		got, err := ReadModelKey[testCloneableValue](m, "score")
-		if err != nil {
-			t.Fatalf("expected no error, got %v", err)
-		}
-		if got != expected {
-			t.Fatalf("expected value %+v, got %+v", expected, got)
-		}
-	})
-
-	t.Run("missing key", func(t *testing.T) {
-		m := NewModel("test-model")
-
-		got, err := ReadModelKey[testCloneableValue](m, "missing")
-		if err == nil {
-			t.Fatal("expected error for missing key")
-		}
-		if got != (testCloneableValue{}) {
-			t.Fatalf("expected zero value, got %+v", got)
-		}
-		if !strings.Contains(err.Error(), `attribute "missing": not found`) {
-			t.Fatalf("expected not found error, got %v", err)
-		}
-	})
-
-	t.Run("wrong type", func(t *testing.T) {
-		m := NewModel("test-model")
-		m.GetAttributes().Put("score", testCloneableValue{Value: 42})
-
-		got, err := ReadModelKey[*testCloneableValue](m, "score")
-		if err == nil {
-			t.Fatal("expected error for wrong type")
-		}
-		if got != nil {
-			t.Fatalf("expected zero value nil, got %+v", got)
-		}
-		if !strings.Contains(err.Error(), `unexpected type for key "score"`) {
-			t.Fatalf("expected type mismatch error, got %v", err)
-		}
-	})
 }

--- a/pkg/framework/datalayer/model_test.go
+++ b/pkg/framework/datalayer/model_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datalayer
+
+import (
+	"strings"
+	"testing"
+)
+
+// Verifies non-nil model
+// Verifies name is preserved
+// Verifies attributes are initialized
+func TestNewModel(t *testing.T) {
+	m := NewModel("test-model")
+
+	if m == nil {
+		t.Fatal("expected model to be non-nil")
+	}
+	if got := m.GetName(); got != "test-model" {
+		t.Fatalf("expected model name %q, got %q", "test-model", got)
+	}
+	if m.GetAttributes() == nil {
+		t.Fatal("expected model attributes to be initialized")
+	}
+}
+
+// Verifies success case: key is found and value is of expected type.
+// Verifies error case: key is not found.
+// Verifies error case: value is not of expected type.
+func TestReadModelKey(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		m := NewModel("test-model")
+		expected := testCloneableValue{Value: 42}
+		m.GetAttributes().Put("score", expected)
+
+		got, err := ReadModelKey[testCloneableValue](m, "score")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if got != expected {
+			t.Fatalf("expected value %+v, got %+v", expected, got)
+		}
+	})
+
+	t.Run("missing key", func(t *testing.T) {
+		m := NewModel("test-model")
+
+		got, err := ReadModelKey[testCloneableValue](m, "missing")
+		if err == nil {
+			t.Fatal("expected error for missing key")
+		}
+		if got != (testCloneableValue{}) {
+			t.Fatalf("expected zero value, got %+v", got)
+		}
+		if !strings.Contains(err.Error(), `attribute "missing": not found`) {
+			t.Fatalf("expected not found error, got %v", err)
+		}
+	})
+
+	t.Run("wrong type", func(t *testing.T) {
+		m := NewModel("test-model")
+		m.GetAttributes().Put("score", testCloneableValue{Value: 42})
+
+		got, err := ReadModelKey[*testCloneableValue](m, "score")
+		if err == nil {
+			t.Fatal("expected error for wrong type")
+		}
+		if got != nil {
+			t.Fatalf("expected zero value nil, got %+v", got)
+		}
+		if !strings.Contains(err.Error(), `unexpected type for key "score"`) {
+			t.Fatalf("expected type mismatch error, got %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## What does this PR do?

Adds a generic template read helper that reads `model` attributes by a given key and asserts the value to the type T.
Returns an error if the key is not found or the type assertion fails.

## Why is this change needed?

Helps to avoid recurring type assertions in plugins using `model` attributes.

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

Fixes #88
