### PR TITLE
added single profile picker

### DIFF
--- a/cmd/runner/runner.go
+++ b/cmd/runner/runner.go
@@ -51,6 +51,7 @@ import (
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/plugins/modelselector/picker/weightedrandom"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/plugins/requesthandling/basemodelextractor"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/plugins/requesthandling/bodyfieldtoheader"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/plugins/requesthandling/profilepicker/single"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/metrics"
 	runserver "github.com/llm-d/llm-d-inference-payload-processor/pkg/server"
 	"github.com/llm-d/llm-d-inference-payload-processor/version"
@@ -266,6 +267,7 @@ func (r *Runner) loadConfiguration(ctx context.Context, opts *runserver.Options,
 
 // registerInTreePlugins registers the factory functions of all known payload processor plugins
 func (r *Runner) registerInTreePlugins() {
+	plugin.Register(single.SingleProfilePickerType, single.SingleProfilePickerFactory)
 	plugin.Register(bodyfieldtoheader.BodyFieldToHeaderPluginType, bodyfieldtoheader.BodyFieldToHeaderPluginFactory)
 	plugin.Register(basemodelextractor.BaseModelToHeaderPluginType, basemodelextractor.BaseModelToHeaderPluginFactory)
 	plugin.Register(requestmetadata.PluginType, requestmetadata.ExtractorFactory)

--- a/pkg/framework/interface/requesthandling/plugins.go
+++ b/pkg/framework/interface/requesthandling/plugins.go
@@ -25,7 +25,7 @@ import (
 type PreProcessor interface {
 	plugin.Plugin
 
-	// PreProcess is invoked to pre-process requests before the request pipeline is run
+	// PreProcess is invoked to pre-process requests before the request plugins of the selected profile run.
 	PreProcess(ctx context.Context, cycleState *plugin.CycleState, request *InferenceRequest) error
 }
 
@@ -33,7 +33,7 @@ type ProfilePicker interface {
 	plugin.Plugin
 
 	// Pick selects the Profile to run from a list of candidate profiles, while taking into consideration the request properties.
-	Pick(ctx context.Context, cycleState *plugin.CycleState, request *InferenceRequest, profiles map[string]Profile) *Profile
+	Pick(ctx context.Context, cycleState *plugin.CycleState, request *InferenceRequest, profiles map[string]*Profile) (*Profile, error)
 }
 
 type RequestProcessor interface {
@@ -43,16 +43,16 @@ type RequestProcessor interface {
 	ProcessRequest(ctx context.Context, cycleState *plugin.CycleState, request *InferenceRequest) error
 }
 
-type PostProcessor interface {
-	plugin.Plugin
-
-	// PostProcess is invoked to post-process requests after the request pipeline is run
-	PostProcess(ctx context.Context, cycleState *plugin.CycleState, request *InferenceRequest) error
-}
-
 type ResponseProcessor interface {
 	plugin.Plugin
 	// ProcessResponse runs the ResponseProcessor plugin.
 	// ResponseProcessor can mutate the headers and/or the body of the response.
 	ProcessResponse(ctx context.Context, cycleState *plugin.CycleState, response *InferenceResponse) error
+}
+
+type PostProcessor interface {
+	plugin.Plugin
+
+	// PostProcess is invoked to post-process requests after the response plugins of the selected profile run.
+	PostProcess(ctx context.Context, cycleState *plugin.CycleState, request *InferenceRequest) error
 }

--- a/pkg/framework/plugins/requesthandling/profilepicker/single/README.md
+++ b/pkg/framework/plugins/requesthandling/profilepicker/single/README.md
@@ -1,0 +1,18 @@
+# SingleProfilePicker
+
+**Type:** `single-profile-picker`
+
+> [!NOTE]
+> This plugin is enabled by default when exactly one profile is defined and no profile picker is configured. You do not need to explicitly declare it in your configuration.
+
+Selects the single configured profile as the profile to invoke for every request.
+
+## What it does
+
+Runs the one configured profile and returns its result.
+
+## Configuration
+
+### Parameters
+
+None.

--- a/pkg/framework/plugins/requesthandling/profilepicker/single/single_profile_picker.go
+++ b/pkg/framework/plugins/requesthandling/profilepicker/single/single_profile_picker.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package single
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/plugin"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/requesthandling"
+)
+
+const (
+	SingleProfilePickerType = "single-profile-picker"
+)
+
+// compile-time type assertion
+var _ requesthandling.ProfilePicker = &SingleProfilePicker{}
+
+// SingleProfilePickerFactory defines the factory function for SingleProfilePicker.
+func SingleProfilePickerFactory(name string, _ json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
+	return NewSingleProfilePicker().WithName(name), nil
+}
+
+// NewSingleProfilePicker initializes a new SingleProfilePicker and returns its pointer.
+func NewSingleProfilePicker() *SingleProfilePicker {
+	return &SingleProfilePicker{
+		typedName: plugin.TypedName{Type: SingleProfilePickerType, Name: SingleProfilePickerType},
+	}
+}
+
+// SingleProfilePicker handles a single profile which is always the picked profile.
+type SingleProfilePicker struct {
+	typedName plugin.TypedName
+}
+
+// TypedName returns the type and name tuple of this plugin instance.
+func (p *SingleProfilePicker) TypedName() plugin.TypedName {
+	return p.typedName
+}
+
+// WithName sets the name of the profile picker.
+func (p *SingleProfilePicker) WithName(name string) *SingleProfilePicker {
+	p.typedName.Name = name
+	return p
+}
+
+// Pick selects the Profile to run from the list of candidate profiles, while taking into consideration the request properties and the
+// previously executed cycles along with their results.
+func (p *SingleProfilePicker) Pick(ctx context.Context, cycleState *plugin.CycleState, request *requesthandling.InferenceRequest, profiles map[string]*requesthandling.Profile) (*requesthandling.Profile, error) {
+	if len(profiles) != 1 {
+		return nil, fmt.Errorf("failed to select a single profile from %d profiles", len(profiles))
+	}
+
+	var result *requesthandling.Profile
+	for _, profile := range profiles {
+		result = profile
+		break // assumes a single profile
+	}
+
+	return result, nil
+}

--- a/pkg/framework/plugins/requesthandling/profilepicker/single/single_profile_picker_test.go
+++ b/pkg/framework/plugins/requesthandling/profilepicker/single/single_profile_picker_test.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package single
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/plugin"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/requesthandling"
+)
+
+func TestNewSingleProfilePicker(t *testing.T) {
+	picker := NewSingleProfilePicker()
+
+	wantTypedName := plugin.TypedName{
+		Type: SingleProfilePickerType,
+		Name: SingleProfilePickerType,
+	}
+	if diff := cmp.Diff(wantTypedName, picker.TypedName()); diff != "" {
+		t.Errorf("Unexpected TypedName (-want +got): %s", diff)
+	}
+}
+
+func TestNewSingleProfilePickerFactory(t *testing.T) {
+	instance, err := SingleProfilePickerFactory("custom-name", nil, nil)
+	if err != nil {
+		t.Fatalf("SingleProfilePickerFactory() returned unexpected error: %v", err)
+	}
+
+	picker, ok := instance.(*SingleProfilePicker)
+	if !ok {
+		t.Fatalf("Expected *SingleProfilePicker, got %T", instance)
+	}
+
+	wantTypedName := plugin.TypedName{
+		Type: SingleProfilePickerType,
+		Name: "custom-name",
+	}
+	if diff := cmp.Diff(wantTypedName, picker.TypedName()); diff != "" {
+		t.Errorf("Unexpected TypedName (-want +got): %s", diff)
+	}
+}
+
+func TestWithName(t *testing.T) {
+	picker := NewSingleProfilePicker().WithName("renamed")
+
+	if picker.TypedName().Name != "renamed" {
+		t.Errorf("Expected Name to be %q, got %q", "renamed", picker.TypedName().Name)
+	}
+	if picker.TypedName().Type != SingleProfilePickerType {
+		t.Errorf("Expected Type to remain %q, got %q", SingleProfilePickerType, picker.TypedName().Type)
+	}
+}
+
+func TestPick(t *testing.T) {
+	defaultProfile := &requesthandling.Profile{}
+
+	tests := []struct {
+		name        string
+		profiles    map[string]*requesthandling.Profile
+		wantProfile *requesthandling.Profile
+		wantErr     bool
+	}{
+		{
+			name:     "no profiles configured, returns error",
+			profiles: map[string]*requesthandling.Profile{},
+			wantErr:  true,
+		},
+		{
+			name: "more than a single profile defined, returns error",
+			profiles: map[string]*requesthandling.Profile{
+				"default": defaultProfile,
+				"another": defaultProfile,
+			},
+			wantErr: true,
+		},
+		{
+			name: "a single profile is configured, returns the single profile",
+			profiles: map[string]*requesthandling.Profile{
+				"default": defaultProfile,
+			},
+			wantProfile: defaultProfile,
+		},
+	}
+
+	picker := NewSingleProfilePicker()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := picker.Pick(context.Background(), plugin.NewCycleState(), requesthandling.NewInferenceRequest(), tt.profiles)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if diff := cmp.Diff(tt.wantProfile, got); diff != "" {
+				t.Errorf("Unexpected profile (-want +got): %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
add `single-profile-picker`. this is the first profile picker that's being added and is still not used. 
as a follow up, config loader should use it as default value when no profile picker is explicitly defined and a single profile is configured.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
