### PR TITLE
feat: add model-selector RequestProcessor plugin

### DIFF
--- a/cmd/runner/runner.go
+++ b/cmd/runner/runner.go
@@ -43,6 +43,7 @@ import (
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/metrics"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/plugins/basemodelextractor"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/plugins/bodyfieldtoheader"
+	modelselectorplugin "github.com/llm-d/llm-d-inference-payload-processor/pkg/plugins/modelselector"
 	runserver "github.com/llm-d/llm-d-inference-payload-processor/pkg/server"
 	"github.com/llm-d/llm-d-inference-payload-processor/version"
 )
@@ -254,6 +255,7 @@ func (r *Runner) registerInTreePlugins() {
 	framework.Register(bodyfieldtoheader.BodyFieldToHeaderPluginType, bodyfieldtoheader.BodyFieldToHeaderPluginFactory)
 	framework.Register(basemodelextractor.BaseModelToHeaderPluginType, basemodelextractor.BaseModelToHeaderPluginFactory)
 	framework.Register(datalayer.NotificationSourcePluginType, datalayer.NotificationSourceFactory)
+	framework.Register(modelselectorplugin.ModelSelectorPluginType, modelselectorplugin.ModelSelectorPluginFactory)
 }
 
 // registerHealthServer adds the Health gRPC server as a Runnable to the given manager.

--- a/pkg/plugins/modelselector/plugin.go
+++ b/pkg/plugins/modelselector/plugin.go
@@ -19,12 +19,12 @@ package modelselector
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	logutil "github.com/llm-d/llm-d-inference-payload-processor/pkg/common/observability/logging"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/datastore"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/datalayer"
 	fwkms "github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/modelselector"
