### PR TITLE
Move datalayer.go to pkg/datalayer/types.go.

### DIFF
--- a/cmd/runner/runner.go
+++ b/cmd/runner/runner.go
@@ -38,11 +38,11 @@ import (
 	logutil "github.com/llm-d/llm-d-inference-payload-processor/pkg/common/observability/logging"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/common/observability/profiling"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/common/observability/tracing"
-	"github.com/llm-d/llm-d-inference-payload-processor/pkg/datalayer"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/metrics"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/plugins/basemodelextractor"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/plugins/bodyfieldtoheader"
+	notificationsource "github.com/llm-d/llm-d-inference-payload-processor/pkg/plugins/datalayer/notificationsource"
 	runserver "github.com/llm-d/llm-d-inference-payload-processor/pkg/server"
 	"github.com/llm-d/llm-d-inference-payload-processor/version"
 )
@@ -253,7 +253,7 @@ func (r *Runner) Run(ctx context.Context) error {
 func (r *Runner) registerInTreePlugins() {
 	framework.Register(bodyfieldtoheader.BodyFieldToHeaderPluginType, bodyfieldtoheader.BodyFieldToHeaderPluginFactory)
 	framework.Register(basemodelextractor.BaseModelToHeaderPluginType, basemodelextractor.BaseModelToHeaderPluginFactory)
-	framework.Register(datalayer.NotificationSourcePluginType, datalayer.NotificationSourceFactory)
+	framework.Register(notificationsource.PluginType, notificationsource.Factory)
 }
 
 // registerHealthServer adds the Health gRPC server as a Runnable to the given manager.

--- a/pkg/framework/datalayer/types.go
+++ b/pkg/framework/datalayer/types.go
@@ -14,23 +14,23 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package framework
+package datalayer
 
 import (
 	"context"
 	"time"
 
-	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/datalayer"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
 )
 
 // DataStore provides model-keyed access to aggregated runtime metrics.
 type DataStore interface {
-	GetOrCreateModel(name string) datalayer.Model
+	GetOrCreateModel(name string) Model
 }
 
 // DataSource is the base interface for background data layer components.
 type DataSource interface {
-	Plugin
+	framework.Plugin
 	Start(ctx context.Context) error
 	// Stop signals the component to shut down and blocks until it has fully stopped.
 	Stop()
@@ -52,13 +52,13 @@ type Event struct {
 
 // RequestPayload is the Payload for RequestEventType.
 type RequestPayload struct {
-	Request *InferenceRequest
+	Request *framework.InferenceRequest
 }
 
 // ResponsePayload is the Payload for ResponseEventType.
 type ResponsePayload struct {
-	Request  *InferenceRequest
-	Response *InferenceResponse
+	Request  *framework.InferenceRequest
+	Response *framework.InferenceResponse
 	Duration time.Duration
 }
 
@@ -79,6 +79,6 @@ type NotificationSource interface {
 
 // Extractor processes a batch of Events. It does not manage its own goroutines.
 type Extractor interface {
-	Plugin
+	framework.Plugin
 	Extract(ctx context.Context, events []Event) error
 }

--- a/pkg/plugins/datalayer/notificationsource/plugin.go
+++ b/pkg/plugins/datalayer/notificationsource/plugin.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package datalayer
+package notificationsource
 
 import (
 	"context"
@@ -26,45 +26,45 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/datalayer"
 )
 
 const (
-	NotificationSourcePluginType = "notification-source"
+	PluginType = "notification-source"
 
 	defaultBufferSize = 10000
 )
 
 // compile-time interface assertion
-var _ framework.NotificationSource = &notificationSource{}
+var _ datalayer.NotificationSource = &notificationSource{}
 
 type notificationSource struct {
 	name       framework.TypedName
-	ch         chan framework.Event
-	extractors []framework.Extractor
+	ch         chan datalayer.Event
+	extractors []datalayer.Extractor
 
 	started atomic.Bool
 	cancel  context.CancelFunc
 	done    chan struct{}
 }
 
-// NotificationSourceFactory is the factory function for NotificationSource.
-func NotificationSourceFactory(name string, _ json.RawMessage, _ framework.Handle) (framework.Plugin, error) {
-	src, err := NewNotificationSource(name)
+// Factory is the factory function for NotificationSource.
+func Factory(name string, _ json.RawMessage, _ framework.Handle) (framework.Plugin, error) {
+	src, err := New(name)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create '%s' plugin - %w", NotificationSourcePluginType, err)
+		return nil, fmt.Errorf("failed to create '%s' plugin - %w", PluginType, err)
 	}
 	return src, nil
 }
 
-// NewNotificationSource creates a NotificationSource that delivers each event
-// to the given extractors as it arrives.
-func NewNotificationSource(name string, extractors ...framework.Extractor) (framework.NotificationSource, error) {
+// New creates a NotificationSource that delivers each event to the given extractors as it arrives.
+func New(name string, extractors ...datalayer.Extractor) (datalayer.NotificationSource, error) {
 	if name == "" {
-		return nil, fmt.Errorf("name is required for plugin '%s'", NotificationSourcePluginType)
+		return nil, fmt.Errorf("name is required for plugin '%s'", PluginType)
 	}
 	return &notificationSource{
-		name:       framework.TypedName{Type: NotificationSourcePluginType, Name: name},
-		ch:         make(chan framework.Event, defaultBufferSize),
+		name:       framework.TypedName{Type: PluginType, Name: name},
+		ch:         make(chan datalayer.Event, defaultBufferSize),
 		extractors: extractors,
 		done:       make(chan struct{}),
 	}, nil
@@ -72,12 +72,12 @@ func NewNotificationSource(name string, extractors ...framework.Extractor) (fram
 
 func (n *notificationSource) TypedName() framework.TypedName { return n.name }
 
-func (n *notificationSource) RegisterExtractor(e framework.Extractor) {
+func (n *notificationSource) RegisterExtractor(e datalayer.Extractor) {
 	n.extractors = append(n.extractors, e)
 }
 
 // Notify fires an event non-blocking; drops silently if the buffer is full.
-func (n *notificationSource) Notify(e framework.Event) {
+func (n *notificationSource) Notify(e datalayer.Event) {
 	select {
 	case n.ch <- e:
 	default:
@@ -118,7 +118,7 @@ func (n *notificationSource) eventLoop(ctx context.Context, ready chan struct{})
 			// Extractors are called sequentially; current extractors are in-memory only.
 			// Switch to a WaitGroup if any extractor performs I/O.
 			for _, ext := range n.extractors {
-				if err := ext.Extract(ctx, []framework.Event{e}); err != nil {
+				if err := ext.Extract(ctx, []datalayer.Event{e}); err != nil {
 					logger.Error(err, "extractor error", "extractor", ext.TypedName())
 				}
 			}


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the changes and their purpose -->
Move the contents of `datalayer.go` into `pkg/framework/datalayer/types.go`. Types like `datalayer.Extractor`, `datalayer.DataStore`, `datalayer.NotificationSource` are clearer than `framework.Extractor` since the package name makes the domain explicit.
## Why is this change needed?

<!-- Explain the motivation: bug fix, feature request, performance improvement, etc. -->

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [ ] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues
Fixes #103.
<!-- Link to related issues: Fixes #123, Related to #456 -->
