### PR TITLE
Adds tracking of actual token usage per model.

### DIFF
--- a/pkg/plugins/datalayer/requestmetadata/plugin.go
+++ b/pkg/plugins/datalayer/requestmetadata/plugin.go
@@ -19,6 +19,7 @@ package requestmetadata
 import (
 	"context"
 	"encoding/json"
+	"math"
 
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/datastore"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/datalayer"
@@ -46,14 +47,18 @@ func ExtractorFactory(name string, _ json.RawMessage, _ plugin.Handle) (plugin.P
 }
 
 // RequestMetadataCount holds in-flight request counts, in-flight max_tokens proxy totals,
-// and cumulative actual token usage for one model.
+// cumulative actual token usage for one model, and rollover counts for the cumulative token fields.
 type RequestMetadataCount struct {
-	Requests     int64
-	MaxTokens    int64
-	InputTokens  int64
-	OutputTokens int64
-	CachedTokens int64
-	ThinkTokens  int64
+	Requests             int64
+	MaxTokens            int64
+	InputTokens          int64
+	InputTokenRollovers  int64
+	OutputTokens         int64
+	OutputTokenRollovers int64
+	CachedTokens         int64
+	CachedTokenRollovers int64
+	ThinkTokens          int64
+	ThinkTokenRollovers  int64
 }
 
 func (r RequestMetadataCount) Clone() datalayer.Cloneable { return r }
@@ -136,10 +141,10 @@ func (e *RequestMetadataExtractor) Extract(_ context.Context, events []dlsrc.Eve
 
 			usage, ok := extractStandardizedUsage(p.Request.Body, p.Response.Body)
 			if ok {
-				c.InputTokens += usage.InputTokens
-				c.OutputTokens += usage.OutputTokens
-				c.CachedTokens += usage.CachedTokens
-				c.ThinkTokens += usage.ThinkTokens
+				addWithRollover(&c.InputTokens, &c.InputTokenRollovers, usage.InputTokens)
+				addWithRollover(&c.OutputTokens, &c.OutputTokenRollovers, usage.OutputTokens)
+				addWithRollover(&c.CachedTokens, &c.CachedTokenRollovers, usage.CachedTokens)
+				addWithRollover(&c.ThinkTokens, &c.ThinkTokenRollovers, usage.ThinkTokens)
 			}
 
 			e.counters[model] = c
@@ -240,4 +245,18 @@ func floorDecrement(v *int64, delta int64) {
 	if *v < 0 {
 		*v = 0
 	}
+}
+
+// addWithRollover adds delta to v, incrementing rollovers if necessary.
+// addWithRollover behavior is modulo-int64 accumulation with explicit overflow counting.
+func addWithRollover(v *int64, rollovers *int64, delta int64) {
+	if delta <= 0 {
+		return
+	}
+	if *v > math.MaxInt64-delta {
+		*rollovers++
+		*v = delta - (math.MaxInt64 - *v) - 1
+		return
+	}
+	*v += delta
 }

--- a/pkg/plugins/datalayer/requestmetadata/plugin.go
+++ b/pkg/plugins/datalayer/requestmetadata/plugin.go
@@ -45,15 +45,28 @@ func ExtractorFactory(name string, _ json.RawMessage, _ plugin.Handle) (plugin.P
 	return NewRequestMetadataExtractor(nil).WithName(name), nil
 }
 
-// RequestMetadataCount holds in-flight request and token counts for one model.
+// RequestMetadataCount holds in-flight request counts, in-flight max_tokens proxy totals,
+// and cumulative actual token usage for one model.
 type RequestMetadataCount struct {
-	Requests int64
-	Tokens   int64
+	Requests     int64
+	MaxTokens    int64
+	InputTokens  int64
+	OutputTokens int64
+	CachedTokens int64
+	ThinkTokens  int64
 }
 
 func (r RequestMetadataCount) Clone() datalayer.Cloneable { return r }
 
-// RequestMetadataExtractor tracks in-flight request counts and token sums per model.
+// standardizedUsage holds provider-normalized token counters for one response.
+type standardizedUsage struct {
+	InputTokens  int64
+	OutputTokens int64
+	CachedTokens int64
+	ThinkTokens  int64
+}
+
+// RequestMetadataExtractor tracks in-flight request counts and cumulative actual token usage per model.
 // It writes RequestMetadataCount to each model's RequestMetadataAttributeKey attribute.
 //
 // Extract is assumed to be called from a single goroutine (the NotificationSource event loop).
@@ -98,10 +111,11 @@ func (e *RequestMetadataExtractor) Extract(_ context.Context, events []dlsrc.Eve
 			if model == "" {
 				continue
 			}
-			maxTokens, _ := p.Request.Body["max_tokens"].(float64)
+			ensureStreamingUsageIncluded(p.Request.Body)
+			maxTokens := int64Value(p.Request.Body["max_tokens"])
 			c := e.counters[model]
 			c.Requests++
-			c.Tokens += int64(maxTokens)
+			c.MaxTokens += maxTokens
 			e.counters[model] = c
 			updated[model] = c
 
@@ -114,19 +128,110 @@ func (e *RequestMetadataExtractor) Extract(_ context.Context, events []dlsrc.Eve
 			if model == "" {
 				continue
 			}
-			maxTokens, _ := p.Request.Body["max_tokens"].(float64)
 			c := e.counters[model]
 			floorDecrement(&c.Requests, 1)
-			floorDecrement(&c.Tokens, int64(maxTokens))
+
+			maxTokens := int64Value(p.Request.Body["max_tokens"])
+			floorDecrement(&c.MaxTokens, maxTokens)
+
+			usage, ok := extractStandardizedUsage(p.Request.Body, p.Response.Body)
+			if ok {
+				c.InputTokens += usage.InputTokens
+				c.OutputTokens += usage.OutputTokens
+				c.CachedTokens += usage.CachedTokens
+				c.ThinkTokens += usage.ThinkTokens
+			}
+
 			e.counters[model] = c
 			updated[model] = c
 		}
 	}
 
-	for model, c := range updated {
-		e.ds.GetOrCreateModel(model).GetAttributes().Put(RequestMetadataAttributeKey, c)
+	if e.ds != nil {
+		for model, c := range updated {
+			e.ds.GetOrCreateModel(model).GetAttributes().Put(RequestMetadataAttributeKey, c)
+		}
 	}
 	return nil
+}
+
+// extractStandardizedUsage resolves the provider and extracts provider-normalized response usage.
+// Phase 1 supports conservative detection of OpenAI-compatible response bodies only, including
+// streamed final response chunks that carry a top-level usage object.
+// TODO: extend to other providers
+func extractStandardizedUsage(reqBody map[string]any, respBody map[string]any) (standardizedUsage, bool) {
+	if !isOpenAIRequest(reqBody, respBody) {
+		return standardizedUsage{}, false
+	}
+	return extractOpenAIUsage(respBody)
+}
+
+func isOpenAIRequest(reqBody map[string]any, respBody map[string]any) bool {
+	model, _ := reqBody["model"].(string)
+	if model == "" {
+		return false
+	}
+
+	usage, ok := respBody["usage"].(map[string]any)
+	if !ok {
+		return false
+	}
+
+	_, hasPromptTokens := usage["prompt_tokens"]
+	_, hasCompletionTokens := usage["completion_tokens"]
+	if !hasPromptTokens || !hasCompletionTokens {
+		return false
+	}
+
+	return true
+}
+
+func extractOpenAIUsage(body map[string]any) (standardizedUsage, bool) {
+	usage, ok := body["usage"].(map[string]any)
+	if !ok {
+		return standardizedUsage{}, false
+	}
+
+	result := standardizedUsage{
+		InputTokens:  int64Value(usage["prompt_tokens"]),
+		OutputTokens: int64Value(usage["completion_tokens"]),
+	}
+
+	if promptDetails, ok := usage["prompt_tokens_details"].(map[string]any); ok {
+		result.CachedTokens = int64Value(promptDetails["cached_tokens"])
+	}
+	if completionDetails, ok := usage["completion_tokens_details"].(map[string]any); ok {
+		result.ThinkTokens = int64Value(completionDetails["reasoning_tokens"])
+	}
+
+	return result, true
+}
+
+func ensureStreamingUsageIncluded(body map[string]any) {
+	stream, _ := body["stream"].(bool)
+	if !stream {
+		return
+	}
+
+	streamOptions, ok := body["stream_options"].(map[string]any)
+	if !ok {
+		streamOptions = map[string]any{}
+		body["stream_options"] = streamOptions
+	}
+	streamOptions["include_usage"] = true
+}
+
+func int64Value(v any) int64 {
+	switch n := v.(type) {
+	case int:
+		return int64(n)
+	case int64:
+		return n
+	case float64:
+		return int64(n)
+	default:
+		return 0
+	}
 }
 
 // floorDecrement decrements v by delta, flooring at zero.

--- a/pkg/plugins/datalayer/requestmetadata/plugin_test.go
+++ b/pkg/plugins/datalayer/requestmetadata/plugin_test.go
@@ -26,34 +26,73 @@ import (
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/requesthandling"
 )
 
-// makeRequestEvent creates a RequestEventType event with model and max_tokens.
-func makeRequestEvent(model string, maxTokens float64) dlsrc.Event {
+// makeRequestEvent creates a RequestEventType event with model, max_tokens, and optional extra request body fields.
+func makeRequestEvent(model string, maxTokens float64, extras map[string]any) dlsrc.Event {
 	req := requesthandling.NewInferenceRequest()
 	req.Body["model"] = model
 	req.Body["max_tokens"] = maxTokens
+	for k, v := range extras {
+		req.Body[k] = v
+	}
 	return dlsrc.Event{
 		Type:    dlsrc.RequestEventType,
 		Payload: dlsrc.RequestPayload{Request: req},
 	}
 }
 
-// makeResponseEvent creates a ResponseEventType event with model, duration, and max_tokens.
-// maxTokens mirrors the original request's max_tokens so the extractor can decrement correctly.
-func makeResponseEvent(model string, durationMs int, maxTokens float64) dlsrc.Event {
+// makeResponseEvent creates a ResponseEventType event with model, duration, request max_tokens, request extras, and response body.
+func makeResponseEvent(model string, durationMs int, maxTokens float64, requestExtras map[string]any, responseBody map[string]any) dlsrc.Event {
 	req := requesthandling.NewInferenceRequest()
 	req.Body["model"] = model
 	req.Body["max_tokens"] = maxTokens
+	for k, v := range requestExtras {
+		req.Body[k] = v
+	}
+
+	resp := requesthandling.NewInferenceResponse()
+	for k, v := range responseBody {
+		resp.Body[k] = v
+	}
+
 	return dlsrc.Event{
 		Type: dlsrc.ResponseEventType,
 		Payload: dlsrc.ResponsePayload{
 			Request:  req,
-			Response: requesthandling.NewInferenceResponse(),
+			Response: resp,
 			Duration: time.Duration(durationMs) * time.Millisecond,
 		},
 	}
 }
 
+func openAIUsageResponseBody(promptTokens, completionTokens, totalTokens, cachedTokens, reasoningTokens float64) map[string]any {
+	return map[string]any{
+		"usage": map[string]any{
+			"prompt_tokens":     promptTokens,
+			"completion_tokens": completionTokens,
+			"total_tokens":      totalTokens,
+			"prompt_tokens_details": map[string]any{
+				"cached_tokens": cachedTokens,
+			},
+			"completion_tokens_details": map[string]any{
+				"reasoning_tokens": reasoningTokens,
+			},
+		},
+	}
+}
+
 // getInflightRequests asserts the inflight-requests attribute exists for model and returns it.
+func streamedOpenAIFinalChunkResponseBody(promptTokens, completionTokens, cachedTokens, reasoningTokens float64) map[string]any {
+	body := openAIUsageResponseBody(promptTokens, completionTokens, promptTokens+completionTokens, cachedTokens, reasoningTokens)
+	body["object"] = "chat.completion.chunk"
+	body["choices"] = []any{
+		map[string]any{
+			"index": 0,
+			"delta": map[string]any{},
+		},
+	}
+	return body
+}
+
 func getRequestMetadata(t testing.TB, ds datastore.Datastore, model string) RequestMetadataCount {
 	t.Helper()
 	val, ok := ds.GetOrCreateModel(model).GetAttributes().Get(RequestMetadataAttributeKey)
@@ -73,10 +112,10 @@ func newRequestMetadataTest(t *testing.T) (*RequestMetadataExtractor, datastore.
 	return NewRequestMetadataExtractor(ds), ds
 }
 
-func TestRequestIncrementsCounter(t *testing.T) {
+func TestRequestIncrementsInflightCounterOnly(t *testing.T) {
 	ext, ds := newRequestMetadataTest(t)
 
-	batch := []dlsrc.Event{makeRequestEvent("m1", 100)}
+	batch := []dlsrc.Event{makeRequestEvent("m1", 100, nil)}
 	if err := ext.Extract(context.Background(), batch); err != nil {
 		t.Fatalf("Extract failed: %v", err)
 	}
@@ -85,37 +124,49 @@ func TestRequestIncrementsCounter(t *testing.T) {
 	if rc.Requests != 1 {
 		t.Errorf("expected Requests=1, got %d", rc.Requests)
 	}
-	if rc.Tokens != 100 {
-		t.Errorf("expected Tokens=100, got %d", rc.Tokens)
+	if rc.MaxTokens != 100 {
+		t.Errorf("expected MaxTokens=100, got %d", rc.MaxTokens)
+	}
+	if rc.InputTokens != 0 || rc.OutputTokens != 0 || rc.CachedTokens != 0 || rc.ThinkTokens != 0 {
+		t.Errorf("expected zero cumulative token counts on request, got %+v", rc)
 	}
 }
 
-func TestResponseDecrementsCounter(t *testing.T) {
-	ext, ds := newRequestMetadataTest(t)
+func TestStreamingRequestMutatesIncludeUsage(t *testing.T) {
+	ext, _ := newRequestMetadataTest(t)
 
-	// Response carries the original request's max_tokens so the extractor can decrement correctly.
 	batch := []dlsrc.Event{
-		makeRequestEvent("m1", 100),
-		makeResponseEvent("m1", 50, 100),
+		makeRequestEvent("m1", 100, map[string]any{
+			"stream": true,
+			"stream_options": map[string]any{
+				"existing": "value",
+			},
+		}),
 	}
 	if err := ext.Extract(context.Background(), batch); err != nil {
 		t.Fatalf("Extract failed: %v", err)
 	}
 
-	rc := getRequestMetadata(t, ds, "m1")
-	if rc.Requests != 0 {
-		t.Errorf("expected Requests=0, got %d", rc.Requests)
+	payload := batch[0].Payload.(dlsrc.RequestPayload)
+	streamOptions, ok := payload.Request.Body["stream_options"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected stream_options map to be created")
 	}
-	if rc.Tokens != 0 {
-		t.Errorf("expected Tokens=0, got %d", rc.Tokens)
+	if includeUsage, ok := streamOptions["include_usage"].(bool); !ok || !includeUsage {
+		t.Fatalf("expected stream_options.include_usage=true, got %#v", streamOptions["include_usage"])
+	}
+	if got := streamOptions["existing"]; got != "value" {
+		t.Fatalf("expected existing stream_options keys preserved, got %#v", got)
 	}
 }
 
-func TestCounterFloorsAtZero(t *testing.T) {
+func TestStreamingFinalChunkAccumulatesUsage(t *testing.T) {
 	ext, ds := newRequestMetadataTest(t)
 
-	// Response with no prior request — both counters must floor at zero.
-	batch := []dlsrc.Event{makeResponseEvent("m1", 50, 100)}
+	batch := []dlsrc.Event{
+		makeRequestEvent("m1", 300, map[string]any{"stream": true}),
+		makeResponseEvent("m1", 50, 300, map[string]any{"stream": true}, streamedOpenAIFinalChunkResponseBody(100, 200, 25, 75)),
+	}
 	if err := ext.Extract(context.Background(), batch); err != nil {
 		t.Fatalf("Extract failed: %v", err)
 	}
@@ -124,8 +175,131 @@ func TestCounterFloorsAtZero(t *testing.T) {
 	if rc.Requests != 0 {
 		t.Errorf("expected Requests=0, got %d", rc.Requests)
 	}
-	if rc.Tokens != 0 {
-		t.Errorf("expected Tokens=0, got %d", rc.Tokens)
+	if rc.MaxTokens != 0 {
+		t.Errorf("expected MaxTokens=0 after matching response, got %d", rc.MaxTokens)
+	}
+	if rc.InputTokens != 100 || rc.OutputTokens != 200 || rc.CachedTokens != 25 || rc.ThinkTokens != 75 {
+		t.Errorf("unexpected cumulative usage from streamed final chunk: %+v", rc)
+	}
+}
+
+func TestResponseDecrementsInflightAndAccumulatesUsage(t *testing.T) {
+	ext, ds := newRequestMetadataTest(t)
+
+	batch := []dlsrc.Event{
+		makeRequestEvent("m1", 300, nil),
+		makeResponseEvent("m1", 50, 300, nil, openAIUsageResponseBody(100, 200, 123, 25, 75)),
+	}
+	if err := ext.Extract(context.Background(), batch); err != nil {
+		t.Fatalf("Extract failed: %v", err)
+	}
+
+	rc := getRequestMetadata(t, ds, "m1")
+	if rc.Requests != 0 {
+		t.Errorf("expected Requests=0, got %d", rc.Requests)
+	}
+	if rc.MaxTokens != 0 {
+		t.Errorf("expected MaxTokens=0 after matching response, got %d", rc.MaxTokens)
+	}
+	if rc.InputTokens != 100 || rc.OutputTokens != 200 || rc.CachedTokens != 25 || rc.ThinkTokens != 75 {
+		t.Errorf("unexpected cumulative usage: %+v", rc)
+	}
+}
+
+func TestCounterFloorsAtZeroAndAccumulatesUsage(t *testing.T) {
+	ext, ds := newRequestMetadataTest(t)
+
+	batch := []dlsrc.Event{
+		makeResponseEvent("m1", 50, 300, nil, openAIUsageResponseBody(10, 20, 30, 3, 4)),
+	}
+	if err := ext.Extract(context.Background(), batch); err != nil {
+		t.Fatalf("Extract failed: %v", err)
+	}
+
+	rc := getRequestMetadata(t, ds, "m1")
+	if rc.Requests != 0 {
+		t.Errorf("expected Requests=0, got %d", rc.Requests)
+	}
+	if rc.MaxTokens != 0 {
+		t.Errorf("expected MaxTokens floored to zero, got %d", rc.MaxTokens)
+	}
+	if rc.InputTokens != 10 || rc.OutputTokens != 20 || rc.CachedTokens != 3 || rc.ThinkTokens != 4 {
+		t.Errorf("unexpected cumulative usage: %+v", rc)
+	}
+}
+
+func TestResponseMissingUsageOnlyDecrementsInflight(t *testing.T) {
+	ext, ds := newRequestMetadataTest(t)
+
+	batch := []dlsrc.Event{
+		makeRequestEvent("m1", 125, nil),
+		makeResponseEvent("m1", 50, 125, nil, map[string]any{}),
+	}
+	if err := ext.Extract(context.Background(), batch); err != nil {
+		t.Fatalf("Extract failed: %v", err)
+	}
+
+	rc := getRequestMetadata(t, ds, "m1")
+	if rc.Requests != 0 {
+		t.Errorf("expected Requests=0, got %d", rc.Requests)
+	}
+	if rc.MaxTokens != 0 {
+		t.Errorf("expected MaxTokens=0 after fallback decrement, got %d", rc.MaxTokens)
+	}
+	if rc.InputTokens != 0 || rc.OutputTokens != 0 || rc.CachedTokens != 0 || rc.ThinkTokens != 0 {
+		t.Errorf("expected zero cumulative usage without usage payload, got %+v", rc)
+	}
+}
+
+func TestResponseUsageWithoutOpenAIShapeDoesNotAccumulateUsage(t *testing.T) {
+	ext, ds := newRequestMetadataTest(t)
+
+	batch := []dlsrc.Event{
+		makeRequestEvent("m1", 125, nil),
+		makeResponseEvent("m1", 50, 125, nil, map[string]any{
+			"usage": map[string]any{
+				"input_tokens":  float64(11),
+				"output_tokens": float64(22),
+			},
+		}),
+	}
+	if err := ext.Extract(context.Background(), batch); err != nil {
+		t.Fatalf("Extract failed: %v", err)
+	}
+
+	rc := getRequestMetadata(t, ds, "m1")
+	if rc.Requests != 0 {
+		t.Errorf("expected Requests=0, got %d", rc.Requests)
+	}
+	if rc.MaxTokens != 0 {
+		t.Errorf("expected MaxTokens=0 after fallback decrement, got %d", rc.MaxTokens)
+	}
+	if rc.InputTokens != 0 || rc.OutputTokens != 0 || rc.CachedTokens != 0 || rc.ThinkTokens != 0 {
+		t.Errorf("expected zero cumulative usage for non-OpenAI-shaped usage payload, got %+v", rc)
+	}
+}
+
+func TestResponseMissingNestedUsageDetailsDefaultsToZero(t *testing.T) {
+	ext, ds := newRequestMetadataTest(t)
+
+	batch := []dlsrc.Event{
+		makeResponseEvent("m1", 50, 40, nil, map[string]any{
+			"usage": map[string]any{
+				"prompt_tokens":     float64(11),
+				"completion_tokens": float64(22),
+			},
+		}),
+	}
+	if err := ext.Extract(context.Background(), batch); err != nil {
+		t.Fatalf("Extract failed: %v", err)
+	}
+
+	rc := getRequestMetadata(t, ds, "m1")
+	if rc.MaxTokens != 0 {
+		t.Errorf("expected MaxTokens=0 after request max_tokens decrement, got %d", rc.MaxTokens)
+	}
+	if rc.InputTokens != 11 || rc.OutputTokens != 22 || rc.CachedTokens != 0 || rc.ThinkTokens != 0 {
+		t.Errorf("unexpected cumulative usage: %+v", rc)
 	}
 }
 
@@ -133,21 +307,23 @@ func TestRequestMetadataMultipleModels(t *testing.T) {
 	ext, ds := newRequestMetadataTest(t)
 
 	batch := []dlsrc.Event{
-		makeRequestEvent("m1", 10),
-		makeRequestEvent("m2", 20),
+		makeRequestEvent("m1", 10, nil),
+		makeRequestEvent("m2", 20, nil),
+		makeResponseEvent("m1", 10, 10, nil, openAIUsageResponseBody(1, 2, 3, 0, 0)),
+		makeResponseEvent("m2", 20, 20, nil, openAIUsageResponseBody(3, 4, 7, 1, 2)),
 	}
 	if err := ext.Extract(context.Background(), batch); err != nil {
 		t.Fatalf("Extract failed: %v", err)
 	}
 
 	rc1 := getRequestMetadata(t, ds, "m1")
-	if rc1.Requests != 1 || rc1.Tokens != 10 {
-		t.Errorf("m1: expected {Requests:1, Tokens:10}, got %+v", rc1)
+	if rc1.Requests != 0 || rc1.MaxTokens != 0 || rc1.InputTokens != 1 || rc1.OutputTokens != 2 || rc1.CachedTokens != 0 || rc1.ThinkTokens != 0 {
+		t.Errorf("m1: unexpected metadata %+v", rc1)
 	}
 
 	rc2 := getRequestMetadata(t, ds, "m2")
-	if rc2.Requests != 1 || rc2.Tokens != 20 {
-		t.Errorf("m2: expected {Requests:1, Tokens:20}, got %+v", rc2)
+	if rc2.Requests != 0 || rc2.MaxTokens != 0 || rc2.InputTokens != 3 || rc2.OutputTokens != 4 || rc2.CachedTokens != 1 || rc2.ThinkTokens != 2 {
+		t.Errorf("m2: unexpected metadata %+v", rc2)
 	}
 }
 
@@ -170,7 +346,6 @@ func TestRequestMetadataMissingModelFieldIgnored(t *testing.T) {
 
 	// Payload without a "model" key — no counter should be updated.
 	req := requesthandling.NewInferenceRequest()
-	req.Body["max_tokens"] = float64(50)
 	batch := []dlsrc.Event{
 		{Type: dlsrc.RequestEventType, Payload: dlsrc.RequestPayload{Request: req}},
 	}
@@ -181,5 +356,22 @@ func TestRequestMetadataMissingModelFieldIgnored(t *testing.T) {
 	modelCount := len(ds.Models())
 	if modelCount != 0 {
 		t.Errorf("expected no models in datastore, got %d", modelCount)
+	}
+}
+
+func TestExtractWithNilDatastoreDoesNotPanic(t *testing.T) {
+	ext := NewRequestMetadataExtractor(nil)
+
+	batch := []dlsrc.Event{
+		makeRequestEvent("m1", 100, nil),
+		makeResponseEvent("m1", 50, 100, nil, openAIUsageResponseBody(10, 20, 30, 3, 4)),
+	}
+	if err := ext.Extract(context.Background(), batch); err != nil {
+		t.Fatalf("Extract failed: %v", err)
+	}
+
+	rc := ext.counters["m1"]
+	if rc.Requests != 0 || rc.MaxTokens != 0 || rc.InputTokens != 10 || rc.OutputTokens != 20 || rc.CachedTokens != 3 || rc.ThinkTokens != 4 {
+		t.Fatalf("unexpected in-memory counters with nil datastore: %+v", rc)
 	}
 }

--- a/pkg/plugins/datalayer/requestmetadata/plugin_test.go
+++ b/pkg/plugins/datalayer/requestmetadata/plugin_test.go
@@ -18,6 +18,7 @@ package requestmetadata
 
 import (
 	"context"
+	"math"
 	"testing"
 	"time"
 
@@ -130,6 +131,9 @@ func TestRequestIncrementsInflightCounterOnly(t *testing.T) {
 	if rc.InputTokens != 0 || rc.OutputTokens != 0 || rc.CachedTokens != 0 || rc.ThinkTokens != 0 {
 		t.Errorf("expected zero cumulative token counts on request, got %+v", rc)
 	}
+	if rc.InputTokenRollovers != 0 || rc.OutputTokenRollovers != 0 || rc.CachedTokenRollovers != 0 || rc.ThinkTokenRollovers != 0 {
+		t.Errorf("expected zero rollover counts on request, got %+v", rc)
+	}
 }
 
 func TestStreamingRequestMutatesIncludeUsage(t *testing.T) {
@@ -181,6 +185,9 @@ func TestStreamingFinalChunkAccumulatesUsage(t *testing.T) {
 	if rc.InputTokens != 100 || rc.OutputTokens != 200 || rc.CachedTokens != 25 || rc.ThinkTokens != 75 {
 		t.Errorf("unexpected cumulative usage from streamed final chunk: %+v", rc)
 	}
+	if rc.InputTokenRollovers != 0 || rc.OutputTokenRollovers != 0 || rc.CachedTokenRollovers != 0 || rc.ThinkTokenRollovers != 0 {
+		t.Errorf("expected zero rollover counts, got %+v", rc)
+	}
 }
 
 func TestResponseDecrementsInflightAndAccumulatesUsage(t *testing.T) {
@@ -204,6 +211,9 @@ func TestResponseDecrementsInflightAndAccumulatesUsage(t *testing.T) {
 	if rc.InputTokens != 100 || rc.OutputTokens != 200 || rc.CachedTokens != 25 || rc.ThinkTokens != 75 {
 		t.Errorf("unexpected cumulative usage: %+v", rc)
 	}
+	if rc.InputTokenRollovers != 0 || rc.OutputTokenRollovers != 0 || rc.CachedTokenRollovers != 0 || rc.ThinkTokenRollovers != 0 {
+		t.Errorf("expected zero rollover counts, got %+v", rc)
+	}
 }
 
 func TestCounterFloorsAtZeroAndAccumulatesUsage(t *testing.T) {
@@ -225,6 +235,9 @@ func TestCounterFloorsAtZeroAndAccumulatesUsage(t *testing.T) {
 	}
 	if rc.InputTokens != 10 || rc.OutputTokens != 20 || rc.CachedTokens != 3 || rc.ThinkTokens != 4 {
 		t.Errorf("unexpected cumulative usage: %+v", rc)
+	}
+	if rc.InputTokenRollovers != 0 || rc.OutputTokenRollovers != 0 || rc.CachedTokenRollovers != 0 || rc.ThinkTokenRollovers != 0 {
+		t.Errorf("expected zero rollover counts, got %+v", rc)
 	}
 }
 
@@ -248,6 +261,9 @@ func TestResponseMissingUsageOnlyDecrementsInflight(t *testing.T) {
 	}
 	if rc.InputTokens != 0 || rc.OutputTokens != 0 || rc.CachedTokens != 0 || rc.ThinkTokens != 0 {
 		t.Errorf("expected zero cumulative usage without usage payload, got %+v", rc)
+	}
+	if rc.InputTokenRollovers != 0 || rc.OutputTokenRollovers != 0 || rc.CachedTokenRollovers != 0 || rc.ThinkTokenRollovers != 0 {
+		t.Errorf("expected zero rollover counts without usage payload, got %+v", rc)
 	}
 }
 
@@ -277,6 +293,9 @@ func TestResponseUsageWithoutOpenAIShapeDoesNotAccumulateUsage(t *testing.T) {
 	if rc.InputTokens != 0 || rc.OutputTokens != 0 || rc.CachedTokens != 0 || rc.ThinkTokens != 0 {
 		t.Errorf("expected zero cumulative usage for non-OpenAI-shaped usage payload, got %+v", rc)
 	}
+	if rc.InputTokenRollovers != 0 || rc.OutputTokenRollovers != 0 || rc.CachedTokenRollovers != 0 || rc.ThinkTokenRollovers != 0 {
+		t.Errorf("expected zero rollover counts for non-OpenAI-shaped usage payload, got %+v", rc)
+	}
 }
 
 func TestResponseMissingNestedUsageDetailsDefaultsToZero(t *testing.T) {
@@ -301,6 +320,9 @@ func TestResponseMissingNestedUsageDetailsDefaultsToZero(t *testing.T) {
 	if rc.InputTokens != 11 || rc.OutputTokens != 22 || rc.CachedTokens != 0 || rc.ThinkTokens != 0 {
 		t.Errorf("unexpected cumulative usage: %+v", rc)
 	}
+	if rc.InputTokenRollovers != 0 || rc.OutputTokenRollovers != 0 || rc.CachedTokenRollovers != 0 || rc.ThinkTokenRollovers != 0 {
+		t.Errorf("expected zero rollover counts, got %+v", rc)
+	}
 }
 
 func TestRequestMetadataMultipleModels(t *testing.T) {
@@ -317,12 +339,14 @@ func TestRequestMetadataMultipleModels(t *testing.T) {
 	}
 
 	rc1 := getRequestMetadata(t, ds, "m1")
-	if rc1.Requests != 0 || rc1.MaxTokens != 0 || rc1.InputTokens != 1 || rc1.OutputTokens != 2 || rc1.CachedTokens != 0 || rc1.ThinkTokens != 0 {
+	if rc1.Requests != 0 || rc1.MaxTokens != 0 || rc1.InputTokens != 1 || rc1.OutputTokens != 2 || rc1.CachedTokens != 0 || rc1.ThinkTokens != 0 ||
+		rc1.InputTokenRollovers != 0 || rc1.OutputTokenRollovers != 0 || rc1.CachedTokenRollovers != 0 || rc1.ThinkTokenRollovers != 0 {
 		t.Errorf("m1: unexpected metadata %+v", rc1)
 	}
 
 	rc2 := getRequestMetadata(t, ds, "m2")
-	if rc2.Requests != 0 || rc2.MaxTokens != 0 || rc2.InputTokens != 3 || rc2.OutputTokens != 4 || rc2.CachedTokens != 1 || rc2.ThinkTokens != 2 {
+	if rc2.Requests != 0 || rc2.MaxTokens != 0 || rc2.InputTokens != 3 || rc2.OutputTokens != 4 || rc2.CachedTokens != 1 || rc2.ThinkTokens != 2 ||
+		rc2.InputTokenRollovers != 0 || rc2.OutputTokenRollovers != 0 || rc2.CachedTokenRollovers != 0 || rc2.ThinkTokenRollovers != 0 {
 		t.Errorf("m2: unexpected metadata %+v", rc2)
 	}
 }
@@ -371,7 +395,36 @@ func TestExtractWithNilDatastoreDoesNotPanic(t *testing.T) {
 	}
 
 	rc := ext.counters["m1"]
-	if rc.Requests != 0 || rc.MaxTokens != 0 || rc.InputTokens != 10 || rc.OutputTokens != 20 || rc.CachedTokens != 3 || rc.ThinkTokens != 4 {
+	if rc.Requests != 0 || rc.MaxTokens != 0 || rc.InputTokens != 10 || rc.OutputTokens != 20 || rc.CachedTokens != 3 || rc.ThinkTokens != 4 ||
+		rc.InputTokenRollovers != 0 || rc.OutputTokenRollovers != 0 || rc.CachedTokenRollovers != 0 || rc.ThinkTokenRollovers != 0 {
 		t.Fatalf("unexpected in-memory counters with nil datastore: %+v", rc)
+	}
+}
+
+func TestAddWithRolloverNoOverflow(t *testing.T) {
+	var value int64 = 10
+	var rollovers int64
+
+	addWithRollover(&value, &rollovers, 5)
+
+	if value != 15 {
+		t.Fatalf("expected value=15, got %d", value)
+	}
+	if rollovers != 0 {
+		t.Fatalf("expected rollovers=0, got %d", rollovers)
+	}
+}
+
+func TestAddWithRolloverOverflow(t *testing.T) {
+	value := int64(math.MaxInt64 - 2)
+	var rollovers int64
+
+	addWithRollover(&value, &rollovers, 5)
+
+	if value != 2 {
+		t.Fatalf("expected wrapped value=2, got %d", value)
+	}
+	if rollovers != 1 {
+		t.Fatalf("expected rollovers=1, got %d", rollovers)
 	}
 }


### PR DESCRIPTION
## What does this PR do?

1. Adds tracking of actual token usage per model
2. Hardens implementation: protects against an accidental writing to the `nil` datastore 
3. Current implementation is limited to OpenAI as Phase 1, other providers will be added in subsequent PRs 

## Why is this change needed?

requestmetadata/plugin.go extracts max_tokens on the inbound request event. max_tokens is optional and is only a proxy for the actual token usage. The actual token usage will be instrumental for advanced cost-aware scoring, accurate cost tracking to capture price reversals, cache management, and visualization.

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

Fixes #115