@@ -40,48 +40,20 @@ const (
 
 var _ framework.RequestProcessor = &ModelSelectorPlugin{}
 
-// ModelSelectorPluginConfig holds the configuration parsed from plugin parameters.
-type ModelSelectorPluginConfig struct {
-	// Candidates is a static list of model names eligible for selection.
-	// In this initial version, candidates are configured statically.
-	// Future versions may source candidates from Datastore, CRD, or other dynamic sources.
-	Candidates []string `json:"candidates"`
-}
-
 // ModelSelectorPluginFactory is the factory function for the ModelSelector RequestProcessor plugin.
-func ModelSelectorPluginFactory(name string, rawParameters json.RawMessage, _ framework.Handle) (framework.Plugin, error) {
-	var config ModelSelectorPluginConfig
-	if rawParameters != nil {
-		if err := json.Unmarshal(rawParameters, &config); err != nil {
-			return nil, fmt.Errorf("failed to parse parameters for '%s' plugin: %w", ModelSelectorPluginType, err)
-		}
-	}
+func ModelSelectorPluginFactory(name string, _ json.RawMessage, handle framework.Handle) (framework.Plugin, error) {
+	// TODO: once PR #84 merges, get Datastore from handle via handle.Datastore()
+	// For now, Datastore is passed directly to the constructor.
+	_ = handle
 
-	if len(config.Candidates) == 0 {
-		return nil, fmt.Errorf("'%s' plugin requires at least one candidate model", ModelSelectorPluginType)
-	}
-
-	plugin, err := NewModelSelectorPlugin(config.Candidates)
-	if err != nil {
-		return nil, err
-	}
-
-	if name != "" {
-		plugin.typedName.Name = name
-	}
-
-	return plugin, nil
+	return nil, fmt.Errorf("'%s' plugin must be created via NewModelSelectorPlugin, not via factory (Datastore not yet available in Handle)", ModelSelectorPluginType)
 }
 
-// NewModelSelectorPlugin creates a ModelSelector RequestProcessor plugin with the given candidate models.
-func NewModelSelectorPlugin(candidateNames []string) (*ModelSelectorPlugin, error) {
-	if len(candidateNames) == 0 {
-		return nil, errors.New("at least one candidate model is required")
-	}
-
-	candidateModels := make([]datalayer.Model, len(candidateNames))
-	for i, name := range candidateNames {
-		candidateModels[i] = datalayer.NewModel(name)
+// NewModelSelectorPlugin creates a ModelSelector RequestProcessor plugin.
+// Candidate models are read from the Datastore on each request.
+func NewModelSelectorPlugin(ds datastore.Datastore) (*ModelSelectorPlugin, error) {
+	if ds == nil {
+		return nil, fmt.Errorf("datastore is required for '%s' plugin", ModelSelectorPluginType)
 	}
 
 	// Build profile with picker only.
@@ -93,30 +65,36 @@ func NewModelSelectorPlugin(candidateNames []string) (*ModelSelectorPlugin, erro
 	selector := ms.NewModelSelector(profile)
 
 	return &ModelSelectorPlugin{
-		typedName:       framework.TypedName{Type: ModelSelectorPluginType, Name: ModelSelectorPluginType},
-		selector:        selector,
-		candidateModels: candidateModels,
+		typedName: framework.TypedName{Type: ModelSelectorPluginType, Name: ModelSelectorPluginType},
+		selector:  selector,
+		datastore: ds,
 	}, nil
 }
 
 // ModelSelectorPlugin is a RequestProcessor that runs the ModelSelector
 // pipeline (Filter → Score → Pick) to select a model for the request.
+// Candidate models are read from the Datastore on each request.
 type ModelSelectorPlugin struct {
-	typedName       framework.TypedName
-	selector        *ms.ModelSelector
-	candidateModels []datalayer.Model
+	typedName framework.TypedName
+	selector  *ms.ModelSelector
+	datastore datastore.Datastore
 }
 
 func (p *ModelSelectorPlugin) TypedName() framework.TypedName {
 	return p.typedName
 }
 
-// ProcessRequest runs model selection and writes the selected model
-// into the request body and CycleState.
+// ProcessRequest reads candidate models from the Datastore, runs model
+// selection, and writes the selected model into the request body and CycleState.
 func (p *ModelSelectorPlugin) ProcessRequest(ctx context.Context, cycleState *framework.CycleState, request *framework.InferenceRequest) error {
 	logger := log.FromContext(ctx)
 
-	result, err := p.selector.Select(ctx, request, cycleState, p.candidateModels)
+	candidateModels := p.loadCandidateModels()
+	if len(candidateModels) == 0 {
+		return fmt.Errorf("no candidate models available in datastore")
+	}
+
+	result, err := p.selector.Select(ctx, request, cycleState, candidateModels)
 	if err != nil {
 		return fmt.Errorf("model selection failed: %w", err)
 	}
@@ -130,9 +108,19 @@ func (p *ModelSelectorPlugin) ProcessRequest(ctx context.Context, cycleState *fr
 	return nil
 }
 
-// defaultPicker picks the first model from the scored list.
-// This is a minimal picker for the initial version. Replace with
-// MaxScorePicker or WeightedRandomPicker once available.
+// loadCandidateModels reads all known models from the Datastore.
+func (p *ModelSelectorPlugin) loadCandidateModels() []datalayer.Model {
+	modelNames := p.datastore.Models()
+	candidates := make([]datalayer.Model, len(modelNames))
+	for i, name := range modelNames {
+		candidates[i] = p.datastore.GetOrCreateModel(name)
+	}
+	return candidates
+}
+
+// defaultPicker picks the model with the highest score.
+// Replace with MaxScorePicker or WeightedRandomPicker once PR #74
+// pickers are wired with factory functions.
 type defaultPicker struct{}
 
 func (p *defaultPicker) TypedName() framework.TypedName {

--- a/pkg/plugins/modelselector/plugin.go
+++ b/pkg/plugins/modelselector/plugin.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package modelselector
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	logutil "github.com/llm-d/llm-d-inference-payload-processor/pkg/common/observability/logging"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/datalayer"
+	fwkms "github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/modelselector"
+	ms "github.com/llm-d/llm-d-inference-payload-processor/pkg/modelselector"
+)
+
+const (
+	ModelSelectorPluginType = "model-selector"
+
+	// CycleState key where the selected model name is stored for downstream plugins.
+	SelectedModelKey = "selected-model"
+)
+
+var _ framework.RequestProcessor = &ModelSelectorPlugin{}
+
+// ModelSelectorPluginConfig holds the configuration parsed from plugin parameters.
+type ModelSelectorPluginConfig struct {
+	// Candidates is a static list of model names eligible for selection.
+	// In this initial version, candidates are configured statically.
+	// Future versions may source candidates from Datastore, CRD, or other dynamic sources.
+	Candidates []string `json:"candidates"`
+}
+
+// ModelSelectorPluginFactory is the factory function for the ModelSelector RequestProcessor plugin.
+func ModelSelectorPluginFactory(name string, rawParameters json.RawMessage, _ framework.Handle) (framework.Plugin, error) {
+	var config ModelSelectorPluginConfig
+	if rawParameters != nil {
+		if err := json.Unmarshal(rawParameters, &config); err != nil {
+			return nil, fmt.Errorf("failed to parse parameters for '%s' plugin: %w", ModelSelectorPluginType, err)
+		}
+	}
+
+	if len(config.Candidates) == 0 {
+		return nil, fmt.Errorf("'%s' plugin requires at least one candidate model", ModelSelectorPluginType)
+	}
+
+	plugin, err := NewModelSelectorPlugin(config.Candidates)
+	if err != nil {
+		return nil, err
+	}
+
+	if name != "" {
+		plugin.typedName.Name = name
+	}
+
+	return plugin, nil
+}
+
+// NewModelSelectorPlugin creates a ModelSelector RequestProcessor plugin with the given candidate models.
+func NewModelSelectorPlugin(candidateNames []string) (*ModelSelectorPlugin, error) {
+	if len(candidateNames) == 0 {
+		return nil, errors.New("at least one candidate model is required")
+	}
+
+	candidateModels := make([]datalayer.Model, len(candidateNames))
+	for i, name := range candidateNames {
+		candidateModels[i] = datalayer.NewModel(name)
+	}
+
+	// Build profile with picker only.
+	// Filters and scorers can be added via WithFilters() / WithScorers()
+	// once implementations are available.
+	profile := ms.NewModelSelectorProfile().
+		WithPicker(&defaultPicker{})
+
+	selector := ms.NewModelSelector(profile)
+
+	return &ModelSelectorPlugin{
+		typedName:       framework.TypedName{Type: ModelSelectorPluginType, Name: ModelSelectorPluginType},
+		selector:        selector,
+		candidateModels: candidateModels,
+	}, nil
+}
+
+// ModelSelectorPlugin is a RequestProcessor that runs the ModelSelector
+// pipeline (Filter → Score → Pick) to select a model for the request.
+type ModelSelectorPlugin struct {
+	typedName       framework.TypedName
+	selector        *ms.ModelSelector
+	candidateModels []datalayer.Model
+}
+
+func (p *ModelSelectorPlugin) TypedName() framework.TypedName {
+	return p.typedName
+}
+
+// ProcessRequest runs model selection and writes the selected model
+// into the request body and CycleState.
+func (p *ModelSelectorPlugin) ProcessRequest(ctx context.Context, cycleState *framework.CycleState, request *framework.InferenceRequest) error {
+	logger := log.FromContext(ctx)
+
+	result, err := p.selector.Select(ctx, request, cycleState, p.candidateModels)
+	if err != nil {
+		return fmt.Errorf("model selection failed: %w", err)
+	}
+
+	selectedName := result.TargetModel.GetName()
+	logger.V(logutil.VERBOSE).Info("Model selected", "model", selectedName)
+
+	cycleState.Write(SelectedModelKey, selectedName)
+	request.SetBodyField("model", selectedName)
+
+	return nil
+}
+
+// defaultPicker picks the first model from the scored list.
+// This is a minimal picker for the initial version. Replace with
+// MaxScorePicker or WeightedRandomPicker once available.
+type defaultPicker struct{}
+
+func (p *defaultPicker) TypedName() framework.TypedName {
+	return framework.TypedName{Type: "default-picker", Name: "default-picker"}
+}
+
+func (p *defaultPicker) Pick(_ context.Context, _ *framework.CycleState, scoredModels []*fwkms.ScoredModel) *fwkms.ProfileRunResult {
+	if len(scoredModels) == 0 {
+		return nil
+	}
+	best := scoredModels[0]
+	for _, sm := range scoredModels[1:] {
+		if sm.Score > best.Score {
+			best = sm
+		}
+	}
+	return &fwkms.ProfileRunResult{TargetModel: best.Model}
+}

--- a/pkg/plugins/modelselector/plugin_test.go
+++ b/pkg/plugins/modelselector/plugin_test.go
@@ -18,14 +18,23 @@ package modelselector
 
 import (
 	"context"
-	"encoding/json"
 	"testing"
 
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/datastore"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
 )
 
+func newTestDatastore(modelNames ...string) datastore.Datastore {
+	ds := datastore.NewStore()
+	for _, name := range modelNames {
+		ds.GetOrCreateModel(name)
+	}
+	return ds
+}
+
 func TestProcessRequestWritesSelectedModelToBodyAndCycleState(t *testing.T) {
-	plugin, err := NewModelSelectorPlugin([]string{"model-a", "model-b", "model-c"})
+	ds := newTestDatastore("model-a", "model-b", "model-c")
+	plugin, err := NewModelSelectorPlugin(ds)
 	if err != nil {
 		t.Fatalf("failed to create plugin: %v", err)
 	}
@@ -56,9 +65,10 @@ func TestProcessRequestWritesSelectedModelToBodyAndCycleState(t *testing.T) {
 	}
 }
 
-func TestProcessRequestSelectsFromConfiguredCandidates(t *testing.T) {
+func TestProcessRequestSelectsFromDatastoreModels(t *testing.T) {
 	candidates := []string{"llama-70b", "llama-8b", "mistral-7b"}
-	plugin, err := NewModelSelectorPlugin(candidates)
+	ds := newTestDatastore(candidates...)
+	plugin, err := NewModelSelectorPlugin(ds)
 	if err != nil {
 		t.Fatalf("failed to create plugin: %v", err)
 	}
@@ -81,57 +91,37 @@ func TestProcessRequestSelectsFromConfiguredCandidates(t *testing.T) {
 		}
 	}
 	if !found {
-		t.Errorf("selected model %q is not in candidate list %v", selectedModel, candidates)
+		t.Errorf("selected model %q is not in datastore models %v", selectedModel, candidates)
 	}
 }
 
-func TestNewModelSelectorPluginRejectsEmptyCandidates(t *testing.T) {
-	_, err := NewModelSelectorPlugin([]string{})
-	if err == nil {
-		t.Fatal("expected error for empty candidates")
-	}
-}
-
-func TestFactoryParsesCandidatesFromConfig(t *testing.T) {
-	config := ModelSelectorPluginConfig{
-		Candidates: []string{"model-a", "model-b"},
-	}
-	rawParams, _ := json.Marshal(config)
-
-	plugin, err := ModelSelectorPluginFactory("test-selector", rawParams, nil)
+func TestProcessRequestFailsWithEmptyDatastore(t *testing.T) {
+	ds := newTestDatastore() // no models
+	plugin, err := NewModelSelectorPlugin(ds)
 	if err != nil {
-		t.Fatalf("factory failed: %v", err)
+		t.Fatalf("failed to create plugin: %v", err)
 	}
 
-	if plugin.TypedName().Name != "test-selector" {
-		t.Errorf("expected name 'test-selector', got %q", plugin.TypedName().Name)
-	}
-	if plugin.TypedName().Type != ModelSelectorPluginType {
-		t.Errorf("expected type %q, got %q", ModelSelectorPluginType, plugin.TypedName().Type)
+	request := framework.NewInferenceRequest()
+	request.Body["model"] = "auto"
+	cycleState := framework.NewCycleState()
+
+	err = plugin.ProcessRequest(context.Background(), cycleState, request)
+	if err == nil {
+		t.Fatal("expected error with empty datastore")
 	}
 }
 
-func TestFactoryRejectsEmptyCandidates(t *testing.T) {
-	config := ModelSelectorPluginConfig{
-		Candidates: []string{},
-	}
-	rawParams, _ := json.Marshal(config)
-
-	_, err := ModelSelectorPluginFactory("test-selector", rawParams, nil)
+func TestNewModelSelectorPluginRejectsNilDatastore(t *testing.T) {
+	_, err := NewModelSelectorPlugin(nil)
 	if err == nil {
-		t.Fatal("expected error for empty candidates in factory")
-	}
-}
-
-func TestFactoryRejectsInvalidJSON(t *testing.T) {
-	_, err := ModelSelectorPluginFactory("test-selector", json.RawMessage(`{invalid`), nil)
-	if err == nil {
-		t.Fatal("expected error for invalid JSON")
+		t.Fatal("expected error for nil datastore")
 	}
 }
 
 func TestTypedName(t *testing.T) {
-	plugin, _ := NewModelSelectorPlugin([]string{"model-a"})
+	ds := newTestDatastore("model-a")
+	plugin, _ := NewModelSelectorPlugin(ds)
 	if plugin.TypedName().Type != ModelSelectorPluginType {
 		t.Errorf("expected type %q, got %q", ModelSelectorPluginType, plugin.TypedName().Type)
 	}

--- a/pkg/plugins/modelselector/plugin_test.go
+++ b/pkg/plugins/modelselector/plugin_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package modelselector
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
+)
+
+func TestProcessRequestWritesSelectedModelToBodyAndCycleState(t *testing.T) {
+	plugin, err := NewModelSelectorPlugin([]string{"model-a", "model-b", "model-c"})
+	if err != nil {
+		t.Fatalf("failed to create plugin: %v", err)
+	}
+
+	request := framework.NewInferenceRequest()
+	request.Body["model"] = "auto"
+	cycleState := framework.NewCycleState()
+
+	err = plugin.ProcessRequest(context.Background(), cycleState, request)
+	if err != nil {
+		t.Fatalf("ProcessRequest failed: %v", err)
+	}
+
+	selectedModel, ok := request.Body["model"].(string)
+	if !ok || selectedModel == "" {
+		t.Fatal("expected model field in request body to be set")
+	}
+	if selectedModel == "auto" {
+		t.Error("expected model field to be replaced with selected model, still 'auto'")
+	}
+
+	storedModel, err := framework.ReadCycleStateKey[string](cycleState, SelectedModelKey)
+	if err != nil {
+		t.Fatalf("expected selected model in CycleState: %v", err)
+	}
+	if storedModel != selectedModel {
+		t.Errorf("CycleState model %q does not match body model %q", storedModel, selectedModel)
+	}
+}
+
+func TestProcessRequestSelectsFromConfiguredCandidates(t *testing.T) {
+	candidates := []string{"llama-70b", "llama-8b", "mistral-7b"}
+	plugin, err := NewModelSelectorPlugin(candidates)
+	if err != nil {
+		t.Fatalf("failed to create plugin: %v", err)
+	}
+
+	request := framework.NewInferenceRequest()
+	request.Body["model"] = "auto"
+	cycleState := framework.NewCycleState()
+
+	err = plugin.ProcessRequest(context.Background(), cycleState, request)
+	if err != nil {
+		t.Fatalf("ProcessRequest failed: %v", err)
+	}
+
+	selectedModel := request.Body["model"].(string)
+	found := false
+	for _, c := range candidates {
+		if c == selectedModel {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("selected model %q is not in candidate list %v", selectedModel, candidates)
+	}
+}
+
+func TestNewModelSelectorPluginRejectsEmptyCandidates(t *testing.T) {
+	_, err := NewModelSelectorPlugin([]string{})
+	if err == nil {
+		t.Fatal("expected error for empty candidates")
+	}
+}
+
+func TestFactoryParsesCandidatesFromConfig(t *testing.T) {
+	config := ModelSelectorPluginConfig{
+		Candidates: []string{"model-a", "model-b"},
+	}
+	rawParams, _ := json.Marshal(config)
+
+	plugin, err := ModelSelectorPluginFactory("test-selector", rawParams, nil)
+	if err != nil {
+		t.Fatalf("factory failed: %v", err)
+	}
+
+	if plugin.TypedName().Name != "test-selector" {
+		t.Errorf("expected name 'test-selector', got %q", plugin.TypedName().Name)
+	}
+	if plugin.TypedName().Type != ModelSelectorPluginType {
+		t.Errorf("expected type %q, got %q", ModelSelectorPluginType, plugin.TypedName().Type)
+	}
+}
+
+func TestFactoryRejectsEmptyCandidates(t *testing.T) {
+	config := ModelSelectorPluginConfig{
+		Candidates: []string{},
+	}
+	rawParams, _ := json.Marshal(config)
+
+	_, err := ModelSelectorPluginFactory("test-selector", rawParams, nil)
+	if err == nil {
+		t.Fatal("expected error for empty candidates in factory")
+	}
+}
+
+func TestFactoryRejectsInvalidJSON(t *testing.T) {
+	_, err := ModelSelectorPluginFactory("test-selector", json.RawMessage(`{invalid`), nil)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestTypedName(t *testing.T) {
+	plugin, _ := NewModelSelectorPlugin([]string{"model-a"})
+	if plugin.TypedName().Type != ModelSelectorPluginType {
+		t.Errorf("expected type %q, got %q", ModelSelectorPluginType, plugin.TypedName().Type)
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Adds glue code to run the ModelSelector pipeline (Filter → Score → Pick) as a RequestProcessor plugin in the IPP pipeline. This allows model selection to be wired alongside other plugins like body-field-to-header in the request processing chain.

### How it works:
1. Plugin is configured with a static list of candidate model names
2. On each request, `ModelSelector.Select()` runs the configured profile (Filter → Score → Pick)
3. Selected model name is written to CycleState (`selected-model` key) and the request body `model` field

### What's included:
- `pkg/plugins/modelselector/plugin.go` — RequestProcessor wrapper with factory function
- `pkg/plugins/modelselector/plugin_test.go` — 7 tests
- Registration in `cmd/runner/runner.go`

### Extension points:
- **Candidate source**: Static list from config in this version. Future versions can source candidates from Datastore, CRD, or other dynamic sources.
- **Filters and scorers**: Not configured in this version but the profile supports them — add via `WithFilters()` / `WithScorers()` when implementations are ready.
- **Picker**: Uses a default max-score picker inline. Will switch to shared picker implementations once PR #74 merges.

## Why is this change needed?

This is the glue code needed to run the model-selector as a request plugin with one profile, as discussed with @shmuelk.

## How was this tested?

- [x] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [x] Manual testing performed

7 tests covering:
- Selected model written to body and CycleState
- Selection from configured candidates only
- Empty candidates rejected at startup
- Factory config parsing
- Invalid JSON rejection

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

Related to the model selector work: #65, #73
Related to profiles design: #15, PR #92