### PR TITLE
Second step in implementing the configuration file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 # Sources
+COPY apix ./apix
 COPY cmd ./cmd
 COPY pkg ./pkg
 COPY internal ./internal

--- a/cmd/runner/runner.go
+++ b/cmd/runner/runner.go
@@ -40,8 +40,8 @@ import (
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/common/observability/profiling"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/common/observability/tracing"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/config/loader"
-	"github.com/llm-d/llm-d-inference-payload-processor/pkg/datastore"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/datastore/inmemory"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/datalayer"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/plugin"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/requesthandling"
 	notificationsource "github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/plugins/datalayer/notificationsource"
@@ -272,7 +272,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	return nil
 }
 
-func (r *Runner) loadConfiguration(ctx context.Context, opts *runserver.Options, mgr manager.Manager, ds datastore.Datastore) error {
+func (r *Runner) loadConfiguration(ctx context.Context, opts *runserver.Options, mgr manager.Manager, ds datalayer.Datastore) error {
 	handle := plugin.NewHandle(ctx, mgr, ds)
 
 	logger := log.FromContext(ctx)

--- a/cmd/runner/runner.go
+++ b/cmd/runner/runner.go
@@ -292,10 +292,10 @@ func (r *Runner) loadConfiguration(ctx context.Context, opts *runserver.Options,
 	r.registerInTreePlugins()
 
 	_, err := loader.LoadConfiguration(configBytes, handle, logger)
-	//if err == nil {
-	//	r.requestPlugins = theConfig.RequestPlugins
-	//	r.responsePlugins = theConfig.ResponsePlugins
-	//}
+	// if err == nil {
+	//     r.requestPlugins = theConfig.RequestPlugins
+	//	   r.responsePlugins = theConfig.ResponsePlugins
+	// }
 
 	return err
 }

--- a/cmd/runner/runner.go
+++ b/cmd/runner/runner.go
@@ -30,6 +30,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -38,6 +39,8 @@ import (
 	logutil "github.com/llm-d/llm-d-inference-payload-processor/pkg/common/observability/logging"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/common/observability/profiling"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/common/observability/tracing"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/config/loader"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/datastore"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/datastore/inmemory"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/plugin"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/requesthandling"
@@ -177,10 +180,11 @@ func (r *Runner) Run(ctx context.Context) error {
 	}
 
 	ds := inmemory.NewDatastore()
-	handle := plugin.NewHandle(ctx, mgr, ds)
 
-	// Register factories for all known in-tree plugins
-	r.registerInTreePlugins()
+	err = r.loadConfiguration(ctx, opts, mgr, ds)
+	if err != nil {
+		return err
+	}
 
 	// Construct plugin instances for the in-tree plugins that are (1) registered and (2) requested via the --plugin flags
 	if len(opts.PluginSpecs) == 0 {
@@ -205,7 +209,7 @@ func (r *Runner) Run(ctx context.Context) error {
 		r.requestPlugins = append(r.requestPlugins, baseModelToHeaderPlugin)
 	} else {
 		setupLog.Info("plugins are specified, running with the specified plugins.")
-
+		handle := plugin.NewHandle(ctx, mgr, ds)
 		for _, s := range opts.PluginSpecs {
 			factory, ok := plugin.Registry[s.Type]
 			if !ok {
@@ -266,6 +270,34 @@ func (r *Runner) Run(ctx context.Context) error {
 	}
 	setupLog.Info("manager terminated")
 	return nil
+}
+
+func (r *Runner) loadConfiguration(ctx context.Context, opts *runserver.Options, mgr manager.Manager, ds datastore.Datastore) error {
+	handle := plugin.NewHandle(ctx, mgr, ds)
+
+	logger := log.FromContext(ctx)
+
+	var configBytes []byte
+	if opts.ConfigText != "" {
+		configBytes = []byte(opts.ConfigText)
+	} else if opts.ConfigFile != "" { // if config was specified through a file
+		var err error
+		configBytes, err = os.ReadFile(opts.ConfigFile)
+		if err != nil {
+			return fmt.Errorf("failed to load config from a file '%s' - %w", opts.ConfigFile, err)
+		}
+	}
+
+	// Register factories for all known in-tree plugins
+	r.registerInTreePlugins()
+
+	_, err := loader.LoadConfiguration(configBytes, handle, logger)
+	//if err == nil {
+	//	r.requestPlugins = theConfig.RequestPlugins
+	//	r.responsePlugins = theConfig.ResponsePlugins
+	//}
+
+	return err
 }
 
 // registerInTreePlugins registers the factory functions of all known payload processor plugins

--- a/deploy/config/ipp-config.yaml
+++ b/deploy/config/ipp-config.yaml
@@ -1,0 +1,9 @@
+# Sample IPP configuration file
+#
+apiVersion: llm-d.ai/v1alpha1
+kind: PayloadProcessorConfig
+plugins:
+- type: body-field-to-header
+  parameters:
+    fieldName: model
+    headerName: X-Gateway-Model-Name

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import "github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
+
+// Config contains the final configuration loaded by the configuration loader
+type Config struct {
+	// RequestPlugins are the request processing plugin instances executed by the request handler,
+	// in the same order provided in the configuration file.
+	RequestPlugins []framework.RequestProcessor
+	// ResponsePlugins are the response processing plugin instances executed by the response handler,
+	// in the same order provided in the configuration file.
+	ResponsePlugins []framework.ResponseProcessor
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -16,14 +16,14 @@ limitations under the License.
 
 package config
 
-import "github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
+import "github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/requesthandling"
 
 // Config contains the final configuration loaded by the configuration loader
 type Config struct {
 	// RequestPlugins are the request processing plugin instances executed by the request handler,
 	// in the same order provided in the configuration file.
-	RequestPlugins []framework.RequestProcessor
+	RequestPlugins []requesthandling.RequestProcessor
 	// ResponsePlugins are the response processing plugin instances executed by the response handler,
 	// in the same order provided in the configuration file.
-	ResponsePlugins []framework.ResponseProcessor
+	ResponsePlugins []requesthandling.ResponseProcessor
 }

--- a/pkg/config/loader/configloader.go
+++ b/pkg/config/loader/configloader.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package loader
+
+import (
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	configapi "github.com/llm-d/llm-d-inference-payload-processor/apix/config/v1alpha1"
+	config "github.com/llm-d/llm-d-inference-payload-processor/pkg/config"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
+)
+
+var (
+	scheme = runtime.NewScheme()
+)
+
+func init() {
+	utilruntime.Must(configapi.Install(scheme))
+}
+
+func LoadConfiguration(configBytes []byte, handle framework.Handle, logger logr.Logger) (*config.Config, error) {
+	rawConfig, err := loadRawConfiguration(configBytes, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = instantiatePlugins(rawConfig.Plugins, handle); err != nil {
+		return nil, err
+	}
+
+	return nil, err
+}
+
+func loadRawConfiguration(configBytes []byte, logger logr.Logger) (*configapi.PayloadProcessorConfig, error) {
+	var rawConfig *configapi.PayloadProcessorConfig
+	var err error
+	if len(configBytes) != 0 {
+		rawConfig = &configapi.PayloadProcessorConfig{}
+		codecs := serializer.NewCodecFactory(scheme, serializer.EnableStrict)
+		if err := runtime.DecodeInto(codecs.UniversalDecoder(), configBytes, rawConfig); err != nil {
+			return nil, fmt.Errorf("failed to decode configuration JSON/YAML: %w", err)
+		}
+		logger.Info("Loaded raw configuration", "config", rawConfig.String())
+	} else {
+		logger.Info("A configuration wasn't specified. A default one is being used.")
+		rawConfig = loadDefaultConfig()
+		logger.Info("Default raw configuration used", "config", rawConfig.String())
+	}
+
+	applyRawConfigDefaults(rawConfig)
+
+	return rawConfig, err
+}
+
+func instantiatePlugins(configuredPlugins []configapi.PluginSpec, handle framework.Handle) error {
+	pluginNames := sets.New[string]()
+	for _, spec := range configuredPlugins {
+		if spec.Type == "" {
+			return fmt.Errorf("plugin '%s' is missing a type", spec.Name)
+		}
+		if pluginNames.Has(spec.Name) {
+			return fmt.Errorf("duplicate plugin name '%s'", spec.Name)
+		}
+		pluginNames.Insert(spec.Name)
+
+		factory, ok := framework.Registry[spec.Type]
+		if !ok {
+			return fmt.Errorf("plugin type '%s' is not registered", spec.Type)
+		}
+		plugin, err := factory(spec.Name, spec.Parameters, handle)
+		if err != nil {
+			return fmt.Errorf("failed to create plugin '%s' (type: %s): %w", spec.Name, spec.Type, err)
+		}
+
+		handle.AddPlugin(spec.Name, plugin)
+	}
+
+	return nil
+}

--- a/pkg/config/loader/configloader.go
+++ b/pkg/config/loader/configloader.go
@@ -27,7 +27,7 @@ import (
 
 	configapi "github.com/llm-d/llm-d-inference-payload-processor/apix/config/v1alpha1"
 	config "github.com/llm-d/llm-d-inference-payload-processor/pkg/config"
-	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/plugin"
 )
 
 var (
@@ -38,7 +38,7 @@ func init() {
 	utilruntime.Must(configapi.Install(scheme))
 }
 
-func LoadConfiguration(configBytes []byte, handle framework.Handle, logger logr.Logger) (*config.Config, error) {
+func LoadConfiguration(configBytes []byte, handle plugin.Handle, logger logr.Logger) (*config.Config, error) {
 	rawConfig, err := loadRawConfiguration(configBytes, logger)
 	if err != nil {
 		return nil, err
@@ -72,7 +72,7 @@ func loadRawConfiguration(configBytes []byte, logger logr.Logger) (*configapi.Pa
 	return rawConfig, err
 }
 
-func instantiatePlugins(configuredPlugins []configapi.PluginSpec, handle framework.Handle) error {
+func instantiatePlugins(configuredPlugins []configapi.PluginSpec, handle plugin.Handle) error {
 	pluginNames := sets.New[string]()
 	for _, spec := range configuredPlugins {
 		if spec.Type == "" {
@@ -83,7 +83,7 @@ func instantiatePlugins(configuredPlugins []configapi.PluginSpec, handle framewo
 		}
 		pluginNames.Insert(spec.Name)
 
-		factory, ok := framework.Registry[spec.Type]
+		factory, ok := plugin.Registry[spec.Type]
 		if !ok {
 			return fmt.Errorf("plugin type '%s' is not registered", spec.Type)
 		}

--- a/pkg/config/loader/configloader_test.go
+++ b/pkg/config/loader/configloader_test.go
@@ -130,7 +130,7 @@ func TestInstantiatePlugins(t *testing.T) {
 		// --- Success Scenarios ---
 
 		{
-			name:       "Successfull load of plugins",
+			name:       "Successful load of plugins",
 			configText: successConfigText,
 			wantErr:    false,
 			validate: func(t *testing.T, handle framework.Handle) {

--- a/pkg/config/loader/configloader_test.go
+++ b/pkg/config/loader/configloader_test.go
@@ -1,0 +1,284 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package loader
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/google/go-cmp/cmp"
+	configapi "github.com/llm-d/llm-d-inference-payload-processor/apix/config/v1alpha1"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/common/observability/logging"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/datalayer"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/modelselector"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/plugins/basemodelextractor"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/plugins/bodyfieldtoheader"
+)
+
+// Define constants for test plugins.
+// Constants must match those used in testdata_test.go.
+const (
+	testPickerType       = "test-picker"
+	testPluginType       = "test-plugin"
+	testRequestProcType  = "test-request-processor"
+	testResponseProcType = "test-response-processor"
+	testScorerType       = "test-scorer"
+)
+
+func TestLoadRawConfiguration(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		configText string
+		want       *configapi.PayloadProcessorConfig
+		wantErr    bool
+	}{
+		{
+			name:       "Success - Full Configuration",
+			configText: successConfigText,
+			want: &configapi.PayloadProcessorConfig{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "PayloadProcessorConfig",
+					APIVersion: "llm-d.ai/v1alpha1",
+				},
+				Plugins: []configapi.PluginSpec{
+					{Name: testRequestProcType, Type: testRequestProcType},
+					{Name: testResponseProcType, Type: testResponseProcType},
+					{Name: "test1", Type: testPluginType, Parameters: json.RawMessage(`{"threshold":10}`)},
+					{Name: testScorerType, Type: testScorerType, Parameters: json.RawMessage(`{"cost":42}`)},
+					{Name: "testPicker", Type: testPickerType},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:       "Success - Default configuration",
+			configText: "",
+			want: &configapi.PayloadProcessorConfig{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "llm-d.ai/v1alpha1",
+					Kind:       "PayloadProcessorConfig",
+				},
+				Plugins: []configapi.PluginSpec{
+					{
+						Name:       bodyfieldtoheader.BodyFieldToHeaderPluginType,
+						Type:       bodyfieldtoheader.BodyFieldToHeaderPluginType,
+						Parameters: json.RawMessage(`{"fieldName": "model", "headerName": "X-Gateway-Model-Name"}`),
+					},
+					{
+						Name: basemodelextractor.BaseModelToHeaderPluginType,
+						Type: basemodelextractor.BaseModelToHeaderPluginType,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:       "Error - Invalid YAML",
+			configText: errorBadYamlText,
+			wantErr:    true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			logger := logging.NewTestLogger()
+
+			got, err := loadRawConfiguration([]byte(tc.configText), logger)
+
+			if tc.wantErr {
+				require.Error(t, err, "Expected LoadRawConfig to fail")
+				return
+			}
+			require.NoError(t, err, "Expected LoadRawConfig to succeed")
+			diff := cmp.Diff(tc.want, got)
+			require.Empty(t, diff, "Config mismatch (-want +got):\n%s", diff)
+		})
+	}
+}
+
+func TestInstantiatePlugins(t *testing.T) {
+	// Not parallel because it modifies global plugin registry.
+	registerTestPlugins(t)
+
+	tests := []struct {
+		name       string
+		configText string
+		wantErr    bool
+		validate   func(t *testing.T, handle framework.Handle)
+	}{
+		// --- Success Scenarios ---
+
+		{
+			name:       "Successfull load of plugins",
+			configText: successConfigText,
+			wantErr:    false,
+			validate: func(t *testing.T, handle framework.Handle) {
+				loadedPlugins := handle.GetAllPlugins()
+				require.Len(t, loadedPlugins, 5)
+				require.NotNil(t, handle.Plugin("test1"), "Explicit test plugin should be instantiated")
+				require.NotNil(t, handle.Plugin(testScorerType), "Explicit scorer should be instantiated")
+				require.NotNil(t, handle.Plugin("testPicker"), "Explicit picker should be instantiated")
+			},
+		},
+
+		// --- Instantiation Errors ---
+
+		{
+			name:       "Error (Instantiation) - Missing Type Field",
+			configText: errorBadPluginReferenceText,
+			wantErr:    true,
+		},
+		{
+			name:       "Error (Instantiation) - Unknown Plugin Type",
+			configText: errorBadPluginReferencePluginText,
+			wantErr:    true,
+		},
+		{
+			name:       "Error (Instantiation) - Invalid JSON Parameters",
+			configText: errorBadPluginJSONText,
+			wantErr:    true,
+		},
+		{
+			name:       "Error (Instantiation) - Duplicate plugin name",
+			configText: errorDuplicatePluginText,
+			wantErr:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			logger := logging.NewTestLogger()
+
+			// 1. Load Raw (Assuming valid yaml/structure for Phase 2 tests)
+			rawConfig, err := loadRawConfiguration([]byte(tc.configText), logger)
+			if err != nil {
+				// If we expected failure (and it failed early in Phase 1), success.
+				if tc.wantErr {
+					return
+				}
+				require.NoError(t, err, "Setup: LoadRawConfig failed")
+			}
+
+			// 2. Instantiate
+			handle := framework.NewHandle(context.Background(), nil)
+			err = instantiatePlugins(rawConfig.Plugins, handle)
+
+			if tc.wantErr {
+				require.Error(t, err, "Expected instantiatePlugins to fail")
+				return
+			}
+			require.NoError(t, err, "Expected instantiatePlugins to succeed")
+
+			if tc.validate != nil {
+				tc.validate(t, handle)
+			}
+		})
+	}
+}
+
+// --- Mocks ---
+
+type mockPlugin struct {
+	t framework.TypedName
+}
+
+func (m *mockPlugin) TypedName() framework.TypedName { return m.t }
+
+// Mock RequestProcessor
+type mockRequestProcessor struct{ mockPlugin }
+
+// compile-time type assertion
+var _ framework.RequestProcessor = &mockRequestProcessor{}
+
+func (m *mockRequestProcessor) ProcessRequest(ctx context.Context, cycleState *framework.CycleState, request *framework.InferenceRequest) error {
+	return nil
+}
+
+// Mock ResponseProcessor
+type mockResponseProcessor struct{ mockPlugin }
+
+// compile-time type assertion
+var _ framework.ResponseProcessor = &mockResponseProcessor{}
+
+func (m *mockResponseProcessor) ProcessResponse(ctx context.Context, cycleState *framework.CycleState, request *framework.InferenceResponse) error {
+	return nil
+}
+
+// Mock Scorer
+type mockScorer struct{ mockPlugin }
+
+// compile-time type assertion
+var _ modelselector.Scorer = &mockScorer{}
+
+func (m *mockScorer) Score(ctx context.Context, cycleState *framework.CycleState, request *framework.InferenceRequest, models []datalayer.Model) map[datalayer.Model]float64 {
+	return nil
+}
+
+// Mock Picker
+type mockPicker struct{ mockPlugin }
+
+// compile-time type assertion
+var _ modelselector.Picker = &mockPicker{}
+
+func (m *mockPicker) Pick(ctx context.Context, cycleState *framework.CycleState, scoredModels []*modelselector.ScoredModel) *modelselector.ProfileRunResult {
+	return nil
+}
+
+func registerTestPlugins(t *testing.T) {
+	t.Helper()
+
+	// Register standard test mocks.
+	framework.Register(testPluginType,
+		func(name string, params json.RawMessage, _ framework.Handle) (framework.Plugin, error) {
+			return &mockPlugin{t: framework.TypedName{Name: name, Type: testPluginType}}, nil
+		})
+
+	framework.Register(testRequestProcType,
+		func(name string, params json.RawMessage, _ framework.Handle) (framework.Plugin, error) {
+			return &mockRequestProcessor{mockPlugin{t: framework.TypedName{Name: name, Type: testRequestProcType}}}, nil
+		})
+
+	framework.Register(testResponseProcType,
+		func(name string, params json.RawMessage, _ framework.Handle) (framework.Plugin, error) {
+			return &mockResponseProcessor{mockPlugin{t: framework.TypedName{Name: name, Type: testResponseProcType}}}, nil
+		})
+
+	framework.Register(testPickerType,
+		func(name string, params json.RawMessage, _ framework.Handle) (framework.Plugin, error) {
+			return &mockPicker{mockPlugin{t: framework.TypedName{Name: name, Type: testPickerType}}}, nil
+		})
+
+	framework.Register(testScorerType, func(name string, params json.RawMessage, _ framework.Handle) (framework.Plugin, error) {
+		// Attempt to unmarshal to trigger errors for invalid JSON in tests.
+		if len(params) > 0 {
+			var p struct {
+				Cost float32 `json:"cost"`
+			}
+			if err := json.Unmarshal(params, &p); err != nil {
+				return nil, err
+			}
+		}
+		return &mockScorer{mockPlugin{t: framework.TypedName{Name: name, Type: testScorerType}}}, nil
+	})
+}

--- a/pkg/config/loader/configloader_test.go
+++ b/pkg/config/loader/configloader_test.go
@@ -27,12 +27,12 @@ import (
 	"github.com/google/go-cmp/cmp"
 	configapi "github.com/llm-d/llm-d-inference-payload-processor/apix/config/v1alpha1"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/common/observability/logging"
-	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/datalayer"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/datalayer"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/modelselector"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/plugin"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/requesthandling"
-	"github.com/llm-d/llm-d-inference-payload-processor/pkg/plugins/basemodelextractor"
-	"github.com/llm-d/llm-d-inference-payload-processor/pkg/plugins/bodyfieldtoheader"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/plugins/requesthandling/basemodelextractor"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/plugins/requesthandling/bodyfieldtoheader"
 )
 
 // Define constants for test plugins.

--- a/pkg/config/loader/configloader_test.go
+++ b/pkg/config/loader/configloader_test.go
@@ -27,9 +27,10 @@ import (
 	"github.com/google/go-cmp/cmp"
 	configapi "github.com/llm-d/llm-d-inference-payload-processor/apix/config/v1alpha1"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/common/observability/logging"
-	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/datalayer"
-	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/modelselector"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/modelselector"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/plugin"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/requesthandling"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/plugins/basemodelextractor"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/plugins/bodyfieldtoheader"
 )
@@ -125,7 +126,7 @@ func TestInstantiatePlugins(t *testing.T) {
 		name       string
 		configText string
 		wantErr    bool
-		validate   func(t *testing.T, handle framework.Handle)
+		validate   func(t *testing.T, handle plugin.Handle)
 	}{
 		// --- Success Scenarios ---
 
@@ -133,7 +134,7 @@ func TestInstantiatePlugins(t *testing.T) {
 			name:       "Successful load of plugins",
 			configText: successConfigText,
 			wantErr:    false,
-			validate: func(t *testing.T, handle framework.Handle) {
+			validate: func(t *testing.T, handle plugin.Handle) {
 				loadedPlugins := handle.GetAllPlugins()
 				require.Len(t, loadedPlugins, 5)
 				require.NotNil(t, handle.Plugin("test1"), "Explicit test plugin should be instantiated")
@@ -181,7 +182,7 @@ func TestInstantiatePlugins(t *testing.T) {
 			}
 
 			// 2. Instantiate
-			handle := framework.NewHandle(context.Background(), nil)
+			handle := plugin.NewHandle(context.Background(), nil, nil)
 			err = instantiatePlugins(rawConfig.Plugins, handle)
 
 			if tc.wantErr {
@@ -200,18 +201,18 @@ func TestInstantiatePlugins(t *testing.T) {
 // --- Mocks ---
 
 type mockPlugin struct {
-	t framework.TypedName
+	t plugin.TypedName
 }
 
-func (m *mockPlugin) TypedName() framework.TypedName { return m.t }
+func (m *mockPlugin) TypedName() plugin.TypedName { return m.t }
 
 // Mock RequestProcessor
 type mockRequestProcessor struct{ mockPlugin }
 
 // compile-time type assertion
-var _ framework.RequestProcessor = &mockRequestProcessor{}
+var _ requesthandling.RequestProcessor = &mockRequestProcessor{}
 
-func (m *mockRequestProcessor) ProcessRequest(ctx context.Context, cycleState *framework.CycleState, request *framework.InferenceRequest) error {
+func (m *mockRequestProcessor) ProcessRequest(ctx context.Context, cycleState *plugin.CycleState, request *requesthandling.InferenceRequest) error {
 	return nil
 }
 
@@ -219,9 +220,9 @@ func (m *mockRequestProcessor) ProcessRequest(ctx context.Context, cycleState *f
 type mockResponseProcessor struct{ mockPlugin }
 
 // compile-time type assertion
-var _ framework.ResponseProcessor = &mockResponseProcessor{}
+var _ requesthandling.ResponseProcessor = &mockResponseProcessor{}
 
-func (m *mockResponseProcessor) ProcessResponse(ctx context.Context, cycleState *framework.CycleState, request *framework.InferenceResponse) error {
+func (m *mockResponseProcessor) ProcessResponse(ctx context.Context, cycleState *plugin.CycleState, request *requesthandling.InferenceResponse) error {
 	return nil
 }
 
@@ -231,7 +232,7 @@ type mockScorer struct{ mockPlugin }
 // compile-time type assertion
 var _ modelselector.Scorer = &mockScorer{}
 
-func (m *mockScorer) Score(ctx context.Context, cycleState *framework.CycleState, request *framework.InferenceRequest, models []datalayer.Model) map[datalayer.Model]float64 {
+func (m *mockScorer) Score(ctx context.Context, cycleState *plugin.CycleState, request *requesthandling.InferenceRequest, models []datalayer.Model) map[datalayer.Model]float64 {
 	return nil
 }
 
@@ -241,7 +242,7 @@ type mockPicker struct{ mockPlugin }
 // compile-time type assertion
 var _ modelselector.Picker = &mockPicker{}
 
-func (m *mockPicker) Pick(ctx context.Context, cycleState *framework.CycleState, scoredModels []*modelselector.ScoredModel) *modelselector.ProfileRunResult {
+func (m *mockPicker) Pick(ctx context.Context, cycleState *plugin.CycleState, scoredModels []*modelselector.ScoredModel) *modelselector.ProfileRunResult {
 	return nil
 }
 
@@ -249,27 +250,27 @@ func registerTestPlugins(t *testing.T) {
 	t.Helper()
 
 	// Register standard test mocks.
-	framework.Register(testPluginType,
-		func(name string, params json.RawMessage, _ framework.Handle) (framework.Plugin, error) {
-			return &mockPlugin{t: framework.TypedName{Name: name, Type: testPluginType}}, nil
+	plugin.Register(testPluginType,
+		func(name string, params json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
+			return &mockPlugin{t: plugin.TypedName{Name: name, Type: testPluginType}}, nil
 		})
 
-	framework.Register(testRequestProcType,
-		func(name string, params json.RawMessage, _ framework.Handle) (framework.Plugin, error) {
-			return &mockRequestProcessor{mockPlugin{t: framework.TypedName{Name: name, Type: testRequestProcType}}}, nil
+	plugin.Register(testRequestProcType,
+		func(name string, params json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
+			return &mockRequestProcessor{mockPlugin{t: plugin.TypedName{Name: name, Type: testRequestProcType}}}, nil
 		})
 
-	framework.Register(testResponseProcType,
-		func(name string, params json.RawMessage, _ framework.Handle) (framework.Plugin, error) {
-			return &mockResponseProcessor{mockPlugin{t: framework.TypedName{Name: name, Type: testResponseProcType}}}, nil
+	plugin.Register(testResponseProcType,
+		func(name string, params json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
+			return &mockResponseProcessor{mockPlugin{t: plugin.TypedName{Name: name, Type: testResponseProcType}}}, nil
 		})
 
-	framework.Register(testPickerType,
-		func(name string, params json.RawMessage, _ framework.Handle) (framework.Plugin, error) {
-			return &mockPicker{mockPlugin{t: framework.TypedName{Name: name, Type: testPickerType}}}, nil
+	plugin.Register(testPickerType,
+		func(name string, params json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
+			return &mockPicker{mockPlugin{t: plugin.TypedName{Name: name, Type: testPickerType}}}, nil
 		})
 
-	framework.Register(testScorerType, func(name string, params json.RawMessage, _ framework.Handle) (framework.Plugin, error) {
+	plugin.Register(testScorerType, func(name string, params json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
 		// Attempt to unmarshal to trigger errors for invalid JSON in tests.
 		if len(params) > 0 {
 			var p struct {
@@ -279,6 +280,6 @@ func registerTestPlugins(t *testing.T) {
 				return nil, err
 			}
 		}
-		return &mockScorer{mockPlugin{t: framework.TypedName{Name: name, Type: testScorerType}}}, nil
+		return &mockScorer{mockPlugin{t: plugin.TypedName{Name: name, Type: testScorerType}}}, nil
 	})
 }

--- a/pkg/config/loader/defaults.go
+++ b/pkg/config/loader/defaults.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package loader
+
+import (
+	"encoding/json"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	configapi "github.com/llm-d/llm-d-inference-payload-processor/apix/config/v1alpha1"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/plugins/basemodelextractor"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/plugins/bodyfieldtoheader"
+)
+
+func loadDefaultConfig() *configapi.PayloadProcessorConfig {
+	return &configapi.PayloadProcessorConfig{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "llm-d.ai/v1alpha1",
+			Kind:       "PayloadProcessorConfig",
+		},
+		Plugins: []configapi.PluginSpec{
+			{
+				Type:       bodyfieldtoheader.BodyFieldToHeaderPluginType,
+				Parameters: json.RawMessage(`{"fieldName": "model", "headerName": "X-Gateway-Model-Name"}`),
+			},
+			{
+				Type: basemodelextractor.BaseModelToHeaderPluginType,
+			},
+		},
+	}
+}
+
+// applyRawConfigDefaults applies defaults that can be applied at the level of the raw configuration text
+func applyRawConfigDefaults(rawConfig *configapi.PayloadProcessorConfig) {
+	for idx, pluginConfig := range rawConfig.Plugins {
+		if pluginConfig.Name == "" {
+			rawConfig.Plugins[idx].Name = pluginConfig.Type
+		}
+	}
+}

--- a/pkg/config/loader/defaults.go
+++ b/pkg/config/loader/defaults.go
@@ -22,8 +22,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	configapi "github.com/llm-d/llm-d-inference-payload-processor/apix/config/v1alpha1"
-	"github.com/llm-d/llm-d-inference-payload-processor/pkg/plugins/basemodelextractor"
-	"github.com/llm-d/llm-d-inference-payload-processor/pkg/plugins/bodyfieldtoheader"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/plugins/requesthandling/basemodelextractor"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/plugins/requesthandling/bodyfieldtoheader"
 )
 
 func loadDefaultConfig() *configapi.PayloadProcessorConfig {

--- a/pkg/config/loader/testdata_test.go
+++ b/pkg/config/loader/testdata_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package loader
+
+// --- Valid Configurations ---
+
+// successConfigText represents a fully populated, valid configuration.
+// It uses a mix of explicit names and type-derived names.
+const successConfigText = `
+apiVersion: llm-d.ai/v1alpha1
+kind: PayloadProcessorConfig
+plugins:
+- type: test-request-processor
+- type: test-response-processor
+- name: test1
+  type: test-plugin
+  parameters:
+    threshold: 10
+- type: test-scorer
+  parameters:
+    cost: 42
+- name: testPicker
+  type: test-picker
+`
+
+// --- Invalid Configurations (Syntax/Structure) ---
+
+// errorBadYamlText contains invalid YAML syntax.
+const errorBadYamlText = `
+apiVersion: llm-d.ai/v1alpha1
+kind: PayloadProcessorConfig
+plugins:
+- testing 1 2 3
+`
+
+// errorBadPluginReferenceText is missing the required 'type' field.
+const errorBadPluginReferenceText = `
+apiVersion: llm-d.ai/v1alpha1
+kind: PayloadProcessorConfig
+plugins:
+- parameters:
+    a: 1234
+`
+
+// errorBadPluginReferencePluginText references a plugin type that does not exist in the registry.
+const errorBadPluginReferencePluginText = `
+apiVersion: llm-d.ai/v1alpha1
+kind: PayloadProcessorConfig
+plugins:
+- name: testx
+  type: unknown-plugin-type
+- name: profileHandler
+  type: test-profile-handler
+`
+
+// errorBadPluginJSONText has invalid JSON in parameters (string where int expected).
+const errorBadPluginJSONText = `
+apiVersion: llm-d.ai/v1alpha1
+kind: PayloadProcessorConfig
+plugins:
+- name: testScorer
+  type: test-scorer
+  parameters:
+    cost: asdf
+`
+
+// errorDuplicatePluginText defines the same plugin name twice.
+const errorDuplicatePluginText = `
+apiVersion: llm-d.ai/v1alpha1
+kind: PayloadProcessorConfig
+plugins:
+- name: test1
+  type: test-plugin
+  parameters:
+    threshold: 10
+- name: test1
+  type: test-plugin
+  parameters:
+    threshold: 20
+`

--- a/pkg/framework/interface/plugin/handle.go
+++ b/pkg/framework/interface/plugin/handle.go
@@ -33,6 +33,22 @@ type Handle interface {
 	Client() client.Client
 	ReconcilerBuilder() *ctrlbuilder.Builder
 	Datastore() datalayer.Datastore
+	HandlePlugins
+}
+
+// HandlePlugins defines a set of APIs to work with instantiated plugins
+type HandlePlugins interface {
+	// Plugin returns the named plugin instance
+	Plugin(name string) Plugin
+
+	// AddPlugin adds a plugin to the set of known plugin instances
+	AddPlugin(name string, plugin Plugin)
+
+	// GetAllPlugins returns all of the known plugins
+	GetAllPlugins() []Plugin
+
+	// GetAllPluginsWithNames returns all of the known plugins with their names
+	GetAllPluginsWithNames() map[string]Plugin
 }
 
 // payloadProcessorHandle is an implementation of the Handle interface.
@@ -40,6 +56,7 @@ type payloadProcessorHandle struct {
 	ctx context.Context
 	mgr ctrl.Manager
 	ds  datalayer.Datastore
+	HandlePlugins
 }
 
 // Context returns a context the plugins can use, if they need one
@@ -59,10 +76,42 @@ func (h *payloadProcessorHandle) Datastore() datalayer.Datastore {
 	return h.ds
 }
 
+// ippHandlePlugins implements the set of APIs to work with instantiated plugins
+type ippHandlePlugins struct {
+	plugins map[string]Plugin
+}
+
+// Plugin returns the named plugin instance
+func (h *ippHandlePlugins) Plugin(name string) Plugin {
+	return h.plugins[name]
+}
+
+// AddPlugin adds a plugin to the set of known plugin instances
+func (h *ippHandlePlugins) AddPlugin(name string, plugin Plugin) {
+	h.plugins[name] = plugin
+}
+
+// GetAllPlugins returns all of the known plugins
+func (h *ippHandlePlugins) GetAllPlugins() []Plugin {
+	result := make([]Plugin, 0, len(h.plugins))
+	for _, plugin := range h.plugins {
+		result = append(result, plugin)
+	}
+	return result
+}
+
+// GetAllPluginsWithNames returns al of the known plugins with their names
+func (h *ippHandlePlugins) GetAllPluginsWithNames() map[string]Plugin {
+	return h.plugins
+}
+
 func NewHandle(ctx context.Context, mgr ctrl.Manager, ds datalayer.Datastore) Handle {
 	return &payloadProcessorHandle{
 		ctx: ctx,
 		mgr: mgr,
 		ds:  ds,
+		HandlePlugins: &ippHandlePlugins{
+			plugins: map[string]Plugin{},
+		},
 	}
 }

--- a/pkg/framework/plugins/datalayer/requestmetadata/plugin_test.go
+++ b/pkg/framework/plugins/datalayer/requestmetadata/plugin_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/datastore"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/datalayer"
 	dlsrc "github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/datalayer/datasource"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/plugin"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/requesthandling"
 	ctrlbuilder "sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -33,10 +34,14 @@ import (
 // fakeHandle implements plugin.Handle for unit tests, providing only a Datastore.
 type fakeHandle struct{ ds datalayer.Datastore }
 
-func (f *fakeHandle) Context() context.Context                { return context.Background() }
-func (f *fakeHandle) Client() client.Client                   { return nil }
-func (f *fakeHandle) ReconcilerBuilder() *ctrlbuilder.Builder { return nil }
-func (f *fakeHandle) Datastore() datalayer.Datastore          { return f.ds }
+func (f *fakeHandle) Context() context.Context                         { return context.Background() }
+func (f *fakeHandle) Client() client.Client                            { return nil }
+func (f *fakeHandle) ReconcilerBuilder() *ctrlbuilder.Builder          { return nil }
+func (f *fakeHandle) Datastore() datalayer.Datastore                   { return f.ds }
+func (f *fakeHandle) Plugin(name string) plugin.Plugin                 { return nil }
+func (f *fakeHandle) AddPlugin(name string, plugin plugin.Plugin)      {}
+func (f *fakeHandle) GetAllPlugins() []plugin.Plugin                   { return nil }
+func (f *fakeHandle) GetAllPluginsWithNames() map[string]plugin.Plugin { return nil }
 
 // makeRequestEvent creates a RequestEventType event with model and max_tokens.
 func makeRequestEvent(model string, maxTokens float64) dlsrc.Event {

--- a/pkg/server/options.go
+++ b/pkg/server/options.go
@@ -47,9 +47,11 @@ type Options struct {
 	SecureServing          bool // Enables secure serving.
 	MetricsEndpointAuth    bool // Enables authentication and authorization of the metrics endpoint.
 	//
-	// Plugins.
+	// Configuration.
 	//
 	PluginSpecs config.IPPPluginSpecs // Repeatable --plugin <type>:<name>[:<json>] flag values.
+	ConfigFile  string                // The path to the configuration file.
+	ConfigText  string                // The configuration specified as text, in lieu of a file.
 
 	// internal
 	fs *pflag.FlagSet // FlagSet used in AddFlags()
@@ -92,6 +94,8 @@ func (opts *Options) AddFlags(fs *pflag.FlagSet) {
 		"Enables pprof handlers. Defaults to true. Set to false to disable pprof handlers.")
 
 	fs.Var(&opts.PluginSpecs, "plugin", `Repeatable. --plugin <type>:<name>[:<json>]`)
+	fs.StringVar(&opts.ConfigFile, "config-file", opts.ConfigFile, "The path to the configuration file.")
+	fs.StringVar(&opts.ConfigText, "config-text", opts.ConfigText, "The configuration specified as text, in lieu of a file.")
 
 	opts.LoggingOptions.AddFlags(fs) // Add logging flags.
 }


### PR DESCRIPTION
## What does this PR do?
Extends the basic configuration support by:
1. Loading the configuration file
2. Setting textual defaults
3. Instantiating the plugins referenced in the configuration file

## Why is this change needed?
A step in having a complete and expressive way to configure the IPP.

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

Refs: #77 
Refs: #12
