### PR TITLE
refactor inflightrequests-->requestmetadata

### DIFF
--- a/cmd/runner/runner.go
+++ b/cmd/runner/runner.go
@@ -43,8 +43,8 @@ import (
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/metrics"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/plugins/basemodelextractor"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/plugins/bodyfieldtoheader"
-	inflightrequests "github.com/llm-d/llm-d-inference-payload-processor/pkg/plugins/datalayer/inflightrequests"
 	notificationsource "github.com/llm-d/llm-d-inference-payload-processor/pkg/plugins/datalayer/notificationsource"
+	requestmetadata "github.com/llm-d/llm-d-inference-payload-processor/pkg/plugins/datalayer/requestmetadata"
 	runserver "github.com/llm-d/llm-d-inference-payload-processor/pkg/server"
 	"github.com/llm-d/llm-d-inference-payload-processor/version"
 )
@@ -224,9 +224,9 @@ func (r *Runner) Run(ctx context.Context) error {
 		}
 	}
 
-	// Wire the inflight-requests data pipeline: extractor → notification source.
+	// Wire the request-metadata data pipeline: extractor → notification source.
 	// TODO: config-driven path does not yet support NotificationSource + extractors.
-	notifSrc, err := notificationsource.New("default", inflightrequests.NewInflightRequestsExtractor(ds))
+	notifSrc, err := notificationsource.New("default", requestmetadata.NewRequestMetadataExtractor(ds))
 	if err != nil {
 		setupLog.Error(err, "failed to create notification source")
 		return err
@@ -269,7 +269,7 @@ func (r *Runner) Run(ctx context.Context) error {
 func (r *Runner) registerInTreePlugins() {
 	framework.Register(bodyfieldtoheader.BodyFieldToHeaderPluginType, bodyfieldtoheader.BodyFieldToHeaderPluginFactory)
 	framework.Register(basemodelextractor.BaseModelToHeaderPluginType, basemodelextractor.BaseModelToHeaderPluginFactory)
-	framework.Register(inflightrequests.PluginType, inflightrequests.ExtractorFactory)
+	framework.Register(requestmetadata.PluginType, requestmetadata.ExtractorFactory)
 	framework.Register(notificationsource.PluginType, notificationsource.Factory)
 }
 

--- a/pkg/plugins/datalayer/requestmetadata/plugin.go
+++ b/pkg/plugins/datalayer/requestmetadata/plugin.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package inflightrequests
+package requestmetadata
 
 import (
 	"context"
@@ -26,33 +26,33 @@ import (
 
 const (
 	// PluginType is the identifier used when registering this extractor.
-	PluginType = "inflight-requests-extractor"
+	PluginType = "request-metadata-extractor"
 
-	// InflightRequestsAttributeKey is the attribute key written to each model's attribute store.
-	InflightRequestsAttributeKey = "inflight-requests"
+	// RequestMetadataAttributeKey is the attribute key written to each model's attribute store.
+	RequestMetadataAttributeKey = "request-metadata"
 )
 
 // compile-time interface assertion
-var _ datalayer.Extractor = &InflightRequestsExtractor{}
+var _ datalayer.Extractor = &RequestMetadataExtractor{}
 
-// ExtractorFactory creates a InflightRequestsExtractor with a nil DataStore.
+// ExtractorFactory creates a RequestMetadataExtractor with a nil DataStore.
 // The factory path is limited: the DataStore is not available via framework.Handle,
-// so the created extractor cannot write to the store. Use NewInflightRequestsExtractor
+// so the created extractor cannot write to the store. Use NewRequestMetadataExtractor
 // directly when constructing for production use.
 func ExtractorFactory(name string, _ json.RawMessage, _ framework.Handle) (framework.Plugin, error) {
-	return NewInflightRequestsExtractor(nil).WithName(name), nil
+	return NewRequestMetadataExtractor(nil).WithName(name), nil
 }
 
-// InflightRequestsCount holds in-flight request and token counts for one model.
-type InflightRequestsCount struct {
+// RequestMetadataCount holds in-flight request and token counts for one model.
+type RequestMetadataCount struct {
 	Requests int64
 	Tokens   int64
 }
 
-func (r InflightRequestsCount) Clone() datalayer.Cloneable { return r }
+func (r RequestMetadataCount) Clone() datalayer.Cloneable { return r }
 
-// InflightRequestsExtractor tracks in-flight request counts and token sums per model.
-// It writes InflightRequestsCount to each model's InflightRequestsAttributeKey attribute.
+// RequestMetadataExtractor tracks in-flight request counts and token sums per model.
+// It writes RequestMetadataCount to each model's RequestMetadataAttributeKey attribute.
 //
 // Extract is assumed to be called from a single goroutine (the NotificationSource event loop).
 // If parallel dispatch is introduced, add a sync.Mutex around counters and the DataStore write.
@@ -60,30 +60,30 @@ func (r InflightRequestsCount) Clone() datalayer.Cloneable { return r }
 // TODO: counters leak if a request fails without a corresponding ResponseEventType (e.g. connection
 // drop, upstream error, context cancellation). The call site should fire a
 // synthetic ResponseEventType in its error/EOF path to keep counts accurate.
-type InflightRequestsExtractor struct {
+type RequestMetadataExtractor struct {
 	typedName framework.TypedName
 	dataStore datalayer.DataStore
-	counters  map[string]InflightRequestsCount
+	counters  map[string]RequestMetadataCount
 }
 
-func NewInflightRequestsExtractor(ds datalayer.DataStore) *InflightRequestsExtractor {
-	return &InflightRequestsExtractor{
+func NewRequestMetadataExtractor(ds datalayer.DataStore) *RequestMetadataExtractor {
+	return &RequestMetadataExtractor{
 		typedName: framework.TypedName{Type: PluginType, Name: PluginType},
 		dataStore: ds,
-		counters:  make(map[string]InflightRequestsCount),
+		counters:  make(map[string]RequestMetadataCount),
 	}
 }
 
-func (e *InflightRequestsExtractor) TypedName() framework.TypedName { return e.typedName }
+func (e *RequestMetadataExtractor) TypedName() framework.TypedName { return e.typedName }
 
 // WithName sets the instance name, used by the factory when the plugin is configured by name.
-func (e *InflightRequestsExtractor) WithName(name string) *InflightRequestsExtractor {
+func (e *RequestMetadataExtractor) WithName(name string) *RequestMetadataExtractor {
 	e.typedName.Name = name
 	return e
 }
 
-func (e *InflightRequestsExtractor) Extract(_ context.Context, events []datalayer.Event) error {
-	updated := map[string]InflightRequestsCount{}
+func (e *RequestMetadataExtractor) Extract(_ context.Context, events []datalayer.Event) error {
+	updated := map[string]RequestMetadataCount{}
 
 	for _, ev := range events {
 		switch ev.Type {
@@ -122,7 +122,7 @@ func (e *InflightRequestsExtractor) Extract(_ context.Context, events []datalaye
 	}
 
 	for model, c := range updated {
-		e.dataStore.GetOrCreateModel(model).GetAttributes().Put(InflightRequestsAttributeKey, c)
+		e.dataStore.GetOrCreateModel(model).GetAttributes().Put(RequestMetadataAttributeKey, c)
 	}
 	return nil
 }

--- a/pkg/plugins/datalayer/requestmetadata/plugin_test.go
+++ b/pkg/plugins/datalayer/requestmetadata/plugin_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package inflightrequests
+package requestmetadata
 
 import (
 	"context"
@@ -74,35 +74,35 @@ func makeResponseEvent(model string, durationMs int, maxTokens float64) datalaye
 	}
 }
 
-// getInflightRequests asserts the inflight-requests attribute exists for model and returns it.
-func getInflightRequests(t testing.TB, ds *fakeDataStore, model string) InflightRequestsCount {
+// getRequestMetadata asserts the request-metadata attribute exists for model and returns it.
+func getRequestMetadata(t testing.TB, ds *fakeDataStore, model string) RequestMetadataCount {
 	t.Helper()
-	val, ok := ds.GetOrCreateModel(model).GetAttributes().Get(InflightRequestsAttributeKey)
+	val, ok := ds.GetOrCreateModel(model).GetAttributes().Get(RequestMetadataAttributeKey)
 	if !ok {
-		t.Fatalf("expected %q attribute for model %q", InflightRequestsAttributeKey, model)
+		t.Fatalf("expected %q attribute for model %q", RequestMetadataAttributeKey, model)
 	}
-	rc, ok := val.(InflightRequestsCount)
+	rc, ok := val.(RequestMetadataCount)
 	if !ok {
-		t.Fatalf("expected InflightRequestsCount for model %q", model)
+		t.Fatalf("expected RequestMetadataCount for model %q", model)
 	}
 	return rc
 }
 
-func newInflightRequestsTest(t *testing.T) (*InflightRequestsExtractor, *fakeDataStore) {
+func newRequestMetadataTest(t *testing.T) (*RequestMetadataExtractor, *fakeDataStore) {
 	t.Helper()
 	ds := newFakeDataStore()
-	return NewInflightRequestsExtractor(ds), ds
+	return NewRequestMetadataExtractor(ds), ds
 }
 
 func TestRequestIncrementsCounter(t *testing.T) {
-	ext, ds := newInflightRequestsTest(t)
+	ext, ds := newRequestMetadataTest(t)
 
 	batch := []datalayer.Event{makeRequestEvent("m1", 100)}
 	if err := ext.Extract(context.Background(), batch); err != nil {
 		t.Fatalf("Extract failed: %v", err)
 	}
 
-	rc := getInflightRequests(t, ds, "m1")
+	rc := getRequestMetadata(t, ds, "m1")
 	if rc.Requests != 1 {
 		t.Errorf("expected Requests=1, got %d", rc.Requests)
 	}
@@ -112,7 +112,7 @@ func TestRequestIncrementsCounter(t *testing.T) {
 }
 
 func TestResponseDecrementsCounter(t *testing.T) {
-	ext, ds := newInflightRequestsTest(t)
+	ext, ds := newRequestMetadataTest(t)
 
 	// Response carries the original request's max_tokens so the extractor can decrement correctly.
 	batch := []datalayer.Event{
@@ -123,7 +123,7 @@ func TestResponseDecrementsCounter(t *testing.T) {
 		t.Fatalf("Extract failed: %v", err)
 	}
 
-	rc := getInflightRequests(t, ds, "m1")
+	rc := getRequestMetadata(t, ds, "m1")
 	if rc.Requests != 0 {
 		t.Errorf("expected Requests=0, got %d", rc.Requests)
 	}
@@ -133,7 +133,7 @@ func TestResponseDecrementsCounter(t *testing.T) {
 }
 
 func TestCounterFloorsAtZero(t *testing.T) {
-	ext, ds := newInflightRequestsTest(t)
+	ext, ds := newRequestMetadataTest(t)
 
 	// Response with no prior request — both counters must floor at zero.
 	batch := []datalayer.Event{makeResponseEvent("m1", 50, 100)}
@@ -141,7 +141,7 @@ func TestCounterFloorsAtZero(t *testing.T) {
 		t.Fatalf("Extract failed: %v", err)
 	}
 
-	rc := getInflightRequests(t, ds, "m1")
+	rc := getRequestMetadata(t, ds, "m1")
 	if rc.Requests != 0 {
 		t.Errorf("expected Requests=0, got %d", rc.Requests)
 	}
@@ -150,8 +150,8 @@ func TestCounterFloorsAtZero(t *testing.T) {
 	}
 }
 
-func TestInflightRequestsMultipleModels(t *testing.T) {
-	ext, ds := newInflightRequestsTest(t)
+func TestRequestMetadataMultipleModels(t *testing.T) {
+	ext, ds := newRequestMetadataTest(t)
 
 	batch := []datalayer.Event{
 		makeRequestEvent("m1", 10),
@@ -161,19 +161,19 @@ func TestInflightRequestsMultipleModels(t *testing.T) {
 		t.Fatalf("Extract failed: %v", err)
 	}
 
-	rc1 := getInflightRequests(t, ds, "m1")
+	rc1 := getRequestMetadata(t, ds, "m1")
 	if rc1.Requests != 1 || rc1.Tokens != 10 {
 		t.Errorf("m1: expected {Requests:1, Tokens:10}, got %+v", rc1)
 	}
 
-	rc2 := getInflightRequests(t, ds, "m2")
+	rc2 := getRequestMetadata(t, ds, "m2")
 	if rc2.Requests != 1 || rc2.Tokens != 20 {
 		t.Errorf("m2: expected {Requests:1, Tokens:20}, got %+v", rc2)
 	}
 }
 
-func TestInflightRequestsUnknownEventTypeIgnored(t *testing.T) {
-	ext, ds := newInflightRequestsTest(t)
+func TestRequestMetadataUnknownEventTypeIgnored(t *testing.T) {
+	ext, ds := newRequestMetadataTest(t)
 
 	batch := []datalayer.Event{{Type: "unknown"}}
 	if err := ext.Extract(context.Background(), batch); err != nil {
@@ -188,8 +188,8 @@ func TestInflightRequestsUnknownEventTypeIgnored(t *testing.T) {
 	}
 }
 
-func TestInflightRequestsMissingModelFieldIgnored(t *testing.T) {
-	ext, ds := newInflightRequestsTest(t)
+func TestRequestMetadataMissingModelFieldIgnored(t *testing.T) {
+	ext, ds := newRequestMetadataTest(t)
 
 	// Payload without a "model" key — no counter should be updated.
 	req := framework.NewInferenceRequest()


### PR DESCRIPTION
## What does this PR do?

This PR renames the plugin to be request-metadata instead of named inflight-requests

## Why is this change needed?

The inflight-request-extractor should extract request metadata in addition to the request count.

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [X ] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [] Manual testing performed

## Checklist

- [X ] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [X ] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ X] Tests pass locally (`make test`)
- [X ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

