### PR TITLE
fix: skip HTML comments when parsing /kind labels

### DIFF
--- a/.github/workflows/pr-kind-labeler.yaml
+++ b/.github/workflows/pr-kind-labeler.yaml
@@ -27,8 +27,12 @@ jobs:
             done
 
           # Extract /kind values from PR body and apply labels
-          printf '%s' "$PR_BODY" | tr -d '\r' | grep '^/kind ' | \
-            sed 's|^/kind ||' | sort -u | \
+          # Use awk to skip HTML comments and find /kind lines
+          printf '%s' "$PR_BODY" | tr -d '\r' | awk '
+            /<!--/ { in_comment=1 }
+            /-->/ { in_comment=0; next }
+            !in_comment && /^\/kind / { sub(/^\/kind /, ""); print }
+          ' | sort -u | \
             while IFS= read -r kind; do
               [ -z "$kind" ] && continue
               gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "kind/$kind" || \


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes the `pr-kind-labeler` workflow that was adding all `kind/*` labels to every PR.

**Root cause:** `grep '^/kind '` matched `/kind` lines inside HTML comments in the PR template.

**Fix:** Use `awk` with state tracking to skip HTML comments.

**Which issue(s) this PR fixes**:
Fixes issue reported in https://github.com/llm-d/llm-d-inference-payload-processor/pull/144#issuecomment-4587812938

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE