### PR TITLE
Update request metadata extractor to use handle.

### DIFF
--- a/pkg/plugins/datalayer/requestmetadata/plugin.go
+++ b/pkg/plugins/datalayer/requestmetadata/plugin.go
@@ -37,12 +37,9 @@ const (
 // compile-time interface assertion
 var _ dlsrc.Extractor = &RequestMetadataExtractor{}
 
-// ExtractorFactory creates a RequestMetadataExtractor with a nil DataStore.
-// The factory path is limited: the DataStore is not available via plugin.Handle,
-// so the created extractor cannot write to the store. Use NewRequestMetadataExtractor
-// directly when constructing for production use.
-func ExtractorFactory(name string, _ json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
-	return NewRequestMetadataExtractor(nil).WithName(name), nil
+// ExtractorFactory creates a RequestMetadataExtractor wired to the shared DataStore.
+func ExtractorFactory(name string, _ json.RawMessage, h plugin.Handle) (plugin.Plugin, error) {
+	return NewRequestMetadataExtractor(h.Datastore()).WithName(name), nil
 }
 
 // RequestMetadataCount holds in-flight request and token counts for one model.

--- a/pkg/plugins/datalayer/requestmetadata/plugin_test.go
+++ b/pkg/plugins/datalayer/requestmetadata/plugin_test.go
@@ -18,13 +18,24 @@ package requestmetadata
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/datastore"
 	dlsrc "github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/datalayer/datasource"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/requesthandling"
+	ctrlbuilder "sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// fakeHandle implements plugin.Handle for unit tests, providing only a Datastore.
+type fakeHandle struct{ ds datastore.Datastore }
+
+func (f *fakeHandle) Context() context.Context               { return context.Background() }
+func (f *fakeHandle) Client() client.Client                  { return nil }
+func (f *fakeHandle) ReconcilerBuilder() *ctrlbuilder.Builder { return nil }
+func (f *fakeHandle) Datastore() datastore.Datastore         { return f.ds }
 
 // makeRequestEvent creates a RequestEventType event with model and max_tokens.
 func makeRequestEvent(model string, maxTokens float64) dlsrc.Event {
@@ -181,5 +192,26 @@ func TestRequestMetadataMissingModelFieldIgnored(t *testing.T) {
 	modelCount := len(ds.Models())
 	if modelCount != 0 {
 		t.Errorf("expected no models in datastore, got %d", modelCount)
+	}
+}
+
+func TestExtractorFactoryWiresDatastore(t *testing.T) {
+	ds := datastore.NewFakeDataStore()
+	h := &fakeHandle{ds: ds}
+
+	p, err := ExtractorFactory("my-extractor", json.RawMessage(`{}`), h)
+	if err != nil {
+		t.Fatalf("ExtractorFactory returned error: %v", err)
+	}
+
+	ext, ok := p.(*RequestMetadataExtractor)
+	if !ok {
+		t.Fatalf("expected *RequestMetadataExtractor, got %T", p)
+	}
+	if ext.ds != ds {
+		t.Error("factory did not wire the datastore from the handle")
+	}
+	if ext.TypedName().Name != "my-extractor" {
+		t.Errorf("expected name %q, got %q", "my-extractor", ext.TypedName().Name)
 	}
 }


### PR DESCRIPTION
## What does this PR do?
pass the datastore from `handle` to the constructor of `request metadata extractor` and test it.
<!-- Describe the changes and their purpose -->

## Why is this change needed?

<!-- Explain the motivation: bug fix, feature request, performance improvement, etc. -->

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [ ] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues
Closes #111.
<!-- Link to related issues: Fixes #123, Related to #456 -->
