### PR TITLE
Part one of re-organizing interfaces and plugins into their accepted locations

### DIFF
--- a/cmd/runner/runner.go
+++ b/cmd/runner/runner.go
@@ -39,7 +39,8 @@ import (
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/common/observability/profiling"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/common/observability/tracing"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/datastore/inmemory"
-	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/plugin"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/requesthandling"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/plugins/modelselector/picker/maxscore"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/plugins/modelselector/picker/random"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/plugins/modelselector/picker/weightedrandom"
@@ -59,8 +60,8 @@ var setupLog = ctrl.Log.WithName("setup")
 func NewRunner() *Runner {
 	return &Runner{
 		payloadProcessorExecutableName: "payload-processor",
-		requestPlugins:                 []framework.RequestProcessor{},
-		responsePlugins:                []framework.ResponseProcessor{},
+		requestPlugins:                 []requesthandling.RequestProcessor{},
+		responsePlugins:                []requesthandling.ResponseProcessor{},
 		customCollectors:               []prometheus.Collector{},
 	}
 }
@@ -70,10 +71,10 @@ type Runner struct {
 	payloadProcessorExecutableName string
 	// request processing plugin instances executed by the request handler,
 	// in the same order the plugin flags are provided.
-	requestPlugins []framework.RequestProcessor
+	requestPlugins []requesthandling.RequestProcessor
 	// response processing plugin instances executed by the response handler,
 	// in the same order the plugin flags are provided.
-	responsePlugins []framework.ResponseProcessor
+	responsePlugins []requesthandling.ResponseProcessor
 
 	customCollectors []prometheus.Collector
 }
@@ -176,7 +177,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	}
 
 	ds := inmemory.NewDatastore()
-	handle := framework.NewHandle(ctx, mgr, ds)
+	handle := plugin.NewHandle(ctx, mgr, ds)
 
 	// Register factories for all known in-tree plugins
 	r.registerInTreePlugins()
