### PR TITLE
ci(benchmark): add automated benchmark CI workflow

### DIFF
--- a/.github/scripts/benchmark-report.sh
+++ b/.github/scripts/benchmark-report.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Generate a markdown benchmark report and detect regressions.
+# Outputs: report to OUTPUT_FILE, "regression=true/false" to stdout for CI.
+set -uo pipefail
+
+OLD_FILE="${1:-/tmp/old.txt}"
+NEW_FILE="${2:-/tmp/new.txt}"
+OUTPUT_FILE="${3:-/tmp/report.md}"
+REGRESSION_THRESHOLD="${4:-20}"
+
+# Parse benchmark file: outputs "name|time|allocs" per line
+parse_bench() {
+    grep -E "^Benchmark.*allocs/op" "$1" 2>/dev/null | awk '{
+        name=$1; gsub(/-[0-9]+$/,"",name); gsub(/^Benchmark/,"",name)
+        for(i=1;i<=NF;i++) {
+            if($(i+1)=="ns/op"||$(i+1)=="µs/op"||$(i+1)=="ms/op") time=$i" "$(i+1)
+            if($(i+1)=="allocs/op") allocs=$i
+        }
+        if(name&&allocs) print name"|"time"|"allocs
+    }'
+}
+
+# Cache parsed results
+OLD_DATA=$(parse_bench "$OLD_FILE" || echo "")
+NEW_DATA=$(parse_bench "$NEW_FILE" || echo "")
+
+# Track regression state
+REGRESSION="false"
+
+# Build report and detect regressions
+{
+    echo "## Benchmark Results"
+    echo ""
+    echo "<details open>"
+    echo "<summary>Comparison: main vs PR</summary>"
+    echo ""
+    echo "| Benchmark | main (Time) | PR (Time) | main (Allocs) | PR (Allocs) | Change |"
+    echo "|-----------|-------------|-----------|---------------|-------------|--------|"
+
+    echo "$NEW_DATA" | while IFS='|' read -r name new_time new_allocs; do
+        [ -z "$name" ] && continue
+        old=$(echo "$OLD_DATA" | grep "^${name}|" | head -1 || echo "")
+        if [ -n "$old" ]; then
+            old_time=$(echo "$old" | cut -d'|' -f2)
+            old_allocs=$(echo "$old" | cut -d'|' -f3)
+            if [ "$old_allocs" -gt 0 ] 2>/dev/null; then
+                pct=$(awk "BEGIN{printf \"%.1f\",(($new_allocs-$old_allocs)/$old_allocs)*100}")
+                pct_int="${pct%.*}"
+                if [ "$pct_int" -ge "$REGRESSION_THRESHOLD" ] 2>/dev/null; then
+                    change=":red_circle: +${pct}%"
+                    echo "REGRESSION_DETECTED" >&2
+                elif [ "$pct_int" -gt 0 ] 2>/dev/null; then
+                    change=":small_red_triangle: +${pct}%"
+                elif [ "$pct_int" -lt -5 ] 2>/dev/null; then
+                    change=":green_circle: ${pct}%"
+                else
+                    change="${pct}%"
+                fi
+            else
+                change="N/A"
+            fi
+        else
+            old_time="-"; old_allocs="-"; change="new"
+        fi
+        echo "| $name | $old_time | $new_time | $old_allocs | $new_allocs | $change |"
+    done
+
+    echo "</details>"
+    echo ""
+} > "$OUTPUT_FILE" 2>/tmp/regression_flag
+
+# Check if regression was detected during report generation
+if grep -q "REGRESSION_DETECTED" /tmp/regression_flag 2>/dev/null; then
+    REGRESSION="true"
+    echo ":warning: **Warning:** Significant allocation regression detected (>$REGRESSION_THRESHOLD%)" >> "$OUTPUT_FILE"
+else
+    echo ":white_check_mark: No significant performance regression detected" >> "$OUTPUT_FILE"
+fi
+
+# Output regression status for CI to capture
+echo "regression=$REGRESSION"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,82 @@
+name: Benchmark
+
+on:
+  pull_request:
+    paths:
+      - 'pkg/**/*.go'
+      - 'go.mod'
+      - 'go.sum'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run benchmarks on PR branch
+        run: |
+          make bench > /tmp/new.txt
+          echo "=== PR Branch Benchmarks ==="
+          cat /tmp/new.txt
+
+      - name: Run benchmarks on base branch
+        run: |
+          git checkout ${{ github.event.pull_request.base.sha }}
+          # TODO: remove go test fallback after make bench target is merged to main
+          make bench > /tmp/old.txt 2>/dev/null || \
+            go test -run='^$' -bench=. -benchmem -count=5 -timeout=10m \
+              ./pkg/modelselector/ ./pkg/handlers/ > /tmp/old.txt 2>/dev/null || \
+            echo "No benchmarks on base branch" > /tmp/old.txt
+          echo "=== Base Branch Benchmarks ==="
+          cat /tmp/old.txt
+          git checkout ${{ github.event.pull_request.head.sha }}
+
+      - name: Generate report
+        id: report
+        run: |
+          # Generate report and detect regressions (threshold: 20%)
+          bash .github/scripts/benchmark-report.sh \
+            /tmp/old.txt /tmp/new.txt /tmp/report.md 20 \
+            | tee /tmp/regression_output
+          
+          # Capture regression status from script output
+          grep "regression=" /tmp/regression_output >> $GITHUB_OUTPUT
+
+      - name: Post results and label regression
+        uses: actions/github-script@v7
+        env:
+          REGRESSION: ${{ steps.report.outputs.regression }}
+        with:
+          script: |
+            const fs = require('fs');
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const body = fs.readFileSync('/tmp/report.md', 'utf8');
+            
+            // Post or update comment
+            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number });
+            const existing = comments.find(c => c.user.type === 'Bot' && c.body.includes('## Benchmark Results'));
+            
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
+            
+            // Add label if regression detected
+            if (process.env.REGRESSION === 'true') {
+              await github.rest.issues.addLabels({ owner, repo, issue_number, labels: ['perf-regression'] });
+            }

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,11 @@ test-coverage: ## Run tests with coverage report
 	go test -race -coverprofile=coverage.out -covermode=atomic ./...
 	go tool cover -html=coverage.out -o coverage.html
 
+.PHONY: bench
+bench: ## Run benchmarks with memory stats (5 iterations)
+	go test -run='^$$' -bench=. -benchmem -count=5 -timeout=10m \
+		./pkg/modelselector/ ./pkg/handlers/
+
 .PHONY: lint
 lint: lint-go ## Run all linters
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
/kind ci

**What this PR does / why we need it**:
Add automated benchmark CI workflow that runs on every PR, compares performance against main branch, posts results as PR comment, and adds `perf-regression` label if allocations increase >20%.

**Which issue(s) this PR fixes**:
Fixes #114 

**Release note**:
```release-note
NONE