@@ -206,7 +207,7 @@ func (r *Runner) Run(ctx context.Context) error {
 		setupLog.Info("plugins are specified, running with the specified plugins.")
 
 		for _, s := range opts.PluginSpecs {
-			factory, ok := framework.Registry[s.Type]
+			factory, ok := plugin.Registry[s.Type]
 			if !ok {
 				err := fmt.Errorf("unknown plugin type %q (no factory registered)", s.Type)
 				setupLog.Error(err, "Failed to find plugin factory", "pluginType", s.Type)
@@ -217,10 +218,10 @@ func (r *Runner) Run(ctx context.Context) error {
 				setupLog.Error(err, fmt.Sprintf("invalid %s#%s: %v\n", s.Type, s.Name, err))
 				return err
 			}
-			if requestProcessor, ok := instance.(framework.RequestProcessor); ok {
+			if requestProcessor, ok := instance.(requesthandling.RequestProcessor); ok {
 				r.requestPlugins = append(r.requestPlugins, requestProcessor)
 			}
-			if responseProcessor, ok := instance.(framework.ResponseProcessor); ok {
+			if responseProcessor, ok := instance.(requesthandling.ResponseProcessor); ok {
 				r.responsePlugins = append(r.responsePlugins, responseProcessor)
 			}
 		}
@@ -269,14 +270,14 @@ func (r *Runner) Run(ctx context.Context) error {
 
 // registerInTreePlugins registers the factory functions of all known payload processor plugins
 func (r *Runner) registerInTreePlugins() {
-	framework.Register(bodyfieldtoheader.BodyFieldToHeaderPluginType, bodyfieldtoheader.BodyFieldToHeaderPluginFactory)
-	framework.Register(basemodelextractor.BaseModelToHeaderPluginType, basemodelextractor.BaseModelToHeaderPluginFactory)
-	framework.Register(requestmetadata.PluginType, requestmetadata.ExtractorFactory)
-	framework.Register(notificationsource.PluginType, notificationsource.Factory)
+	plugin.Register(bodyfieldtoheader.BodyFieldToHeaderPluginType, bodyfieldtoheader.BodyFieldToHeaderPluginFactory)
+	plugin.Register(basemodelextractor.BaseModelToHeaderPluginType, basemodelextractor.BaseModelToHeaderPluginFactory)
+	plugin.Register(requestmetadata.PluginType, requestmetadata.ExtractorFactory)
+	plugin.Register(notificationsource.PluginType, notificationsource.Factory)
 	// register model selector plugins
-	framework.Register(random.RandomPickerType, random.RandomPickerFactory)
-	framework.Register(maxscore.MaxScorePickerType, maxscore.MaxScorePickerFactory)
-	framework.Register(weightedrandom.WeightedRandomPickerType, weightedrandom.WeightedRandomPickerFactory)
+	plugin.Register(random.RandomPickerType, random.RandomPickerFactory)
+	plugin.Register(maxscore.MaxScorePickerType, maxscore.MaxScorePickerFactory)
+	plugin.Register(weightedrandom.WeightedRandomPickerType, weightedrandom.WeightedRandomPickerFactory)
 
 }
 

--- a/pkg/framework/datalayer/datasource/types.go
+++ b/pkg/framework/datalayer/datasource/types.go
@@ -20,12 +20,13 @@ import (
 	"context"
 	"time"
 
-	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/plugin"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/requesthandling"
 )
 
 // DataSource is the base interface for background data layer components.
 type DataSource interface {
-	framework.Plugin
+	plugin.Plugin
 	Start(ctx context.Context) error
 	// Stop signals the component to shut down and blocks until it has fully stopped.
 	Stop()
@@ -47,13 +48,13 @@ type Event struct {
 
 // RequestPayload is the Payload for RequestEventType.
 type RequestPayload struct {
-	Request *framework.InferenceRequest
+	Request *requesthandling.InferenceRequest
 }
 
 // ResponsePayload is the Payload for ResponseEventType.
 type ResponsePayload struct {
-	Request  *framework.InferenceRequest
-	Response *framework.InferenceResponse
+	Request  *requesthandling.InferenceRequest
+	Response *requesthandling.InferenceResponse
 	Duration time.Duration
 }
 
@@ -74,6 +75,6 @@ type NotificationSource interface {
 
 // Extractor processes a batch of Events. It does not manage its own goroutines.
 type Extractor interface {
-	framework.Plugin
+	plugin.Plugin
 	Extract(ctx context.Context, events []Event) error
 }

--- a/pkg/framework/interface/modelselector/plugins.go
+++ b/pkg/framework/interface/modelselector/plugins.go
@@ -19,14 +19,15 @@ package modelselector
 import (
 	"context"
 
-	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/datalayer"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/plugin"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/requesthandling"
 )
 
 // Filter defines the interface for filtering a list of candidate models based on context.
 type Filter interface {
-	framework.Plugin
-	Filter(ctx context.Context, cycleState *framework.CycleState, request *framework.InferenceRequest, models []datalayer.Model) []datalayer.Model
+	plugin.Plugin
+	Filter(ctx context.Context, cycleState *plugin.CycleState, request *requesthandling.InferenceRequest, models []datalayer.Model) []datalayer.Model
 }
 
 // Scorer defines the interface for scoring a list of models based on context.
@@ -34,12 +35,12 @@ type Filter interface {
 // If a scorer returns value greater than 1, it will be treated as score 1.
 // If a scorer returns value lower than 0, it will be treated as score 0.
 type Scorer interface {
-	framework.Plugin
-	Score(ctx context.Context, cycleState *framework.CycleState, request *framework.InferenceRequest, models []datalayer.Model) map[datalayer.Model]float64
+	plugin.Plugin
+	Score(ctx context.Context, cycleState *plugin.CycleState, request *requesthandling.InferenceRequest, models []datalayer.Model) map[datalayer.Model]float64
 }
 
 // Picker picks the final model(s) to send the request to.
 type Picker interface {
-	framework.Plugin
-	Pick(ctx context.Context, cycleState *framework.CycleState, scoredModels []*ScoredModel) *ProfileRunResult
+	plugin.Plugin
+	Pick(ctx context.Context, cycleState *plugin.CycleState, scoredModels []*ScoredModel) *ProfileRunResult
 }

--- a/pkg/framework/interface/plugin/cycle_state.go
+++ b/pkg/framework/interface/plugin/cycle_state.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package framework
+package plugin
 
 import (
 	"errors"

--- a/pkg/framework/interface/plugin/handle.go
+++ b/pkg/framework/interface/plugin/handle.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package framework
+package plugin
 
 import (
 	"context"

--- a/pkg/framework/interface/plugin/plugins.go
+++ b/pkg/framework/interface/plugin/plugins.go
@@ -14,29 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package framework
-
-import (
-	"context"
-)
+package plugin
 
 // Plugin defines the interface for a plugin.
 // This interface should be embedded in all plugins across the code.
 type Plugin interface {
 	// TypedName returns the type and name tuple of this plugin instance.
 	TypedName() TypedName
-}
-
-type RequestProcessor interface {
-	Plugin
-	// ProcessRequest runs the RequestProcessor plugin.
-	// RequestProcessor can mutate the headers and/or the body of the request.
-	ProcessRequest(ctx context.Context, cycleState *CycleState, request *InferenceRequest) error
-}
-
-type ResponseProcessor interface {
-	Plugin
-	// ProcessResponse runs the ResponseProcessor plugin.
-	// ResponseProcessor can mutate the headers and/or the body of the response.
-	ProcessResponse(ctx context.Context, cycleState *CycleState, response *InferenceResponse) error
 }

--- a/pkg/framework/interface/plugin/registry.go
+++ b/pkg/framework/interface/plugin/registry.go
@@ -14,21 +14,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package framework
+package plugin
 
-const (
-	separator = "/"
+import (
+	"encoding/json"
 )
 
-// TypedName is a utility struct providing a type and a name to plugins.
-type TypedName struct {
-	// Type returns the type of a plugin.
-	Type string
-	// Name returns the name of a plugin instance.
-	Name string
+// Factory is the definition of the factory functions that are used to instantiate plugins
+// specified in a configuration.
+type FactoryFunc func(name string, parameters json.RawMessage, handle Handle) (Plugin, error)
+
+// Register is a static function that can be called to register plugin factory functions.
+func Register(pluginType string, factory FactoryFunc) {
+	Registry[pluginType] = factory
 }
 
-// String returns the type and name rendered as "<name>/<type>".
-func (tn TypedName) String() string {
-	return tn.Name + separator + tn.Type
-}
+// Registry is a mapping from plugin name to Factory function
+var Registry map[string]FactoryFunc = map[string]FactoryFunc{}

--- a/pkg/framework/interface/plugin/typed_name.go
+++ b/pkg/framework/interface/plugin/typed_name.go
@@ -14,20 +14,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package framework
+package plugin
 
-import (
-	"encoding/json"
+const (
+	separator = "/"
 )
 
-// Factory is the definition of the factory functions that are used to instantiate plugins
-// specified in a configuration.
-type FactoryFunc func(name string, parameters json.RawMessage, handle Handle) (Plugin, error)
-
-// Register is a static function that can be called to register plugin factory functions.
-func Register(pluginType string, factory FactoryFunc) {
-	Registry[pluginType] = factory
+// TypedName is a utility struct providing a type and a name to plugins.
+type TypedName struct {
+	// Type returns the type of a plugin.
+	Type string
+	// Name returns the name of a plugin instance.
+	Name string
 }
 
-// Registry is a mapping from plugin name to Factory function
-var Registry map[string]FactoryFunc = map[string]FactoryFunc{}
+// String returns the type and name rendered as "<name>/<type>".
+func (tn TypedName) String() string {
+	return tn.Name + separator + tn.Type
+}

--- a/pkg/framework/interface/requesthandling/plugins.go
+++ b/pkg/framework/interface/requesthandling/plugins.go
@@ -14,26 +14,24 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package modelselector
+package requesthandling
 
 import (
 	"context"
 
-	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/datalayer"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/plugin"
-	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/requesthandling"
 )
 
-type ScoredModel struct {
-	datalayer.Model
-	Score float64
+type RequestProcessor interface {
+	plugin.Plugin
+	// ProcessRequest runs the RequestProcessor plugin.
+	// RequestProcessor can mutate the headers and/or the body of the request.
+	ProcessRequest(ctx context.Context, cycleState *plugin.CycleState, request *InferenceRequest) error
 }
 
-// ProfileRunResult captures the profile run result.
-type ProfileRunResult struct {
-	TargetModel datalayer.Model
-}
-
-type ModelSelectorProfile interface {
-	Run(ctx context.Context, request *requesthandling.InferenceRequest, cycleState *plugin.CycleState, candidateModels []datalayer.Model) (*ProfileRunResult, error)
+type ResponseProcessor interface {
+	plugin.Plugin
+	// ProcessResponse runs the ResponseProcessor plugin.
+	// ResponseProcessor can mutate the headers and/or the body of the response.
+	ProcessResponse(ctx context.Context, cycleState *plugin.CycleState, response *InferenceResponse) error
 }

--- a/pkg/framework/interface/requesthandling/types.go
+++ b/pkg/framework/interface/requesthandling/types.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package framework
+package requesthandling
 
 import (
 	"k8s.io/apimachinery/pkg/util/sets"

--- a/pkg/framework/interface/requesthandling/types_test.go
+++ b/pkg/framework/interface/requesthandling/types_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package framework
+package requesthandling
 
 import (
 	"testing"

--- a/pkg/framework/plugins/modelselector/picker/maxscore/picker.go
+++ b/pkg/framework/plugins/modelselector/picker/maxscore/picker.go
@@ -24,8 +24,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	logutil "github.com/llm-d/llm-d-inference-payload-processor/pkg/common/observability/logging"
-	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/modelselector"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/plugin"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/plugins/modelselector/picker"
 )
 
@@ -38,20 +38,20 @@ const (
 var _ modelselector.Picker = &MaxScorePicker{}
 
 // MaxScorePickerFactory defines the factory function for MaxScorePicker.
-func MaxScorePickerFactory(name string, _ json.RawMessage, _ framework.Handle) (framework.Plugin, error) {
+func MaxScorePickerFactory(name string, _ json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
 	return NewMaxScorePicker().WithName(name), nil
 }
 
 // NewMaxScorePicker initializes a new MaxScorePicker and returns its pointer.
 func NewMaxScorePicker() *MaxScorePicker {
 	return &MaxScorePicker{
-		typedName: framework.TypedName{Type: MaxScorePickerType, Name: MaxScorePickerType},
+		typedName: plugin.TypedName{Type: MaxScorePickerType, Name: MaxScorePickerType},
 	}
 }
 
 // MaxScorePicker picks the model with the highest score calculated during the scoring phase.
 type MaxScorePicker struct {
-	typedName framework.TypedName
+	typedName plugin.TypedName
 }
 
 // WithName sets the plugin name
@@ -61,12 +61,12 @@ func (p *MaxScorePicker) WithName(name string) *MaxScorePicker {
 }
 
 // TypedName returns the type and name tuple of this plugin instance.
-func (p *MaxScorePicker) TypedName() framework.TypedName {
+func (p *MaxScorePicker) TypedName() plugin.TypedName {
 	return p.typedName
 }
 
 // Pick selects the model with the highest score.
-func (p *MaxScorePicker) Pick(ctx context.Context, _ *framework.CycleState, scoredModels []*modelselector.ScoredModel) *modelselector.ProfileRunResult {
+func (p *MaxScorePicker) Pick(ctx context.Context, _ *plugin.CycleState, scoredModels []*modelselector.ScoredModel) *modelselector.ProfileRunResult {
 	log.FromContext(ctx).V(logutil.DEBUG).Info("selecting model from candidates by max score", "numCandidates", len(scoredModels),
 		"scoredModels", scoredModels)
 

--- a/pkg/framework/plugins/modelselector/picker/maxscore/picker_test.go
+++ b/pkg/framework/plugins/modelselector/picker/maxscore/picker_test.go
@@ -20,9 +20,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/datalayer"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/modelselector"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/plugin"
 )
 
 func TestMaxScorePicker(t *testing.T) {
@@ -71,7 +71,7 @@ func TestMaxScorePicker(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := NewMaxScorePicker()
-			result := p.Pick(context.Background(), framework.NewCycleState(), tt.input)
+			result := p.Pick(context.Background(), plugin.NewCycleState(), tt.input)
 
 			if result == nil {
 				t.Fatal("expected result, got nil")

--- a/pkg/framework/plugins/modelselector/picker/random/picker.go
+++ b/pkg/framework/plugins/modelselector/picker/random/picker.go
@@ -27,8 +27,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	logutil "github.com/llm-d/llm-d-inference-payload-processor/pkg/common/observability/logging"
-	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/modelselector"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/plugin"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/plugins/modelselector/picker"
 )
 
@@ -41,20 +41,20 @@ const (
 var _ modelselector.Picker = &RandomPicker{}
 
 // RandomPickerFactory defines the factory function for RandomPicker.
-func RandomPickerFactory(name string, _ json.RawMessage, _ framework.Handle) (framework.Plugin, error) {
+func RandomPickerFactory(name string, _ json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
 	return NewRandomPicker().WithName(name), nil
 }
 
 // NewRandomPicker initializes a new RandomPicker and returns its pointer.
 func NewRandomPicker() *RandomPicker {
 	return &RandomPicker{
-		typedName: framework.TypedName{Type: RandomPickerType, Name: RandomPickerType},
+		typedName: plugin.TypedName{Type: RandomPickerType, Name: RandomPickerType},
 	}
 }
 
 // RandomPicker picks random model from the list of candidates.
 type RandomPicker struct {
-	typedName framework.TypedName
+	typedName plugin.TypedName
 }
 
 // WithName sets the name of the picker.
@@ -64,12 +64,12 @@ func (p *RandomPicker) WithName(name string) *RandomPicker {
 }
 
 // TypedName returns the type and name tuple of this plugin instance.
-func (p *RandomPicker) TypedName() framework.TypedName {
+func (p *RandomPicker) TypedName() plugin.TypedName {
 	return p.typedName
 }
 
 // Pick selects random model from the list of candidates.
-func (p *RandomPicker) Pick(ctx context.Context, _ *framework.CycleState, scoredModels []*modelselector.ScoredModel) *modelselector.ProfileRunResult {
+func (p *RandomPicker) Pick(ctx context.Context, _ *plugin.CycleState, scoredModels []*modelselector.ScoredModel) *modelselector.ProfileRunResult {
 	log.FromContext(ctx).V(logutil.DEBUG).Info("Selecting model from candidates randomly",
 		"numOfCandidates", len(scoredModels), "scoredModels", scoredModels)
 

--- a/pkg/framework/plugins/modelselector/picker/weightedrandom/picker.go
+++ b/pkg/framework/plugins/modelselector/picker/weightedrandom/picker.go
@@ -26,8 +26,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	logutil "github.com/llm-d/llm-d-inference-payload-processor/pkg/common/observability/logging"
-	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/modelselector"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/plugin"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/plugins/modelselector/picker"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/plugins/modelselector/picker/random"
 )
@@ -47,14 +47,14 @@ type weightedScoredModel struct {
 }
 
 // WeightedRandomPickerFactory defines the factory function for WeightedRandomPicker.
-func WeightedRandomPickerFactory(name string, _ json.RawMessage, _ framework.Handle) (framework.Plugin, error) {
+func WeightedRandomPickerFactory(name string, _ json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
 	return NewWeightedRandomPicker().WithName(name), nil
 }
 
 // NewWeightedRandomPicker initializes a new WeightedRandomPicker and returns its pointer.
 func NewWeightedRandomPicker() *WeightedRandomPicker {
 	return &WeightedRandomPicker{
-		typedName:    framework.TypedName{Type: WeightedRandomPickerType, Name: WeightedRandomPickerType},
+		typedName:    plugin.TypedName{Type: WeightedRandomPickerType, Name: WeightedRandomPickerType},
 		randomPicker: random.NewRandomPicker(),
 	}
 }
@@ -73,7 +73,7 @@ func NewWeightedRandomPicker() *WeightedRandomPicker {
 // - Mathematically correct weighted random sampling
 // - Single pass algorithm with O(n + k log k) complexity
 type WeightedRandomPicker struct {
-	typedName    framework.TypedName
+	typedName    plugin.TypedName
 	randomPicker *random.RandomPicker // fallback for zero weights
 
 }
@@ -86,13 +86,13 @@ func (p *WeightedRandomPicker) WithName(name string) *WeightedRandomPicker {
 }
 
 // TypedName returns the type and name tuple of this plugin instance.
-func (p *WeightedRandomPicker) TypedName() framework.TypedName {
+func (p *WeightedRandomPicker) TypedName() plugin.TypedName {
 	return p.typedName
 }
 
 // Pick selects the model randomly from the list of candidates, where the probability of the model to get picked is derived
 // from its weighted score.
-func (p *WeightedRandomPicker) Pick(ctx context.Context, cycleState *framework.CycleState, scoredModels []*modelselector.ScoredModel) *modelselector.ProfileRunResult {
+func (p *WeightedRandomPicker) Pick(ctx context.Context, cycleState *plugin.CycleState, scoredModels []*modelselector.ScoredModel) *modelselector.ProfileRunResult {
 	// Check if there is at least one model with Score > 0, if not let random picker run
 	if slices.IndexFunc(scoredModels, func(scoredModel *modelselector.ScoredModel) bool { return scoredModel.Score > 0 }) == -1 {
 		log.FromContext(ctx).V(logutil.DEBUG).Info("All scores are zero, delegating to RandomPicker for uniform selection")

--- a/pkg/framework/plugins/modelselector/picker/weightedrandom/picker_test.go
+++ b/pkg/framework/plugins/modelselector/picker/weightedrandom/picker_test.go
@@ -20,9 +20,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/datalayer"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/modelselector"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/plugin"
 )
 
 func TestWeightedRandomPicker(t *testing.T) {
@@ -36,7 +36,7 @@ func TestWeightedRandomPicker(t *testing.T) {
 			{Model: modelB, Score: 0.1},
 		}
 
-		result := p.Pick(context.Background(), framework.NewCycleState(), input)
+		result := p.Pick(context.Background(), plugin.NewCycleState(), input)
 		if result == nil {
 			t.Fatal("expected result, got nil")
 		}
@@ -51,7 +51,7 @@ func TestWeightedRandomPicker(t *testing.T) {
 			{Model: modelA, Score: 1.0},
 		}
 
-		result := p.Pick(context.Background(), framework.NewCycleState(), input)
+		result := p.Pick(context.Background(), plugin.NewCycleState(), input)
 		if result.TargetModel.GetName() != "model-a" {
 			t.Errorf("expected model-a, got %q", result.TargetModel.GetName())
 		}
@@ -64,7 +64,7 @@ func TestWeightedRandomPicker(t *testing.T) {
 			{Model: modelB, Score: 0},
 		}
 
-		result := p.Pick(context.Background(), framework.NewCycleState(), input)
+		result := p.Pick(context.Background(), plugin.NewCycleState(), input)
 		if result == nil || result.TargetModel == nil {
 			t.Fatal("expected a result even with zero scores")
 		}
@@ -80,7 +80,7 @@ func TestWeightedRandomPicker(t *testing.T) {
 				{Model: modelA, Score: 0.99},
 				{Model: modelB, Score: 0.01},
 			}
-			result := p.Pick(context.Background(), framework.NewCycleState(), input)
+			result := p.Pick(context.Background(), plugin.NewCycleState(), input)
 			counts[result.TargetModel.GetName()]++
 		}
 

--- a/pkg/framework/plugins/modelselector/scorer/costaware/plugin.go
+++ b/pkg/framework/plugins/modelselector/scorer/costaware/plugin.go
@@ -20,9 +20,10 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/datalayer"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/modelselector"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/plugin"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/requesthandling"
 )
 
 // Package costaware provides a scorer that scores candidate models based on expected cost
@@ -55,25 +56,25 @@ func (p *PriceValue) Clone() datalayer.Cloneable {
 var _ modelselector.Scorer = &CostScorer{}
 
 // CostScorerFactory defines the factory function for the CostScorer scorer
-func CostScorerFactory(name string, _ json.RawMessage, _ framework.Handle) (framework.Plugin, error) {
+func CostScorerFactory(name string, _ json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
 	return NewCostScorer().WithName(name), nil
 }
 
 // NewCostScorer creates a new lowest price scorer
 func NewCostScorer() *CostScorer {
 	return &CostScorer{
-		typedName: framework.TypedName{Type: CostScorerType, Name: CostScorerType},
+		typedName: plugin.TypedName{Type: CostScorerType, Name: CostScorerType},
 	}
 }
 
 // CostScorer scorer that scores models based on their price
 // Lower-priced models receive higher scores
 type CostScorer struct {
-	typedName framework.TypedName
+	typedName plugin.TypedName
 }
 
 // TypedName returns the typed name of the plugin.
-func (s *CostScorer) TypedName() framework.TypedName {
+func (s *CostScorer) TypedName() plugin.TypedName {
 	return s.typedName
 }
 
@@ -90,7 +91,7 @@ func (s *CostScorer) WithName(name string) *CostScorer {
 //   - Higher score indicates better (cheaper) model
 //   - If only one model, it receives neutral score 0.5
 //   - If all models have zero price, each receives score 1.0
-func (s *CostScorer) Score(_ context.Context, _ *framework.CycleState, _ *framework.InferenceRequest, models []datalayer.Model) map[datalayer.Model]float64 {
+func (s *CostScorer) Score(_ context.Context, _ *plugin.CycleState, _ *requesthandling.InferenceRequest, models []datalayer.Model) map[datalayer.Model]float64 {
 	// Create a map to hold the score of each model candidate
 	scores := make(map[datalayer.Model]float64, len(models))
 

--- a/pkg/framework/plugins/modelselector/scorer/costaware/plugin_test.go
+++ b/pkg/framework/plugins/modelselector/scorer/costaware/plugin_test.go
@@ -21,8 +21,9 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/datalayer"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/plugin"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/requesthandling"
 )
 
 // TestFactory tests the Factory function
@@ -82,8 +83,8 @@ func TestWithName(t *testing.T) {
 // TestScore tests the Score method with various scenarios
 func TestScore(t *testing.T) {
 	ctx := context.Background()
-	cycleState := framework.NewCycleState()
-	request := framework.NewInferenceRequest()
+	cycleState := plugin.NewCycleState()
+	request := requesthandling.NewInferenceRequest()
 
 	tests := []struct {
 		name           string

--- a/pkg/handlers/request.go
+++ b/pkg/handlers/request.go
@@ -29,7 +29,8 @@ import (
 	envoy "github.com/llm-d/llm-d-inference-payload-processor/pkg/common/envoy"
 	errcommon "github.com/llm-d/llm-d-inference-payload-processor/pkg/common/error"
 	logutil "github.com/llm-d/llm-d-inference-payload-processor/pkg/common/observability/logging"
-	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/plugin"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/requesthandling"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/metrics"
 )
 
@@ -108,7 +109,7 @@ func (s *Server) HandleRequestBody(ctx context.Context, reqCtx *RequestContext, 
 }
 
 // runRequestPlugins executes request plugins in the order they were registered.
-func (s *Server) runRequestPlugins(ctx context.Context, cycleState *framework.CycleState, request *framework.InferenceRequest) error {
+func (s *Server) runRequestPlugins(ctx context.Context, cycleState *plugin.CycleState, request *requesthandling.InferenceRequest) error {
 	var err error
 	for _, plugin := range s.requestPlugins {
 		log.FromContext(ctx).V(logutil.VERBOSE).Info("Executing request plugin", "plugin", plugin.TypedName())

--- a/pkg/handlers/request_test.go
+++ b/pkg/handlers/request_test.go
@@ -32,7 +32,8 @@ import (
 
 	envoytest "github.com/llm-d/llm-d-inference-payload-processor/pkg/common/envoy/test"
 	logutil "github.com/llm-d/llm-d-inference-payload-processor/pkg/common/observability/logging"
-	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/plugin"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/requesthandling"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/metrics"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/plugins/basemodelextractor"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/plugins/bodyfieldtoheader"
@@ -147,9 +148,9 @@ func TestHandleRequestHeaders(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			server := NewServer([]framework.RequestProcessor{}, []framework.ResponseProcessor{})
+			server := NewServer([]requesthandling.RequestProcessor{}, []requesthandling.ResponseProcessor{})
 			reqCtx := &RequestContext{
-				Request: framework.NewInferenceRequest(),
+				Request: requesthandling.NewInferenceRequest(),
 			}
 
 			resp := server.HandleRequestHeaders(context.Background(), reqCtx, tc.headers)
@@ -476,10 +477,10 @@ func TestHandleRequestBody_BuiltInPlugins(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			modelToHeaderPlugin, _ := bodyfieldtoheader.NewBodyFieldToHeaderPlugin(modelField, bodyfieldtoheader.ModelHeader)
-			server := NewServer([]framework.RequestProcessor{modelToHeaderPlugin, baseModelToHeaderPlugin}, []framework.ResponseProcessor{})
+			server := NewServer([]requesthandling.RequestProcessor{modelToHeaderPlugin, baseModelToHeaderPlugin}, []requesthandling.ResponseProcessor{})
 			reqCtx := &RequestContext{
-				CycleState: framework.NewCycleState(),
-				Request:    framework.NewInferenceRequest(),
+				CycleState: plugin.NewCycleState(),
+				Request:    requesthandling.NewInferenceRequest(),
 			}
 			bodyBytes, _ := json.Marshal(test.body)
 			resp, err := server.HandleRequestBody(ctx, reqCtx, bodyBytes)
@@ -524,10 +525,10 @@ func TestHandleRequestBodyWithPluginMetrics(t *testing.T) {
 
 	modelToHeaderPlugin, _ := bodyfieldtoheader.NewBodyFieldToHeaderPlugin(modelField, bodyfieldtoheader.ModelHeader)
 	baseModelToHeaderPlugin := &basemodelextractor.BaseModelToHeaderPlugin{AdaptersStore: basemodelextractor.NewAdaptersStore()}
-	server := NewServer([]framework.RequestProcessor{modelToHeaderPlugin, baseModelToHeaderPlugin}, []framework.ResponseProcessor{})
+	server := NewServer([]requesthandling.RequestProcessor{modelToHeaderPlugin, baseModelToHeaderPlugin}, []requesthandling.ResponseProcessor{})
 	reqCtx := &RequestContext{
-		CycleState: framework.NewCycleState(),
-		Request:    framework.NewInferenceRequest(),
+		CycleState: plugin.NewCycleState(),
+		Request:    requesthandling.NewInferenceRequest(),
 	}
 
 	bodyBytes, _ := json.Marshal(map[string]any{
@@ -566,22 +567,22 @@ func TestHandleRequestBodyWithPluginMetrics(t *testing.T) {
 
 // === Request Body Tests (multi-plugin header mutations) ===
 
-// fakeRequestPlugin implements framework.RequestProcessor for testing
+// fakeRequestPlugin implements requesthandling.RequestProcessor for testing
 // multi-plugin header mutation scenarios.
 type fakeRequestPlugin struct {
 	name     string
-	mutateFn func(ctx context.Context, request *framework.InferenceRequest) error
+	mutateFn func(ctx context.Context, request *requesthandling.InferenceRequest) error
 }
 
-func (p *fakeRequestPlugin) TypedName() framework.TypedName {
-	return framework.TypedName{Type: "fake", Name: p.name}
+func (p *fakeRequestPlugin) TypedName() plugin.TypedName {
+	return plugin.TypedName{Type: "fake", Name: p.name}
 }
 
-func (p *fakeRequestPlugin) ProcessRequest(ctx context.Context, _ *framework.CycleState, request *framework.InferenceRequest) error {
+func (p *fakeRequestPlugin) ProcessRequest(ctx context.Context, _ *plugin.CycleState, request *requesthandling.InferenceRequest) error {
 	return p.mutateFn(ctx, request)
 }
 
-var _ framework.RequestProcessor = &fakeRequestPlugin{}
+var _ requesthandling.RequestProcessor = &fakeRequestPlugin{}
 
 // TestHandleRequestBody_MultiPluginHeaderMutations tests the end-to-end behavior of
 // HandleRequestBody when multiple request plugins set and/or remove headers.
@@ -591,7 +592,7 @@ func TestHandleRequestBody_MultiPluginHeaderMutations(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		plugins        []framework.RequestProcessor
+		plugins        []requesthandling.RequestProcessor
 		initialHeaders map[string]string
 		wantSetHeaders map[string]string
 		wantRemoved    []string
@@ -603,17 +604,17 @@ func TestHandleRequestBody_MultiPluginHeaderMutations(t *testing.T) {
 			// However, RemoveHeader() does record it in removedHeaders because
 			// the key existed in Headers at the time of removal.
 			name: "set then remove same header - cancels out",
-			plugins: []framework.RequestProcessor{
+			plugins: []requesthandling.RequestProcessor{
 				&fakeRequestPlugin{
 					name: "setter",
-					mutateFn: func(_ context.Context, req *framework.InferenceRequest) error {
+					mutateFn: func(_ context.Context, req *requesthandling.InferenceRequest) error {
 						req.SetHeader("X-Custom", "value1")
 						return nil
 					},
 				},
 				&fakeRequestPlugin{
 					name: "remover",
-					mutateFn: func(_ context.Context, req *framework.InferenceRequest) error {
+					mutateFn: func(_ context.Context, req *requesthandling.InferenceRequest) error {
 						req.RemoveHeader("X-Custom")
 						return nil
 					},
@@ -626,17 +627,17 @@ func TestHandleRequestBody_MultiPluginHeaderMutations(t *testing.T) {
 			// Plugin1 adds a new header, Plugin2 removes a pre-existing one.
 			// Both mutations should appear in the response.
 			name: "set then remove different headers - both apply",
-			plugins: []framework.RequestProcessor{
+			plugins: []requesthandling.RequestProcessor{
 				&fakeRequestPlugin{
 					name: "setter",
-					mutateFn: func(_ context.Context, req *framework.InferenceRequest) error {
+					mutateFn: func(_ context.Context, req *requesthandling.InferenceRequest) error {
 						req.SetHeader("X-New", "hello")
 						return nil
 					},
 				},
 				&fakeRequestPlugin{
 					name: "remover",
-					mutateFn: func(_ context.Context, req *framework.InferenceRequest) error {
+					mutateFn: func(_ context.Context, req *requesthandling.InferenceRequest) error {
 						req.RemoveHeader("X-Existing")
 						return nil
 					},
@@ -654,10 +655,10 @@ func TestHandleRequestBody_MultiPluginHeaderMutations(t *testing.T) {
 			// RemoveHeader on a key that was never in Headers is a no-op:
 			// the guard `if _, ok := r.Headers[key]; ok` prevents any mutation.
 			name: "remove non-existing header - no-op",
-			plugins: []framework.RequestProcessor{
+			plugins: []requesthandling.RequestProcessor{
 				&fakeRequestPlugin{
 					name: "remover",
-					mutateFn: func(_ context.Context, req *framework.InferenceRequest) error {
+					mutateFn: func(_ context.Context, req *requesthandling.InferenceRequest) error {
 						req.RemoveHeader("X-Ghost")
 						return nil
 					},
@@ -671,17 +672,17 @@ func TestHandleRequestBody_MultiPluginHeaderMutations(t *testing.T) {
 			// SetHeader clears the key from removedHeaders, so the final result
 			// is a set with the new value and no removal.
 			name: "remove then set same header - new value wins",
-			plugins: []framework.RequestProcessor{
+			plugins: []requesthandling.RequestProcessor{
 				&fakeRequestPlugin{
 					name: "remover",
-					mutateFn: func(_ context.Context, req *framework.InferenceRequest) error {
+					mutateFn: func(_ context.Context, req *requesthandling.InferenceRequest) error {
 						req.RemoveHeader("X-Reuse")
 						return nil
 					},
 				},
 				&fakeRequestPlugin{
 					name: "setter",
-					mutateFn: func(_ context.Context, req *framework.InferenceRequest) error {
+					mutateFn: func(_ context.Context, req *requesthandling.InferenceRequest) error {
 						req.SetHeader("X-Reuse", "new-value")
 						return nil
 					},
@@ -699,17 +700,17 @@ func TestHandleRequestBody_MultiPluginHeaderMutations(t *testing.T) {
 			// Both plugins set the same header key. Plugins run sequentially,
 			// so the last writer wins.
 			name: "two plugins set same header - last wins",
-			plugins: []framework.RequestProcessor{
+			plugins: []requesthandling.RequestProcessor{
 				&fakeRequestPlugin{
 					name: "setter1",
-					mutateFn: func(_ context.Context, req *framework.InferenceRequest) error {
+					mutateFn: func(_ context.Context, req *requesthandling.InferenceRequest) error {
 						req.SetHeader("X-Shared", "first")
 						return nil
 					},
 				},
 				&fakeRequestPlugin{
 					name: "setter2",
-					mutateFn: func(_ context.Context, req *framework.InferenceRequest) error {
+					mutateFn: func(_ context.Context, req *requesthandling.InferenceRequest) error {
 						req.SetHeader("X-Shared", "second")
 						return nil
 					},
@@ -723,17 +724,17 @@ func TestHandleRequestBody_MultiPluginHeaderMutations(t *testing.T) {
 		{
 			// Two plugins set different header keys. Both should appear in the response.
 			name: "two plugins set different headers - both apply",
-			plugins: []framework.RequestProcessor{
+			plugins: []requesthandling.RequestProcessor{
 				&fakeRequestPlugin{
 					name: "setter-a",
-					mutateFn: func(_ context.Context, req *framework.InferenceRequest) error {
+					mutateFn: func(_ context.Context, req *requesthandling.InferenceRequest) error {
 						req.SetHeader("X-First", "aaa")
 						return nil
 					},
 				},
 				&fakeRequestPlugin{
 					name: "setter-b",
-					mutateFn: func(_ context.Context, req *framework.InferenceRequest) error {
+					mutateFn: func(_ context.Context, req *requesthandling.InferenceRequest) error {
 						req.SetHeader("X-Second", "bbb")
 						return nil
 					},
@@ -750,17 +751,17 @@ func TestHandleRequestBody_MultiPluginHeaderMutations(t *testing.T) {
 			// The second RemoveHeader is a no-op because the header is already gone.
 			// The header should appear exactly once in removedHeaders.
 			name: "two plugins remove same header - idempotent",
-			plugins: []framework.RequestProcessor{
+			plugins: []requesthandling.RequestProcessor{
 				&fakeRequestPlugin{
 					name: "remover1",
-					mutateFn: func(_ context.Context, req *framework.InferenceRequest) error {
+					mutateFn: func(_ context.Context, req *requesthandling.InferenceRequest) error {
 						req.RemoveHeader("X-Dup")
 						return nil
 					},
 				},
 				&fakeRequestPlugin{
 					name: "remover2",
-					mutateFn: func(_ context.Context, req *framework.InferenceRequest) error {
+					mutateFn: func(_ context.Context, req *requesthandling.InferenceRequest) error {
 						req.RemoveHeader("X-Dup")
 						return nil
 					},
@@ -776,10 +777,10 @@ func TestHandleRequestBody_MultiPluginHeaderMutations(t *testing.T) {
 			// A plugin sets a header to the same value it already has.
 			// The SetHeader optimization (types.go:43) should skip the mutation.
 			name: "set existing header to same value - no mutation",
-			plugins: []framework.RequestProcessor{
+			plugins: []requesthandling.RequestProcessor{
 				&fakeRequestPlugin{
 					name: "noop-setter",
-					mutateFn: func(_ context.Context, req *framework.InferenceRequest) error {
+					mutateFn: func(_ context.Context, req *requesthandling.InferenceRequest) error {
 						req.SetHeader("X-Keep", "original")
 						return nil
 					},
@@ -795,10 +796,10 @@ func TestHandleRequestBody_MultiPluginHeaderMutations(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			server := NewServer(tc.plugins, []framework.ResponseProcessor{})
+			server := NewServer(tc.plugins, []requesthandling.ResponseProcessor{})
 			reqCtx := &RequestContext{
-				Request:    framework.NewInferenceRequest(),
-				CycleState: framework.NewCycleState(),
+				Request:    requesthandling.NewInferenceRequest(),
+				CycleState: plugin.NewCycleState(),
 			}
 			for k, v := range tc.initialHeaders {
 				reqCtx.Request.Headers[k] = v
@@ -882,26 +883,26 @@ func buildStreamingResponse(bodyBytes []byte, setHeaders map[string]string, remo
 
 type bodyMutatingPlugin struct {
 	name     string
-	mutateFn func(ctx context.Context, cycleState *framework.CycleState, request *framework.InferenceRequest) error
+	mutateFn func(ctx context.Context, cycleState *plugin.CycleState, request *requesthandling.InferenceRequest) error
 }
 
-func (p *bodyMutatingPlugin) TypedName() framework.TypedName {
-	return framework.TypedName{Type: "fake", Name: p.name}
+func (p *bodyMutatingPlugin) TypedName() plugin.TypedName {
+	return plugin.TypedName{Type: "fake", Name: p.name}
 }
 
-func (p *bodyMutatingPlugin) ProcessRequest(ctx context.Context, cycleState *framework.CycleState, request *framework.InferenceRequest) error {
+func (p *bodyMutatingPlugin) ProcessRequest(ctx context.Context, cycleState *plugin.CycleState, request *requesthandling.InferenceRequest) error {
 	return p.mutateFn(ctx, cycleState, request)
 }
 
-var _ framework.RequestProcessor = &bodyMutatingPlugin{}
+var _ requesthandling.RequestProcessor = &bodyMutatingPlugin{}
 
 func TestHandleRequestBody_BodyMutation(t *testing.T) {
 	metrics.Register()
 	ctx := logutil.NewTestLoggerIntoContext(context.Background())
 
-	plugin := &bodyMutatingPlugin{
+	bodyPlugin := &bodyMutatingPlugin{
 		name: "body-mutator",
-		mutateFn: func(_ context.Context, _ *framework.CycleState, request *framework.InferenceRequest) error {
+		mutateFn: func(_ context.Context, _ *plugin.CycleState, request *requesthandling.InferenceRequest) error {
 			request.SetBodyField("injected", "value")
 			return nil
 		},
@@ -948,10 +949,10 @@ func TestHandleRequestBody_BodyMutation(t *testing.T) {
 	}
 
 	baseModelPlugin := &basemodelextractor.BaseModelToHeaderPlugin{AdaptersStore: basemodelextractor.NewAdaptersStore()}
-	server := NewServer([]framework.RequestProcessor{plugin, baseModelPlugin}, []framework.ResponseProcessor{})
+	server := NewServer([]requesthandling.RequestProcessor{bodyPlugin, baseModelPlugin}, []requesthandling.ResponseProcessor{})
 	reqCtx := &RequestContext{
-		CycleState: framework.NewCycleState(),
-		Request:    framework.NewInferenceRequest(),
+		CycleState: plugin.NewCycleState(),
+		Request:    requesthandling.NewInferenceRequest(),
 	}
 	bodyBytes, _ := json.Marshal(body)
 	resp, err := server.HandleRequestBody(ctx, reqCtx, bodyBytes)

--- a/pkg/handlers/response.go
+++ b/pkg/handlers/response.go
@@ -28,7 +28,8 @@ import (
 
 	envoy "github.com/llm-d/llm-d-inference-payload-processor/pkg/common/envoy"
 	logutil "github.com/llm-d/llm-d-inference-payload-processor/pkg/common/observability/logging"
-	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/plugin"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/requesthandling"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/metrics"
 )
 
@@ -130,7 +131,7 @@ func (s *Server) HandleResponseTrailers(trailers *eppb.HttpTrailers) ([]*eppb.Pr
 }
 
 // runResponsePlugins executes response plugins in the order they were registered.
-func (s *Server) runResponsePlugins(ctx context.Context, cycleState *framework.CycleState, response *framework.InferenceResponse) error {
+func (s *Server) runResponsePlugins(ctx context.Context, cycleState *plugin.CycleState, response *requesthandling.InferenceResponse) error {
 	var err error
 	for _, plugin := range s.responsePlugins {
 		log.FromContext(ctx).V(logutil.VERBOSE).Info("Executing response plugin", "plugin", plugin.TypedName())

--- a/pkg/handlers/response_test.go
+++ b/pkg/handlers/response_test.go
@@ -30,39 +30,40 @@ import (
 
 	envoytest "github.com/llm-d/llm-d-inference-payload-processor/pkg/common/envoy/test"
 	logutil "github.com/llm-d/llm-d-inference-payload-processor/pkg/common/observability/logging"
-	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/plugin"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/requesthandling"
 )
 
 const testPluginValue = "done"
 
-// fakeResponsePlugin implements framework.PayloadProcessor for testing response plugin execution.
+// fakeResponsePlugin implements requesthandling.PayloadProcessor for testing response plugin execution.
 type fakeResponsePlugin struct {
 	name     string
-	mutateFn func(ctx context.Context, cycleState *framework.CycleState, response *framework.InferenceResponse) error
+	mutateFn func(ctx context.Context, cycleState *plugin.CycleState, response *requesthandling.InferenceResponse) error
 }
 
-func (p *fakeResponsePlugin) TypedName() framework.TypedName {
-	return framework.TypedName{Type: "fake", Name: p.name}
+func (p *fakeResponsePlugin) TypedName() plugin.TypedName {
+	return plugin.TypedName{Type: "fake", Name: p.name}
 }
 
-func (p *fakeResponsePlugin) ProcessResponse(ctx context.Context, cycleState *framework.CycleState, response *framework.InferenceResponse) error {
+func (p *fakeResponsePlugin) ProcessResponse(ctx context.Context, cycleState *plugin.CycleState, response *requesthandling.InferenceResponse) error {
 	return p.mutateFn(ctx, cycleState, response)
 }
 
-var _ framework.ResponseProcessor = &fakeResponsePlugin{}
+var _ requesthandling.ResponseProcessor = &fakeResponsePlugin{}
 
 func newTestRequestContext() *RequestContext {
 	return &RequestContext{
-		CycleState: framework.NewCycleState(),
-		Request:    framework.NewInferenceRequest(),
-		Response:   framework.NewInferenceResponse(),
+		CycleState: plugin.NewCycleState(),
+		Request:    requesthandling.NewInferenceRequest(),
+		Response:   requesthandling.NewInferenceResponse(),
 	}
 }
 
 func TestHandleResponseBody_NoPlugins(t *testing.T) {
 	ctx := logutil.NewTestLoggerIntoContext(context.Background())
 
-	server := NewServer([]framework.RequestProcessor{}, []framework.ResponseProcessor{})
+	server := NewServer([]requesthandling.RequestProcessor{}, []requesthandling.ResponseProcessor{})
 	responseBody := []byte(`{"choices":[{"text":"Hello!"}]}`)
 	resp, err := server.HandleResponseBody(ctx, newTestRequestContext(), responseBody)
 	if err != nil {
@@ -103,13 +104,13 @@ func TestHandleResponseBody_SinglePlugin(t *testing.T) {
 
 	mutatePlugin := &fakeResponsePlugin{
 		name: "mutator",
-		mutateFn: func(_ context.Context, _ *framework.CycleState, response *framework.InferenceResponse) error {
+		mutateFn: func(_ context.Context, _ *plugin.CycleState, response *requesthandling.InferenceResponse) error {
 			response.SetBodyField("mutated", true)
 			return nil
 		},
 	}
 
-	server := NewServer([]framework.RequestProcessor{}, []framework.ResponseProcessor{mutatePlugin})
+	server := NewServer([]requesthandling.RequestProcessor{}, []requesthandling.ResponseProcessor{mutatePlugin})
 	responseBody := []byte(`{"choices":[{"text":"Hello!"}]}`)
 	resp, err := server.HandleResponseBody(ctx, newTestRequestContext(), responseBody)
 	if err != nil {
@@ -134,20 +135,20 @@ func TestHandleResponseBody_MultiplePlugins(t *testing.T) {
 
 	plugin1 := &fakeResponsePlugin{
 		name: "plugin1",
-		mutateFn: func(_ context.Context, _ *framework.CycleState, response *framework.InferenceResponse) error {
+		mutateFn: func(_ context.Context, _ *plugin.CycleState, response *requesthandling.InferenceResponse) error {
 			response.SetBodyField("p1", testPluginValue)
 			return nil
 		},
 	}
 	plugin2 := &fakeResponsePlugin{
 		name: "plugin2",
-		mutateFn: func(_ context.Context, _ *framework.CycleState, response *framework.InferenceResponse) error {
+		mutateFn: func(_ context.Context, _ *plugin.CycleState, response *requesthandling.InferenceResponse) error {
 			response.SetBodyField("p2", testPluginValue)
 			return nil
 		},
 	}
 
-	server := NewServer([]framework.RequestProcessor{}, []framework.ResponseProcessor{plugin1, plugin2})
+	server := NewServer([]requesthandling.RequestProcessor{}, []requesthandling.ResponseProcessor{plugin1, plugin2})
 	responseBody := []byte(`{"original":true}`)
 	resp, err := server.HandleResponseBody(ctx, newTestRequestContext(), responseBody)
 	if err != nil {
@@ -173,12 +174,12 @@ func TestHandleResponseBody_PluginError(t *testing.T) {
 
 	failingPlugin := &fakeResponsePlugin{
 		name: "failing",
-		mutateFn: func(_ context.Context, _ *framework.CycleState, _ *framework.InferenceResponse) error {
+		mutateFn: func(_ context.Context, _ *plugin.CycleState, _ *requesthandling.InferenceResponse) error {
 			return errors.New("failed to execute plugin")
 		},
 	}
 
-	server := NewServer([]framework.RequestProcessor{}, []framework.ResponseProcessor{failingPlugin})
+	server := NewServer([]requesthandling.RequestProcessor{}, []requesthandling.ResponseProcessor{failingPlugin})
 	responseBody := []byte(`{"choices":[{"text":"some response"}]}`)
 	_, err := server.HandleResponseBody(ctx, newTestRequestContext(), responseBody)
 	if err == nil {
@@ -195,13 +196,13 @@ func TestHandleResponseBody_StreamingWithPlugin(t *testing.T) {
 
 	mutatePlugin := &fakeResponsePlugin{
 		name: "mutator",
-		mutateFn: func(_ context.Context, _ *framework.CycleState, response *framework.InferenceResponse) error {
+		mutateFn: func(_ context.Context, _ *plugin.CycleState, response *requesthandling.InferenceResponse) error {
 			response.SetBodyField("mutated", true)
 			return nil
 		},
 	}
 
-	server := NewServer([]framework.RequestProcessor{}, []framework.ResponseProcessor{mutatePlugin})
+	server := NewServer([]requesthandling.RequestProcessor{}, []requesthandling.ResponseProcessor{mutatePlugin})
 	responseBody := []byte(`{"choices":[{"text":"Hello!"}]}`)
 	resp, err := server.HandleResponseBody(ctx, newTestRequestContext(), responseBody)
 	if err != nil {
@@ -226,7 +227,7 @@ func TestHandleResponseBody_PluginNoBodyMutation(t *testing.T) {
 
 	headerOnlyPlugin := &fakeResponsePlugin{
 		name: "header-only",
-		mutateFn: func(_ context.Context, _ *framework.CycleState, response *framework.InferenceResponse) error {
+		mutateFn: func(_ context.Context, _ *plugin.CycleState, response *requesthandling.InferenceResponse) error {
 			response.SetHeader("X-Custom-Response", "added")
 			return nil
 		},
@@ -271,7 +272,7 @@ func TestHandleResponseBody_PluginNoBodyMutation(t *testing.T) {
 		},
 	}
 
-	server := NewServer([]framework.RequestProcessor{}, []framework.ResponseProcessor{headerOnlyPlugin})
+	server := NewServer([]requesthandling.RequestProcessor{}, []requesthandling.ResponseProcessor{headerOnlyPlugin})
 	resp, err := server.HandleResponseBody(ctx, newTestRequestContext(), responseBody)
 	if err != nil {
 		t.Fatalf("HandleResponseBody returned unexpected error: %v", err)

--- a/pkg/handlers/server.go
+++ b/pkg/handlers/server.go
@@ -33,7 +33,8 @@ import (
 	envoy "github.com/llm-d/llm-d-inference-payload-processor/pkg/common/envoy"
 	errcommon "github.com/llm-d/llm-d-inference-payload-processor/pkg/common/error"
 	logutil "github.com/llm-d/llm-d-inference-payload-processor/pkg/common/observability/logging"
-	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/plugin"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/requesthandling"
 	"github.com/llm-d/llm-d-inference-payload-processor/version"
 )
 
@@ -45,7 +46,7 @@ const (
 	responsePluginExtensionPoint = "response"
 )
 
-func NewServer(requestPlugins []framework.RequestProcessor, responsePlugins []framework.ResponseProcessor) *Server {
+func NewServer(requestPlugins []requesthandling.RequestProcessor, responsePlugins []requesthandling.ResponseProcessor) *Server {
 	return &Server{
 		requestPlugins:  requestPlugins,
 		responsePlugins: responsePlugins,
@@ -55,17 +56,17 @@ func NewServer(requestPlugins []framework.RequestProcessor, responsePlugins []fr
 // Server implements the Envoy external processing server.
 // https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/ext_proc/v3/external_processor.proto
 type Server struct {
-	requestPlugins  []framework.RequestProcessor
-	responsePlugins []framework.ResponseProcessor
+	requestPlugins  []requesthandling.RequestProcessor
+	responsePlugins []requesthandling.ResponseProcessor
 }
 
 // RequestContext stores context information during the lifetime of an HTTP request.
 type RequestContext struct {
 	RequestReceivedTimestamp  time.Time
 	ResponseCompleteTimestamp time.Time
-	CycleState                *framework.CycleState
-	Request                   *framework.InferenceRequest
-	Response                  *framework.InferenceResponse
+	CycleState                *plugin.CycleState
+	Request                   *requesthandling.InferenceRequest
+	Response                  *requesthandling.InferenceResponse
 }
 
 func (s *Server) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
@@ -87,9 +88,9 @@ func (s *Server) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
 	loggerVerbose.Info("Processing")
 
 	reqCtx := &RequestContext{
-		Request:    framework.NewInferenceRequest(),
-		Response:   framework.NewInferenceResponse(),
-		CycleState: framework.NewCycleState(),
+		Request:    requesthandling.NewInferenceRequest(),
+		Response:   requesthandling.NewInferenceResponse(),
+		CycleState: plugin.NewCycleState(),
 	}
 	// TODO set a max cap on these.
 	// both requestBody and responseBody accumulate without an upper bound.

--- a/pkg/handlers/server_test.go
+++ b/pkg/handlers/server_test.go
@@ -29,7 +29,8 @@ import (
 
 	envoytest "github.com/llm-d/llm-d-inference-payload-processor/pkg/common/envoy/test"
 	logutil "github.com/llm-d/llm-d-inference-payload-processor/pkg/common/observability/logging"
-	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/plugin"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/requesthandling"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/plugins/basemodelextractor"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/plugins/bodyfieldtoheader"
 	"github.com/llm-d/llm-d-inference-payload-processor/test/utils"
@@ -91,10 +92,10 @@ func TestHandleRequestBody(t *testing.T) {
 
 	baseModelToHeaderPlugin := &basemodelextractor.BaseModelToHeaderPlugin{AdaptersStore: basemodelextractor.NewAdaptersStore()}
 	modelToHeaderPlugin, _ := bodyfieldtoheader.NewBodyFieldToHeaderPlugin(modelField, bodyfieldtoheader.ModelHeader)
-	srv := NewServer([]framework.RequestProcessor{modelToHeaderPlugin, baseModelToHeaderPlugin}, []framework.ResponseProcessor{})
+	srv := NewServer([]requesthandling.RequestProcessor{modelToHeaderPlugin, baseModelToHeaderPlugin}, []requesthandling.ResponseProcessor{})
 	reqCtx := &RequestContext{
-		CycleState: framework.NewCycleState(),
-		Request:    framework.NewInferenceRequest(),
+		CycleState: plugin.NewCycleState(),
+		Request:    requesthandling.NewInferenceRequest(),
 	}
 	got, err := srv.HandleRequestBody(ctx, reqCtx, b)
 	if err != nil {
@@ -113,7 +114,7 @@ func TestHandleResponseBody_Streaming(t *testing.T) {
 	ctx := logutil.NewTestLoggerIntoContext(context.Background())
 	wantFullBody := []byte(`{"choices":[{"text":"Hello!"}]}`)
 
-	ref := NewServer([]framework.RequestProcessor{}, []framework.ResponseProcessor{})
+	ref := NewServer([]requesthandling.RequestProcessor{}, []requesthandling.ResponseProcessor{})
 	want, err := ref.HandleResponseBody(ctx, newTestRequestContext(), wantFullBody)
 	if err != nil {
 		t.Fatalf("reference HandleResponseBody: %v", err)
@@ -153,7 +154,7 @@ func TestHandleResponseBody_Streaming(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			streamCtx, cancel := context.WithCancel(logutil.NewTestLoggerIntoContext(context.Background()))
-			srv := NewServer([]framework.RequestProcessor{}, []framework.ResponseProcessor{})
+			srv := NewServer([]requesthandling.RequestProcessor{}, []requesthandling.ResponseProcessor{})
 			testListener, errChan := utils.SetupTestStreamingServer(t, streamCtx, srv)
 			process, conn := utils.GetStreamingServerClient(streamCtx, t)
 			defer conn.Close()

--- a/pkg/modelselector/model_selector_profile.go
+++ b/pkg/modelselector/model_selector_profile.go
@@ -26,9 +26,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	logutil "github.com/llm-d/llm-d-inference-payload-processor/pkg/common/observability/logging"
-	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/datalayer"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/modelselector"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/plugin"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/requesthandling"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/metrics"
 )
 
@@ -78,7 +79,7 @@ func (p *ModelSelectorProfile) WithPicker(picker modelselector.Picker) *ModelSel
 // A plugin may implement more than one interface.
 // Special Case: In order to add a scorer, one must use NewWeightedScorer in order to provide a weight.
 // If a scorer implements more than one interface, supplying a WeightedScorer is sufficient.
-func (p *ModelSelectorProfile) AddPlugins(pluginObjects ...framework.Plugin) error {
+func (p *ModelSelectorProfile) AddPlugins(pluginObjects ...plugin.Plugin) error {
 	// Validate all plugins before modifying state to avoid inconsistent profile
 	var newFilters []modelselector.Filter
 	var newScorers []*WeightedScorer
@@ -139,7 +140,7 @@ func (p *ModelSelectorProfile) String() string {
 }
 
 // Run runs the ModelSelectorProfile pipeline: Filter → Score → Pick.
-func (p *ModelSelectorProfile) Run(ctx context.Context, request *framework.InferenceRequest, cycleState *framework.CycleState, candidateModels []datalayer.Model) (*modelselector.ProfileRunResult, error) {
+func (p *ModelSelectorProfile) Run(ctx context.Context, request *requesthandling.InferenceRequest, cycleState *plugin.CycleState, candidateModels []datalayer.Model) (*modelselector.ProfileRunResult, error) {
 	models := p.runFilterPlugins(ctx, request, cycleState, candidateModels)
 	if len(models) == 0 {
 		return nil, errors.New("no models available after filtering")
@@ -152,7 +153,7 @@ func (p *ModelSelectorProfile) Run(ctx context.Context, request *framework.Infer
 	return result, nil
 }
 
-func (p *ModelSelectorProfile) runFilterPlugins(ctx context.Context, request *framework.InferenceRequest, cycleState *framework.CycleState, models []datalayer.Model) []datalayer.Model {
+func (p *ModelSelectorProfile) runFilterPlugins(ctx context.Context, request *requesthandling.InferenceRequest, cycleState *plugin.CycleState, models []datalayer.Model) []datalayer.Model {
 	logger := log.FromContext(ctx)
 	filteredModels := models
 	logger.V(logutil.DEBUG).Info("Before running filter plugins", "models", len(filteredModels))
@@ -173,7 +174,7 @@ func (p *ModelSelectorProfile) runFilterPlugins(ctx context.Context, request *fr
 	return filteredModels
 }
 
-func (p *ModelSelectorProfile) runScorerPlugins(ctx context.Context, request *framework.InferenceRequest, cycleState *framework.CycleState, models []datalayer.Model) map[string]*modelselector.ScoredModel {
+func (p *ModelSelectorProfile) runScorerPlugins(ctx context.Context, request *requesthandling.InferenceRequest, cycleState *plugin.CycleState, models []datalayer.Model) map[string]*modelselector.ScoredModel {
 	logger := log.FromContext(ctx)
 
 	scoredModels := make(map[string]*modelselector.ScoredModel, len(models))
@@ -198,7 +199,7 @@ func (p *ModelSelectorProfile) runScorerPlugins(ctx context.Context, request *fr
 	return scoredModels
 }
 
-func (p *ModelSelectorProfile) runPickerPlugin(ctx context.Context, cycleState *framework.CycleState, scoredModelMap map[string]*modelselector.ScoredModel) *modelselector.ProfileRunResult {
+func (p *ModelSelectorProfile) runPickerPlugin(ctx context.Context, cycleState *plugin.CycleState, scoredModelMap map[string]*modelselector.ScoredModel) *modelselector.ProfileRunResult {
 	logger := log.FromContext(ctx)
 
 	scoredModels := make([]*modelselector.ScoredModel, len(scoredModelMap))

--- a/pkg/modelselector/model_selector_profile_test.go
+++ b/pkg/modelselector/model_selector_profile_test.go
@@ -20,19 +20,20 @@ import (
 	"context"
 	"testing"
 
-	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/datalayer"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/modelselector"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/plugin"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/requesthandling"
 )
 
 type testFilter struct {
-	typedName framework.TypedName
+	typedName plugin.TypedName
 	filterFn  func(models []datalayer.Model) []datalayer.Model
 	callCount int
 }
 
-func (f *testFilter) TypedName() framework.TypedName { return f.typedName }
-func (f *testFilter) Filter(_ context.Context, _ *framework.CycleState, _ *framework.InferenceRequest, models []datalayer.Model) []datalayer.Model {
+func (f *testFilter) TypedName() plugin.TypedName { return f.typedName }
+func (f *testFilter) Filter(_ context.Context, _ *plugin.CycleState, _ *requesthandling.InferenceRequest, models []datalayer.Model) []datalayer.Model {
 	f.callCount++
 	if f.filterFn != nil {
 		return f.filterFn(models)
@@ -41,13 +42,13 @@ func (f *testFilter) Filter(_ context.Context, _ *framework.CycleState, _ *frame
 }
 
 type testScorer struct {
-	typedName framework.TypedName
+	typedName plugin.TypedName
 	scoreFn   func(models []datalayer.Model) map[datalayer.Model]float64
 	callCount int
 }
 
-func (s *testScorer) TypedName() framework.TypedName { return s.typedName }
-func (s *testScorer) Score(_ context.Context, _ *framework.CycleState, _ *framework.InferenceRequest, models []datalayer.Model) map[datalayer.Model]float64 {
+func (s *testScorer) TypedName() plugin.TypedName { return s.typedName }
+func (s *testScorer) Score(_ context.Context, _ *plugin.CycleState, _ *requesthandling.InferenceRequest, models []datalayer.Model) map[datalayer.Model]float64 {
 	s.callCount++
 	if s.scoreFn != nil {
 		return s.scoreFn(models)
@@ -60,12 +61,12 @@ func (s *testScorer) Score(_ context.Context, _ *framework.CycleState, _ *framew
 }
 
 type testPicker struct {
-	typedName framework.TypedName
+	typedName plugin.TypedName
 	callCount int
 }
 
-func (p *testPicker) TypedName() framework.TypedName { return p.typedName }
-func (p *testPicker) Pick(_ context.Context, _ *framework.CycleState, scoredModels []*modelselector.ScoredModel) *modelselector.ProfileRunResult {
+func (p *testPicker) TypedName() plugin.TypedName { return p.typedName }
+func (p *testPicker) Pick(_ context.Context, _ *plugin.CycleState, scoredModels []*modelselector.ScoredModel) *modelselector.ProfileRunResult {
 	p.callCount++
 	if len(scoredModels) == 0 {
 		return nil
@@ -96,7 +97,7 @@ func TestProfileRun(t *testing.T) {
 			name:   "basic selection with scorer",
 			models: []datalayer.Model{modelA, modelB, modelC},
 			scorer: &testScorer{
-				typedName: framework.TypedName{Type: "test-scorer", Name: "cost"},
+				typedName: plugin.TypedName{Type: "test-scorer", Name: "cost"},
 				scoreFn: func(models []datalayer.Model) map[datalayer.Model]float64 {
 					scores := make(map[datalayer.Model]float64)
 					for _, m := range models {
@@ -118,7 +119,7 @@ func TestProfileRun(t *testing.T) {
 			name:   "filter removes models before scoring",
 			models: []datalayer.Model{modelA, modelB, modelC},
 			filter: &testFilter{
-				typedName: framework.TypedName{Type: "test-filter", Name: "availability"},
+				typedName: plugin.TypedName{Type: "test-filter", Name: "availability"},
 				filterFn: func(models []datalayer.Model) []datalayer.Model {
 					var result []datalayer.Model
 					for _, m := range models {
@@ -130,7 +131,7 @@ func TestProfileRun(t *testing.T) {
 				},
 			},
 			scorer: &testScorer{
-				typedName: framework.TypedName{Type: "test-scorer", Name: "cost"},
+				typedName: plugin.TypedName{Type: "test-scorer", Name: "cost"},
 				scoreFn: func(models []datalayer.Model) map[datalayer.Model]float64 {
 					scores := make(map[datalayer.Model]float64)
 					for _, m := range models {
@@ -150,7 +151,7 @@ func TestProfileRun(t *testing.T) {
 			name:   "all models filtered returns error",
 			models: []datalayer.Model{modelA, modelB},
 			filter: &testFilter{
-				typedName: framework.TypedName{Type: "test-filter", Name: "block-all"},
+				typedName: plugin.TypedName{Type: "test-filter", Name: "block-all"},
 				filterFn: func(_ []datalayer.Model) []datalayer.Model {
 					return []datalayer.Model{}
 				},
@@ -166,7 +167,7 @@ func TestProfileRun(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			picker := &testPicker{typedName: framework.TypedName{Type: "test-picker", Name: "max-score"}}
+			picker := &testPicker{typedName: plugin.TypedName{Type: "test-picker", Name: "max-score"}}
 			profile := NewModelSelectorProfile().WithPicker(picker)
 
 			if tt.filter != nil {
@@ -176,7 +177,7 @@ func TestProfileRun(t *testing.T) {
 				profile.WithScorers(NewWeightedScorer(tt.scorer, 1.0))
 			}
 
-			result, err := profile.Run(context.Background(), framework.NewInferenceRequest(), framework.NewCycleState(), tt.models)
+			result, err := profile.Run(context.Background(), requesthandling.NewInferenceRequest(), plugin.NewCycleState(), tt.models)
 
 			if tt.wantErr {
 				if err == nil {
@@ -202,7 +203,7 @@ func TestScoreWeightAccumulation(t *testing.T) {
 	modelB := datalayer.NewModel("model-b")
 
 	scorer1 := &testScorer{
-		typedName: framework.TypedName{Type: "test-scorer", Name: "cost"},
+		typedName: plugin.TypedName{Type: "test-scorer", Name: "cost"},
 		scoreFn: func(models []datalayer.Model) map[datalayer.Model]float64 {
 			scores := make(map[datalayer.Model]float64)
 			for _, m := range models {
@@ -216,7 +217,7 @@ func TestScoreWeightAccumulation(t *testing.T) {
 		},
 	}
 	scorer2 := &testScorer{
-		typedName: framework.TypedName{Type: "test-scorer", Name: "latency"},
+		typedName: plugin.TypedName{Type: "test-scorer", Name: "latency"},
 		scoreFn: func(models []datalayer.Model) map[datalayer.Model]float64 {
 			scores := make(map[datalayer.Model]float64)
 			for _, m := range models {
@@ -231,12 +232,12 @@ func TestScoreWeightAccumulation(t *testing.T) {
 	}
 
 	// cost weight=3, latency weight=1 → model-a should win (3*1.0 + 1*0.0 = 3.0 vs 3*0.0 + 1*1.0 = 1.0)
-	picker := &testPicker{typedName: framework.TypedName{Type: "test-picker", Name: "max-score"}}
+	picker := &testPicker{typedName: plugin.TypedName{Type: "test-picker", Name: "max-score"}}
 	profile := NewModelSelectorProfile().
 		WithScorers(NewWeightedScorer(scorer1, 3.0), NewWeightedScorer(scorer2, 1.0)).
 		WithPicker(picker)
 
-	result, err := profile.Run(context.Background(), framework.NewInferenceRequest(), framework.NewCycleState(), []datalayer.Model{modelA, modelB})
+	result, err := profile.Run(context.Background(), requesthandling.NewInferenceRequest(), plugin.NewCycleState(), []datalayer.Model{modelA, modelB})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -273,7 +274,7 @@ func TestScoreRangeEnforcement(t *testing.T) {
 func TestAddPlugins(t *testing.T) {
 	t.Run("scorer without weight returns error", func(t *testing.T) {
 		profile := NewModelSelectorProfile()
-		scorer := &testScorer{typedName: framework.TypedName{Type: "test-scorer", Name: "cost"}}
+		scorer := &testScorer{typedName: plugin.TypedName{Type: "test-scorer", Name: "cost"}}
 		err := profile.AddPlugins(scorer)
 		if err == nil {
 			t.Fatal("expected error for scorer without weight")
@@ -282,8 +283,8 @@ func TestAddPlugins(t *testing.T) {
 
 	t.Run("duplicate picker returns error", func(t *testing.T) {
 		profile := NewModelSelectorProfile()
-		picker1 := &testPicker{typedName: framework.TypedName{Type: "test-picker", Name: "first"}}
-		picker2 := &testPicker{typedName: framework.TypedName{Type: "test-picker", Name: "second"}}
+		picker1 := &testPicker{typedName: plugin.TypedName{Type: "test-picker", Name: "first"}}
+		picker2 := &testPicker{typedName: plugin.TypedName{Type: "test-picker", Name: "second"}}
 		if err := profile.AddPlugins(picker1); err != nil {
 			t.Fatalf("first picker should succeed: %v", err)
 		}
@@ -295,7 +296,7 @@ func TestAddPlugins(t *testing.T) {
 
 	t.Run("weighted scorer registered correctly", func(t *testing.T) {
 		profile := NewModelSelectorProfile()
-		scorer := &testScorer{typedName: framework.TypedName{Type: "test-scorer", Name: "cost"}}
+		scorer := &testScorer{typedName: plugin.TypedName{Type: "test-scorer", Name: "cost"}}
 		ws := NewWeightedScorer(scorer, 2.0)
 		if err := profile.AddPlugins(ws); err != nil {
 			t.Fatalf("unexpected error: %v", err)

--- a/pkg/modelselector/modelselector.go
+++ b/pkg/modelselector/modelselector.go
@@ -24,9 +24,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	logutil "github.com/llm-d/llm-d-inference-payload-processor/pkg/common/observability/logging"
-	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/datalayer"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/modelselector"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/plugin"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/requesthandling"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/metrics"
 )
 
@@ -43,7 +44,7 @@ type ModelSelector struct {
 }
 
 // Select runs the model selection pipeline (Filter → Score → Pick) and returns the selected model.
-func (s *ModelSelector) Select(ctx context.Context, request *framework.InferenceRequest, cycleState *framework.CycleState, candidateModels []datalayer.Model) (result *modelselector.ProfileRunResult, err error) {
+func (s *ModelSelector) Select(ctx context.Context, request *requesthandling.InferenceRequest, cycleState *plugin.CycleState, candidateModels []datalayer.Model) (result *modelselector.ProfileRunResult, err error) {
 	logger := log.FromContext(ctx)
 	logger.V(logutil.VERBOSE).Info("Starting model selection", "candidateModels", len(candidateModels))
 

--- a/pkg/modelselector/modelselector_test.go
+++ b/pkg/modelselector/modelselector_test.go
@@ -20,8 +20,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/datalayer"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/plugin"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/requesthandling"
 )
 
 func TestSelect(t *testing.T) {
@@ -54,7 +55,7 @@ func TestSelect(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			scorer := &testScorer{
-				typedName: framework.TypedName{Type: "test-scorer", Name: "cost"},
+				typedName: plugin.TypedName{Type: "test-scorer", Name: "cost"},
 				scoreFn: func(models []datalayer.Model) map[datalayer.Model]float64 {
 					scores := make(map[datalayer.Model]float64)
 					for _, m := range models {
@@ -67,7 +68,7 @@ func TestSelect(t *testing.T) {
 					return scores
 				},
 			}
-			picker := &testPicker{typedName: framework.TypedName{Type: "test-picker", Name: "max-score"}}
+			picker := &testPicker{typedName: plugin.TypedName{Type: "test-picker", Name: "max-score"}}
 
 			profile := NewModelSelectorProfile().
 				WithScorers(NewWeightedScorer(scorer, 1.0)).
@@ -75,7 +76,7 @@ func TestSelect(t *testing.T) {
 
 			selector := NewModelSelector(profile)
 
-			result, err := selector.Select(context.Background(), framework.NewInferenceRequest(), framework.NewCycleState(), tt.models)
+			result, err := selector.Select(context.Background(), requesthandling.NewInferenceRequest(), plugin.NewCycleState(), tt.models)
 
 			if tt.wantErr {
 				if err == nil {
@@ -102,7 +103,7 @@ func TestSelectWithFilterAndScorer(t *testing.T) {
 	modelC := datalayer.NewModel("mistral-7b")
 
 	filter := &testFilter{
-		typedName: framework.TypedName{Type: "test-filter", Name: "rate-limit"},
+		typedName: plugin.TypedName{Type: "test-filter", Name: "rate-limit"},
 		filterFn: func(models []datalayer.Model) []datalayer.Model {
 			var result []datalayer.Model
 			for _, m := range models {
@@ -115,7 +116,7 @@ func TestSelectWithFilterAndScorer(t *testing.T) {
 	}
 
 	scorer := &testScorer{
-		typedName: framework.TypedName{Type: "test-scorer", Name: "cost"},
+		typedName: plugin.TypedName{Type: "test-scorer", Name: "cost"},
 		scoreFn: func(models []datalayer.Model) map[datalayer.Model]float64 {
 			scores := make(map[datalayer.Model]float64)
 			for _, m := range models {
@@ -130,7 +131,7 @@ func TestSelectWithFilterAndScorer(t *testing.T) {
 		},
 	}
 
-	picker := &testPicker{typedName: framework.TypedName{Type: "test-picker", Name: "max-score"}}
+	picker := &testPicker{typedName: plugin.TypedName{Type: "test-picker", Name: "max-score"}}
 
 	profile := NewModelSelectorProfile().
 		WithFilters(filter).
@@ -139,7 +140,7 @@ func TestSelectWithFilterAndScorer(t *testing.T) {
 
 	selector := NewModelSelector(profile)
 
-	result, err := selector.Select(context.Background(), framework.NewInferenceRequest(), framework.NewCycleState(), []datalayer.Model{modelA, modelB, modelC})
+	result, err := selector.Select(context.Background(), requesthandling.NewInferenceRequest(), plugin.NewCycleState(), []datalayer.Model{modelA, modelB, modelC})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/plugins/basemodelextractor/base_model_to_header.go
+++ b/pkg/plugins/basemodelextractor/base_model_to_header.go
@@ -27,7 +27,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	logutil "github.com/llm-d/llm-d-inference-payload-processor/pkg/common/observability/logging"
-	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/plugin"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/requesthandling"
 )
 
 const (
@@ -37,15 +38,15 @@ const (
 )
 
 // compile-time type validation
-var _ framework.RequestProcessor = &BaseModelToHeaderPlugin{}
+var _ requesthandling.RequestProcessor = &BaseModelToHeaderPlugin{}
 
 type BaseModelToHeaderPlugin struct {
-	typedName     framework.TypedName
+	typedName     plugin.TypedName
 	AdaptersStore AdaptersStore
 }
 
 // BaseModelToHeaderPluginFactory defines the factory function for BaseModelToHeaderPlugin
-func BaseModelToHeaderPluginFactory(name string, _ json.RawMessage, handle framework.Handle) (framework.Plugin, error) {
+func BaseModelToHeaderPluginFactory(name string, _ json.RawMessage, handle plugin.Handle) (plugin.Plugin, error) {
 	plugin, err := NewBaseModelToHeaderPlugin(handle.ReconcilerBuilder, handle.Client())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create plugin '%s' - %w", BaseModelToHeaderPluginType, err)
@@ -67,13 +68,13 @@ func NewBaseModelToHeaderPlugin(reconcilerBuilder func() *builder.Builder, clien
 	}
 
 	return &BaseModelToHeaderPlugin{
-		typedName:     framework.TypedName{Type: BaseModelToHeaderPluginType, Name: BaseModelToHeaderPluginType},
+		typedName:     plugin.TypedName{Type: BaseModelToHeaderPluginType, Name: BaseModelToHeaderPluginType},
 		AdaptersStore: adaptersStore,
 	}, nil
 }
 
 // TypedName returns the type and name tuple of this plugin instance.
-func (p *BaseModelToHeaderPlugin) TypedName() framework.TypedName {
+func (p *BaseModelToHeaderPlugin) TypedName() plugin.TypedName {
 	return p.typedName
 }
 
@@ -84,7 +85,7 @@ func (p *BaseModelToHeaderPlugin) WithName(name string) *BaseModelToHeaderPlugin
 }
 
 // ProcessRequest sets base model name on the header
-func (p *BaseModelToHeaderPlugin) ProcessRequest(ctx context.Context, _ *framework.CycleState, request *framework.InferenceRequest) error {
+func (p *BaseModelToHeaderPlugin) ProcessRequest(ctx context.Context, _ *plugin.CycleState, request *requesthandling.InferenceRequest) error {
 	// extract raw field value from body
 	rawFieldValue, exists := request.Body[modelField]
 	if !exists {

--- a/pkg/plugins/basemodelextractor/base_model_to_header_test.go
+++ b/pkg/plugins/basemodelextractor/base_model_to_header_test.go
@@ -29,7 +29,8 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/datastore"
-	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/plugin"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/requesthandling"
 )
 
 const (
@@ -40,7 +41,7 @@ const (
 // TestBaseModelToHeaderPlugin_TypedName tests the TypedName method returns correct type and name.
 func TestBaseModelToHeaderPlugin_TypedName(t *testing.T) {
 	p := &BaseModelToHeaderPlugin{
-		typedName:     framework.TypedName{Type: BaseModelToHeaderPluginType, Name: "test-plugin"},
+		typedName:     plugin.TypedName{Type: BaseModelToHeaderPluginType, Name: "test-plugin"},
 		AdaptersStore: NewAdaptersStore(),
 	}
 
@@ -56,7 +57,7 @@ func TestBaseModelToHeaderPlugin_TypedName(t *testing.T) {
 // TestBaseModelToHeaderPlugin_WithName tests that WithName correctly updates the plugin name.
 func TestBaseModelToHeaderPlugin_WithName(t *testing.T) {
 	p := &BaseModelToHeaderPlugin{
-		typedName:     framework.TypedName{Type: BaseModelToHeaderPluginType, Name: "original"},
+		typedName:     plugin.TypedName{Type: BaseModelToHeaderPluginType, Name: "original"},
 		AdaptersStore: NewAdaptersStore(),
 	}
 
@@ -120,7 +121,7 @@ func TestBaseModelToHeaderPluginFactory(t *testing.T) {
 			fakeDS := datastore.NewFakeDataStore()
 
 			// Create a handle using the test manager and fake datastore
-			handle := framework.NewHandle(context.Background(), mgr, fakeDS)
+			handle := plugin.NewHandle(context.Background(), mgr, fakeDS)
 
 			p, err := BaseModelToHeaderPluginFactory(tt.pluginName, tt.rawParams, handle)
 			if err != nil {
@@ -156,20 +157,20 @@ func TestBaseModelToHeaderPlugin_ProcessRequest(t *testing.T) {
 	}
 
 	p := &BaseModelToHeaderPlugin{
-		typedName:     framework.TypedName{Type: BaseModelToHeaderPluginType, Name: "test"},
+		typedName:     plugin.TypedName{Type: BaseModelToHeaderPluginType, Name: "test"},
 		AdaptersStore: store,
 	}
 
 	tests := []struct {
 		name       string
-		request    *framework.InferenceRequest
+		request    *requesthandling.InferenceRequest
 		wantErr    bool
 		wantHeader string
 	}{
 		{
 			name: "base model maps to itself",
-			request: func() *framework.InferenceRequest {
-				r := framework.NewInferenceRequest()
+			request: func() *requesthandling.InferenceRequest {
+				r := requesthandling.NewInferenceRequest()
 				r.Body["model"] = testBaseModel
 				return r
 			}(),
@@ -177,8 +178,8 @@ func TestBaseModelToHeaderPlugin_ProcessRequest(t *testing.T) {
 		},
 		{
 			name: "lora adapter maps to base model",
-			request: func() *framework.InferenceRequest {
-				r := framework.NewInferenceRequest()
+			request: func() *requesthandling.InferenceRequest {
+				r := requesthandling.NewInferenceRequest()
 				r.Body["model"] = testAdapter
 				return r
 			}(),
@@ -186,8 +187,8 @@ func TestBaseModelToHeaderPlugin_ProcessRequest(t *testing.T) {
 		},
 		{
 			name: "unknown model returns empty string",
-			request: func() *framework.InferenceRequest {
-				r := framework.NewInferenceRequest()
+			request: func() *requesthandling.InferenceRequest {
+				r := requesthandling.NewInferenceRequest()
 				r.Body["model"] = "unknown-model"
 				return r
 			}(),
@@ -195,8 +196,8 @@ func TestBaseModelToHeaderPlugin_ProcessRequest(t *testing.T) {
 		},
 		{
 			name: "missing model field returns empty string",
-			request: func() *framework.InferenceRequest {
-				r := framework.NewInferenceRequest()
+			request: func() *requesthandling.InferenceRequest {
+				r := requesthandling.NewInferenceRequest()
 				r.Body["prompt"] = "test prompt"
 				return r
 			}(),
@@ -204,8 +205,8 @@ func TestBaseModelToHeaderPlugin_ProcessRequest(t *testing.T) {
 		},
 		{
 			name: "empty string model returns empty string",
-			request: func() *framework.InferenceRequest {
-				r := framework.NewInferenceRequest()
+			request: func() *requesthandling.InferenceRequest {
+				r := requesthandling.NewInferenceRequest()
 				r.Body["model"] = ""
 				return r
 			}(),
@@ -213,8 +214,8 @@ func TestBaseModelToHeaderPlugin_ProcessRequest(t *testing.T) {
 		},
 		{
 			name: "integer model value",
-			request: func() *framework.InferenceRequest {
-				r := framework.NewInferenceRequest()
+			request: func() *requesthandling.InferenceRequest {
+				r := requesthandling.NewInferenceRequest()
 				r.Body["model"] = 123
 				return r
 			}(),
@@ -222,8 +223,8 @@ func TestBaseModelToHeaderPlugin_ProcessRequest(t *testing.T) {
 		},
 		{
 			name: "boolean model value",
-			request: func() *framework.InferenceRequest {
-				r := framework.NewInferenceRequest()
+			request: func() *requesthandling.InferenceRequest {
+				r := requesthandling.NewInferenceRequest()
 				r.Body["model"] = true
 				return r
 			}(),
@@ -231,8 +232,8 @@ func TestBaseModelToHeaderPlugin_ProcessRequest(t *testing.T) {
 		},
 		{
 			name: "nil model value",
-			request: func() *framework.InferenceRequest {
-				r := framework.NewInferenceRequest()
+			request: func() *requesthandling.InferenceRequest {
+				r := requesthandling.NewInferenceRequest()
 				r.Body["model"] = nil
 				return r
 			}(),
@@ -280,11 +281,11 @@ func TestBaseModelToHeaderPlugin_ProcessRequest_MutatedHeaders(t *testing.T) {
 	}
 
 	p := &BaseModelToHeaderPlugin{
-		typedName:     framework.TypedName{Type: BaseModelToHeaderPluginType, Name: "test"},
+		typedName:     plugin.TypedName{Type: BaseModelToHeaderPluginType, Name: "test"},
 		AdaptersStore: store,
 	}
 
-	request := framework.NewInferenceRequest()
+	request := requesthandling.NewInferenceRequest()
 	request.Body["model"] = testAdapter
 
 	if err := p.ProcessRequest(context.Background(), nil, request); err != nil {

--- a/pkg/plugins/bodyfieldtoheader/body_field_to_header.go
+++ b/pkg/plugins/bodyfieldtoheader/body_field_to_header.go
@@ -24,7 +24,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	logutil "github.com/llm-d/llm-d-inference-payload-processor/pkg/common/observability/logging"
-	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/plugin"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/requesthandling"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/metrics"
 )
 
@@ -34,7 +35,7 @@ const (
 )
 
 // compile-time type validation
-var _ framework.RequestProcessor = &BodyFieldToHeaderPlugin{}
+var _ requesthandling.RequestProcessor = &BodyFieldToHeaderPlugin{}
 
 // BodyFieldToHeaderConfig defines the JSON configuration structure for the plugin.
 type BodyFieldToHeaderConfig struct {
@@ -45,7 +46,7 @@ type BodyFieldToHeaderConfig struct {
 }
 
 // BodyFieldToHeaderPluginFactory defines the factory function for NewBodyFieldToHeaderPlugin.
-func BodyFieldToHeaderPluginFactory(name string, rawParameters json.RawMessage, _ framework.Handle) (framework.Plugin, error) {
+func BodyFieldToHeaderPluginFactory(name string, rawParameters json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
 	var config BodyFieldToHeaderConfig
 
 	if len(rawParameters) > 0 {
@@ -73,7 +74,7 @@ func NewBodyFieldToHeaderPlugin(fieldName, headerName string) (*BodyFieldToHeade
 	}
 
 	return &BodyFieldToHeaderPlugin{
-		typedName: framework.TypedName{
+		typedName: plugin.TypedName{
 			Type: BodyFieldToHeaderPluginType,
 			Name: BodyFieldToHeaderPluginType,
 		},
@@ -84,13 +85,13 @@ func NewBodyFieldToHeaderPlugin(fieldName, headerName string) (*BodyFieldToHeade
 
 // BodyFieldToHeaderPlugin extracts value from a given body field and sets it as HTTP header.
 type BodyFieldToHeaderPlugin struct {
-	typedName  framework.TypedName
+	typedName  plugin.TypedName
 	fieldName  string
 	headerName string
 }
 
 // TypedName returns the type and name tuple of this plugin instance.
-func (p *BodyFieldToHeaderPlugin) TypedName() framework.TypedName {
+func (p *BodyFieldToHeaderPlugin) TypedName() plugin.TypedName {
 	return p.typedName
 }
 
@@ -101,7 +102,7 @@ func (p *BodyFieldToHeaderPlugin) WithName(name string) *BodyFieldToHeaderPlugin
 }
 
 // ProcessRequest extracts value from a given body field and sets it as HTTP header.
-func (p *BodyFieldToHeaderPlugin) ProcessRequest(ctx context.Context, _ *framework.CycleState, request *framework.InferenceRequest) error {
+func (p *BodyFieldToHeaderPlugin) ProcessRequest(ctx context.Context, _ *plugin.CycleState, request *requesthandling.InferenceRequest) error {
 	// extract raw field value from body
 	rawFieldValue, exists := request.Body[p.fieldName]
 	if !exists {

--- a/pkg/plugins/bodyfieldtoheader/body_field_to_header_test.go
+++ b/pkg/plugins/bodyfieldtoheader/body_field_to_header_test.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/requesthandling"
 )
 
 const (
@@ -181,7 +181,7 @@ func TestBodyFieldToHeaderPlugin_ProcessRequest(t *testing.T) {
 		name       string
 		fieldName  string
 		headerName string
-		request    *framework.InferenceRequest
+		request    *requesthandling.InferenceRequest
 		wantErr    bool
 		wantHeader string
 	}{
@@ -189,8 +189,8 @@ func TestBodyFieldToHeaderPlugin_ProcessRequest(t *testing.T) {
 			name:       "string field value",
 			fieldName:  "model",
 			headerName: "X-Gateway-Model",
-			request: func() *framework.InferenceRequest {
-				r := framework.NewInferenceRequest()
+			request: func() *requesthandling.InferenceRequest {
+				r := requesthandling.NewInferenceRequest()
 				r.Body["model"] = testModelValue
 				return r
 			}(),
@@ -200,8 +200,8 @@ func TestBodyFieldToHeaderPlugin_ProcessRequest(t *testing.T) {
 			name:       "integer field value",
 			fieldName:  "count",
 			headerName: "X-Gateway-Count",
-			request: func() *framework.InferenceRequest {
-				r := framework.NewInferenceRequest()
+			request: func() *requesthandling.InferenceRequest {
+				r := requesthandling.NewInferenceRequest()
 				r.Body["count"] = 42
 				return r
 			}(),
@@ -211,8 +211,8 @@ func TestBodyFieldToHeaderPlugin_ProcessRequest(t *testing.T) {
 			name:       "float field value",
 			fieldName:  "temperature",
 			headerName: "X-Gateway-Temp",
-			request: func() *framework.InferenceRequest {
-				r := framework.NewInferenceRequest()
+			request: func() *requesthandling.InferenceRequest {
+				r := requesthandling.NewInferenceRequest()
 				r.Body["temperature"] = 0.7
 				return r
 			}(),
@@ -222,8 +222,8 @@ func TestBodyFieldToHeaderPlugin_ProcessRequest(t *testing.T) {
 			name:       "boolean field value",
 			fieldName:  "stream",
 			headerName: "X-Gateway-Stream",
-			request: func() *framework.InferenceRequest {
-				r := framework.NewInferenceRequest()
+			request: func() *requesthandling.InferenceRequest {
+				r := requesthandling.NewInferenceRequest()
 				r.Body["stream"] = true
 				return r
 			}(),
@@ -233,8 +233,8 @@ func TestBodyFieldToHeaderPlugin_ProcessRequest(t *testing.T) {
 			name:       "field not found - skips gracefully",
 			fieldName:  "missing",
 			headerName: "X-Gateway-Missing",
-			request: func() *framework.InferenceRequest {
-				r := framework.NewInferenceRequest()
+			request: func() *requesthandling.InferenceRequest {
+				r := requesthandling.NewInferenceRequest()
 				r.Body["other"] = "value"
 				return r
 			}(),
@@ -243,8 +243,8 @@ func TestBodyFieldToHeaderPlugin_ProcessRequest(t *testing.T) {
 			name:       "field is empty string - skips gracefully",
 			fieldName:  "model",
 			headerName: "X-Gateway-Model",
-			request: func() *framework.InferenceRequest {
-				r := framework.NewInferenceRequest()
+			request: func() *requesthandling.InferenceRequest {
+				r := requesthandling.NewInferenceRequest()
 				r.Body["model"] = ""
 				return r
 			}(),
@@ -282,7 +282,7 @@ func TestBodyFieldToHeaderPlugin_ProcessRequest_MutatedHeaders(t *testing.T) {
 		t.Fatalf("failed to create plugin: %v", err)
 	}
 
-	request := framework.NewInferenceRequest()
+	request := requesthandling.NewInferenceRequest()
 	request.Body["model"] = testModelValue
 
 	if err := p.ProcessRequest(context.Background(), nil, request); err != nil {

--- a/pkg/plugins/datalayer/notificationsource/plugin.go
+++ b/pkg/plugins/datalayer/notificationsource/plugin.go
@@ -25,8 +25,8 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
 	dlsrc "github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/datalayer/datasource"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/plugin"
 )
 
 const (
@@ -39,7 +39,7 @@ const (
 var _ dlsrc.NotificationSource = &notificationSource{}
 
 type notificationSource struct {
-	name       framework.TypedName
+	name       plugin.TypedName
 	ch         chan dlsrc.Event
 	extractors []dlsrc.Extractor
 
@@ -49,7 +49,7 @@ type notificationSource struct {
 }
 
 // Factory is the factory function for NotificationSource.
-func Factory(name string, _ json.RawMessage, _ framework.Handle) (framework.Plugin, error) {
+func Factory(name string, _ json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
 	src, err := New(name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create '%s' plugin - %w", PluginType, err)
@@ -63,14 +63,14 @@ func New(name string, extractors ...dlsrc.Extractor) (dlsrc.NotificationSource, 
 		return nil, fmt.Errorf("name is required for plugin '%s'", PluginType)
 	}
 	return &notificationSource{
-		name:       framework.TypedName{Type: PluginType, Name: name},
+		name:       plugin.TypedName{Type: PluginType, Name: name},
 		ch:         make(chan dlsrc.Event, defaultBufferSize),
 		extractors: extractors,
 		done:       make(chan struct{}),
 	}, nil
 }
 
-func (n *notificationSource) TypedName() framework.TypedName { return n.name }
+func (n *notificationSource) TypedName() plugin.TypedName { return n.name }
 
 func (n *notificationSource) RegisterExtractor(e dlsrc.Extractor) {
 	n.extractors = append(n.extractors, e)

--- a/pkg/plugins/datalayer/requestmetadata/plugin.go
+++ b/pkg/plugins/datalayer/requestmetadata/plugin.go
@@ -21,9 +21,9 @@ import (
 	"encoding/json"
 
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/datastore"
-	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/datalayer"
 	dlsrc "github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/datalayer/datasource"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/plugin"
 )
 
 const (
@@ -38,10 +38,10 @@ const (
 var _ dlsrc.Extractor = &RequestMetadataExtractor{}
 
 // ExtractorFactory creates a RequestMetadataExtractor with a nil DataStore.
-// The factory path is limited: the DataStore is not available via framework.Handle,
+// The factory path is limited: the DataStore is not available via plugin.Handle,
 // so the created extractor cannot write to the store. Use NewRequestMetadataExtractor
 // directly when constructing for production use.
-func ExtractorFactory(name string, _ json.RawMessage, _ framework.Handle) (framework.Plugin, error) {
+func ExtractorFactory(name string, _ json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
 	return NewRequestMetadataExtractor(nil).WithName(name), nil
 }
 
@@ -63,20 +63,20 @@ func (r RequestMetadataCount) Clone() datalayer.Cloneable { return r }
 // drop, upstream error, context cancellation). The call site should fire a
 // synthetic ResponseEventType in its error/EOF path to keep counts accurate.
 type RequestMetadataExtractor struct {
-	typedName framework.TypedName
+	typedName plugin.TypedName
 	ds        datastore.Datastore
 	counters  map[string]RequestMetadataCount
 }
 
 func NewRequestMetadataExtractor(ds datastore.Datastore) *RequestMetadataExtractor {
 	return &RequestMetadataExtractor{
-		typedName: framework.TypedName{Type: PluginType, Name: PluginType},
+		typedName: plugin.TypedName{Type: PluginType, Name: PluginType},
 		ds:        ds,
 		counters:  make(map[string]RequestMetadataCount),
 	}
 }
 
-func (e *RequestMetadataExtractor) TypedName() framework.TypedName { return e.typedName }
+func (e *RequestMetadataExtractor) TypedName() plugin.TypedName { return e.typedName }
 
 // WithName sets the instance name, used by the factory when the plugin is configured by name.
 func (e *RequestMetadataExtractor) WithName(name string) *RequestMetadataExtractor {

--- a/pkg/plugins/datalayer/requestmetadata/plugin_test.go
+++ b/pkg/plugins/datalayer/requestmetadata/plugin_test.go
@@ -22,13 +22,13 @@ import (
 	"time"
 
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/datastore"
-	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
 	dlsrc "github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/datalayer/datasource"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/requesthandling"
 )
 
 // makeRequestEvent creates a RequestEventType event with model and max_tokens.
 func makeRequestEvent(model string, maxTokens float64) dlsrc.Event {
-	req := framework.NewInferenceRequest()
+	req := requesthandling.NewInferenceRequest()
 	req.Body["model"] = model
 	req.Body["max_tokens"] = maxTokens
 	return dlsrc.Event{
@@ -40,14 +40,14 @@ func makeRequestEvent(model string, maxTokens float64) dlsrc.Event {
 // makeResponseEvent creates a ResponseEventType event with model, duration, and max_tokens.
 // maxTokens mirrors the original request's max_tokens so the extractor can decrement correctly.
 func makeResponseEvent(model string, durationMs int, maxTokens float64) dlsrc.Event {
-	req := framework.NewInferenceRequest()
+	req := requesthandling.NewInferenceRequest()
 	req.Body["model"] = model
 	req.Body["max_tokens"] = maxTokens
 	return dlsrc.Event{
 		Type: dlsrc.ResponseEventType,
 		Payload: dlsrc.ResponsePayload{
 			Request:  req,
-			Response: framework.NewInferenceResponse(),
+			Response: requesthandling.NewInferenceResponse(),
 			Duration: time.Duration(durationMs) * time.Millisecond,
 		},
 	}
@@ -169,7 +169,7 @@ func TestRequestMetadataMissingModelFieldIgnored(t *testing.T) {
 	ext, ds := newRequestMetadataTest(t)
 
 	// Payload without a "model" key — no counter should be updated.
-	req := framework.NewInferenceRequest()
+	req := requesthandling.NewInferenceRequest()
 	req.Body["max_tokens"] = float64(50)
 	batch := []dlsrc.Event{
 		{Type: dlsrc.RequestEventType, Payload: dlsrc.RequestPayload{Request: req}},

--- a/pkg/server/runserver.go
+++ b/pkg/server/runserver.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/llm-d/llm-d-inference-payload-processor/internal/runnable"
 	tlsutil "github.com/llm-d/llm-d-inference-payload-processor/internal/tls"
-	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/requesthandling"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/handlers"
 )
 
@@ -37,8 +37,8 @@ import (
 type ExtProcServerRunner struct {
 	GrpcPort        int
 	SecureServing   bool
-	RequestPlugins  []framework.RequestProcessor
-	ResponsePlugins []framework.ResponseProcessor
+	RequestPlugins  []requesthandling.RequestProcessor
+	ResponsePlugins []requesthandling.ResponseProcessor
 }
 
 func NewDefaultExtProcServerRunner(port int) *ExtProcServerRunner {

--- a/test/integration/body_mutation_test.go
+++ b/test/integration/body_mutation_test.go
@@ -29,7 +29,8 @@ import (
 	"google.golang.org/protobuf/testing/protocmp"
 
 	envoytest "github.com/llm-d/llm-d-inference-payload-processor/pkg/common/envoy/test"
-	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/plugin"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/requesthandling"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/plugins/basemodelextractor"
 	"sigs.k8s.io/gateway-api-inference-extension/test/integration"
 )
@@ -40,16 +41,16 @@ type bodyMutatingPlugin struct {
 	fieldValue any
 }
 
-func (p *bodyMutatingPlugin) TypedName() framework.TypedName {
-	return framework.TypedName{Type: "test-body-mutator", Name: "test-body-mutator"}
+func (p *bodyMutatingPlugin) TypedName() plugin.TypedName {
+	return plugin.TypedName{Type: "test-body-mutator", Name: "test-body-mutator"}
 }
 
-func (p *bodyMutatingPlugin) ProcessRequest(_ context.Context, _ *framework.CycleState, request *framework.InferenceRequest) error {
+func (p *bodyMutatingPlugin) ProcessRequest(_ context.Context, _ *plugin.CycleState, request *requesthandling.InferenceRequest) error {
 	request.SetBodyField(p.fieldName, p.fieldValue)
 	return nil
 }
 
-var _ framework.RequestProcessor = &bodyMutatingPlugin{}
+var _ requesthandling.RequestProcessor = &bodyMutatingPlugin{}
 
 // TestBodyMutation verifies that when a plugin mutates the body,
 // the header response includes Content-Length and the body response carries the mutated bytes.
@@ -59,7 +60,7 @@ func TestBodyMutation(t *testing.T) {
 
 	plugin := &bodyMutatingPlugin{fieldName: "injected", fieldValue: "test-value"}
 	baseModelToHeaderPlugin := &basemodelextractor.BaseModelToHeaderPlugin{AdaptersStore: basemodelextractor.NewAdaptersStore()}
-	h := NewHarnessWithPlugins(t, ctx, []framework.RequestProcessor{plugin, baseModelToHeaderPlugin}, []framework.ResponseProcessor{})
+	h := NewHarnessWithPlugins(t, ctx, []requesthandling.RequestProcessor{plugin, baseModelToHeaderPlugin}, []requesthandling.ResponseProcessor{})
 
 	body := map[string]any{"prompt": "hello"}
 	bodyBytes, _ := json.Marshal(body)

--- a/test/integration/harness.go
+++ b/test/integration/harness.go
@@ -30,7 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	logutil "github.com/llm-d/llm-d-inference-payload-processor/pkg/common/observability/logging"
-	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/requesthandling"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/plugins/basemodelextractor"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/plugins/bodyfieldtoheader"
 	runserver "github.com/llm-d/llm-d-inference-payload-processor/pkg/server"
@@ -94,7 +94,7 @@ func NewHarness(t *testing.T, ctx context.Context) *Harness {
 
 	baseModelToHeaderPlugin := &basemodelextractor.BaseModelToHeaderPlugin{AdaptersStore: store}
 
-	return NewHarnessWithPlugins(t, ctx, []framework.RequestProcessor{modelToHeaderPlugin, baseModelToHeaderPlugin}, []framework.ResponseProcessor{})
+	return NewHarnessWithPlugins(t, ctx, []requesthandling.RequestProcessor{modelToHeaderPlugin, baseModelToHeaderPlugin}, []requesthandling.ResponseProcessor{})
 }
 
 // NewHarnessWithPlugins boots up an isolated payload processor server on a random port
@@ -102,8 +102,8 @@ func NewHarness(t *testing.T, ctx context.Context) *Harness {
 func NewHarnessWithPlugins(
 	t *testing.T,
 	ctx context.Context,
-	requestPlugins []framework.RequestProcessor,
-	responsePlugins []framework.ResponseProcessor,
+	requestPlugins []requesthandling.RequestProcessor,
+	responsePlugins []requesthandling.ResponseProcessor,
 ) *Harness {
 	t.Helper()
 


### PR DESCRIPTION
## What does this PR do?
Moved generic plugin and request handling related interfaces to new locations, under pkg/framework/interface/.... as appropriate.

Generic plugin interfaces and structs have been moved under pkg/framework/interface/plugin.

Request handling specific interfaces and structs have been moved under pkg/framework/interface/requesthandling.

Imports and references to these interfaces and structs have been updated as appropriate.

## Why is this change needed?
Organize the code in a way that makes it easier to find things and helps eliminate loops in imports.

## How was this tested?

- [ ] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

