### PR TITLE
Configure the profile picker

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,7 +31,7 @@ type Config struct {
 	ProfilePicker requesthandling.ProfilePicker
 
 	// Profiles is the set of pipeline profiles loaded from the configuration file
-	Profiles map[string]requesthandling.Profile
+	Profiles map[string]*requesthandling.Profile
 
 	// PostProcessors are the response processing plugin instances executed by the response handler,
 	// in the same order provided in the configuration file.

--- a/pkg/config/loader/configloader.go
+++ b/pkg/config/loader/configloader.go
@@ -52,6 +52,18 @@ func LoadConfiguration(configBytes []byte, handle plugin.Handle, logger logr.Log
 		return nil, err
 	}
 
+	if err = applyPluginDefaults(rawConfig, handle); err != nil {
+		logger.Error(err, "failed to inject default plugins")
+		return nil, err
+	}
+
+	var profilePicker requesthandling.ProfilePicker
+	var ok bool
+	if profilePicker, ok = handle.Plugin(rawConfig.ProfilePicker.PluginRef).(requesthandling.ProfilePicker); !ok {
+		err = fmt.Errorf("the profilePicker referenced in the configuration (%s) is not a requesthandling.ProfilePicker", rawConfig.ProfilePicker.PluginRef)
+		logger.Error(err, "failed to load the configuration")
+	}
+
 	profiles, err := buildProfiles(rawConfig.Profiles, handle)
 	if err != nil {
 		logger.Error(err, "failed to load one or more profiles")
@@ -65,6 +77,7 @@ func LoadConfiguration(configBytes []byte, handle plugin.Handle, logger logr.Log
 	}
 
 	return &config.Config{
+		ProfilePicker:       profilePicker,
 		Profiles:            profiles,
 		NotificationSources: notificationSources,
 	}, nil

--- a/pkg/config/loader/configloader.go
+++ b/pkg/config/loader/configloader.go
@@ -151,12 +151,12 @@ func instantiatePlugins(configuredPlugins []configapi.PluginSpec, handle plugin.
 	return nil
 }
 
-func buildProfiles(rawProfiles []configapi.Profile, handle plugin.Handle) (map[string]requesthandling.Profile, error) {
+func buildProfiles(rawProfiles []configapi.Profile, handle plugin.Handle) (map[string]*requesthandling.Profile, error) {
 	if len(rawProfiles) == 0 {
 		return nil, errors.New("at least one profile must be specified")
 	}
 
-	profiles := map[string]requesthandling.Profile{}
+	profiles := map[string]*requesthandling.Profile{}
 
 	for _, rawProfile := range rawProfiles {
 		if len(rawProfile.Name) == 0 {
@@ -198,7 +198,7 @@ func buildProfiles(rawProfiles []configapi.Profile, handle plugin.Handle) (map[s
 			theProfile.ResponsePlugins[idx] = thePlugin
 		}
 
-		profiles[rawProfile.Name] = theProfile
+		profiles[rawProfile.Name] = &theProfile
 	}
 
 	return profiles, nil

--- a/pkg/config/loader/configloader_test.go
+++ b/pkg/config/loader/configloader_test.go
@@ -224,13 +224,13 @@ func TestBuildProfiles(t *testing.T) {
 	tests := []struct {
 		name       string
 		configText string
-		validate   func(*testing.T, *configapi.PayloadProcessorConfig, map[string]requesthandling.Profile, plugin.Handle)
+		validate   func(*testing.T, *configapi.PayloadProcessorConfig, map[string]*requesthandling.Profile, plugin.Handle)
 		wantErr    bool
 	}{
 		{
 			name:       "successConfigWithProfile",
 			configText: successConfigWithProfileText,
-			validate: func(t *testing.T, rawConfig *configapi.PayloadProcessorConfig, profiles map[string]requesthandling.Profile, handle plugin.Handle) {
+			validate: func(t *testing.T, rawConfig *configapi.PayloadProcessorConfig, profiles map[string]*requesthandling.Profile, handle plugin.Handle) {
 				require.Equal(t, rawConfig.ProfilePicker.PluginRef, testProfilePicker, "incorrect profile picker")
 				require.Equal(t, 1, len(profiles), "there should only be one profile")
 				require.NotNil(t, profiles["default"], "the profile `default` wasn't created")
@@ -242,7 +242,7 @@ func TestBuildProfiles(t *testing.T) {
 		{
 			name:       "successConfigWithTwoProfiles",
 			configText: successConfigWithTwoProfilesText,
-			validate: func(t *testing.T, rawConfig *configapi.PayloadProcessorConfig, profiles map[string]requesthandling.Profile, handle plugin.Handle) {
+			validate: func(t *testing.T, rawConfig *configapi.PayloadProcessorConfig, profiles map[string]*requesthandling.Profile, handle plugin.Handle) {
 				require.Equal(t, rawConfig.ProfilePicker.PluginRef, testProfilePicker, "incorrect profile picker")
 				require.Equal(t, 2, len(profiles), "there should be two profiles")
 				require.NotNil(t, profiles["one"], "the profile `one` wasn't created")
@@ -257,7 +257,7 @@ func TestBuildProfiles(t *testing.T) {
 		{
 			name:       "successConfigWithNoProfilePicker",
 			configText: successConfigWithNoProfilePickerText,
-			validate: func(t *testing.T, rawConfig *configapi.PayloadProcessorConfig, profiles map[string]requesthandling.Profile, handle plugin.Handle) {
+			validate: func(t *testing.T, rawConfig *configapi.PayloadProcessorConfig, profiles map[string]*requesthandling.Profile, handle plugin.Handle) {
 				require.Equal(t, rawConfig.ProfilePicker.PluginRef, single.SingleProfilePickerType, "incorrect profile picker")
 				require.Equal(t, 3, len(handle.GetAllPlugins()), "not enough plugins were instantiated")
 				require.Equal(t, 1, len(profiles), "there should only be one profile")
@@ -270,7 +270,7 @@ func TestBuildProfiles(t *testing.T) {
 		{
 			name:       "successConfigWithProfilePickerNotReferenced",
 			configText: successConfigWithProfilePickerNotReferencedText,
-			validate: func(t *testing.T, rawConfig *configapi.PayloadProcessorConfig, profiles map[string]requesthandling.Profile, handle plugin.Handle) {
+			validate: func(t *testing.T, rawConfig *configapi.PayloadProcessorConfig, profiles map[string]*requesthandling.Profile, handle plugin.Handle) {
 				require.Equal(t, rawConfig.ProfilePicker.PluginRef, testProfilePicker, "incorrect profile picker")
 				require.Equal(t, 1, len(profiles), "there should only be one profile")
 				require.NotNil(t, profiles["default"], "the profile `default` wasn't created")

--- a/pkg/config/loader/configloader_test.go
+++ b/pkg/config/loader/configloader_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/plugins/datalayer/notificationsource"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/plugins/requesthandling/basemodelextractor"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/plugins/requesthandling/bodyfieldtoheader"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/plugins/requesthandling/profilepicker/single"
 )
 
 // Define constants for test plugins.
@@ -41,6 +42,7 @@ import (
 const (
 	testPickerType       = "test-picker"
 	testPluginType       = "test-plugin"
+	testProfilePicker    = "test-profile-picker"
 	testRequestProcType  = "test-request-processor"
 	testResponseProcType = "test-response-processor"
 	testScorerType       = "test-scorer"
@@ -214,52 +216,107 @@ func TestInstantiatePlugins(t *testing.T) {
 	}
 }
 
-// --- Mocks ---
+func TestBuildProfiles(t *testing.T) {
+	// Not parallel because it modifies global plugin registry.
+	registerTestPlugins(t)
+	plugin.Register(single.SingleProfilePickerType, single.SingleProfilePickerFactory)
 
-type mockPlugin struct {
-	t plugin.TypedName
-}
+	tests := []struct {
+		name       string
+		configText string
+		validate   func(*testing.T, *configapi.PayloadProcessorConfig, map[string]requesthandling.Profile, plugin.Handle)
+		wantErr    bool
+	}{
+		{
+			name:       "successConfigWithProfile",
+			configText: successConfigWithProfileText,
+			validate: func(t *testing.T, rawConfig *configapi.PayloadProcessorConfig, profiles map[string]requesthandling.Profile, handle plugin.Handle) {
+				require.Equal(t, rawConfig.ProfilePicker.PluginRef, testProfilePicker, "incorrect profile picker")
+				require.Equal(t, 1, len(profiles), "there should only be one profile")
+				require.NotNil(t, profiles["default"], "the profile `default` wasn't created")
+				require.Equal(t, 1, len(profiles["default"].RequestPlugins), "there should be one request plugin")
+				require.Equal(t, 1, len(profiles["default"].ResponsePlugins), "there should be one response plugin")
+			},
+			wantErr: false,
+		},
+		{
+			name:       "successConfigWithTwoProfiles",
+			configText: successConfigWithTwoProfilesText,
+			validate: func(t *testing.T, rawConfig *configapi.PayloadProcessorConfig, profiles map[string]requesthandling.Profile, handle plugin.Handle) {
+				require.Equal(t, rawConfig.ProfilePicker.PluginRef, testProfilePicker, "incorrect profile picker")
+				require.Equal(t, 2, len(profiles), "there should be two profiles")
+				require.NotNil(t, profiles["one"], "the profile `one` wasn't created")
+				require.NotNil(t, profiles["two"], "the profile `two` wasn't created")
+				require.Equal(t, 1, len(profiles["one"].RequestPlugins), "there should be one request plugin")
+				require.Equal(t, 0, len(profiles["one"].ResponsePlugins), "there should be no response plugins")
+				require.Equal(t, 0, len(profiles["two"].RequestPlugins), "there should be no request plugins")
+				require.Equal(t, 1, len(profiles["two"].ResponsePlugins), "there should be one response plugin")
+			},
+			wantErr: false,
+		},
+		{
+			name:       "successConfigWithNoProfilePicker",
+			configText: successConfigWithNoProfilePickerText,
+			validate: func(t *testing.T, rawConfig *configapi.PayloadProcessorConfig, profiles map[string]requesthandling.Profile, handle plugin.Handle) {
+				require.Equal(t, rawConfig.ProfilePicker.PluginRef, single.SingleProfilePickerType, "incorrect profile picker")
+				require.Equal(t, 3, len(handle.GetAllPlugins()), "not enough plugins were instantiated")
+				require.Equal(t, 1, len(profiles), "there should only be one profile")
+				require.NotNil(t, profiles["default"], "the profile `default` wasn't created")
+				require.Equal(t, 1, len(profiles["default"].RequestPlugins), "there should be one request plugin")
+				require.Equal(t, 1, len(profiles["default"].ResponsePlugins), "there should be one response plugin")
+			},
+			wantErr: false,
+		},
+		{
+			name:       "successConfigWithProfilePickerNotReferenced",
+			configText: successConfigWithProfilePickerNotReferencedText,
+			validate: func(t *testing.T, rawConfig *configapi.PayloadProcessorConfig, profiles map[string]requesthandling.Profile, handle plugin.Handle) {
+				require.Equal(t, rawConfig.ProfilePicker.PluginRef, testProfilePicker, "incorrect profile picker")
+				require.Equal(t, 1, len(profiles), "there should only be one profile")
+				require.NotNil(t, profiles["default"], "the profile `default` wasn't created")
+				require.Equal(t, 1, len(profiles["default"].RequestPlugins), "there should be one request plugin")
+				require.Equal(t, 1, len(profiles["default"].ResponsePlugins), "there should be one response plugin")
+			},
+			wantErr: false,
+		},
+		{
+			name:       "errorConfigWithTwoProfilesNoPicker",
+			configText: errorConfigWithTwoProfilesNoPickerText,
+			wantErr:    true,
+		},
+	}
 
-func (m *mockPlugin) TypedName() plugin.TypedName { return m.t }
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			logger := logging.NewTestLogger()
 
-// Mock RequestProcessor
-type mockRequestProcessor struct{ mockPlugin }
+			rawConfig, err := loadRawConfiguration([]byte(tc.configText), logger)
+			require.NoError(t, err, "setup: loadRawConfiguration failed")
 
-// compile-time type assertion
-var _ requesthandling.RequestProcessor = &mockRequestProcessor{}
+			handle := plugin.NewHandle(context.Background(), nil, nil)
+			err = instantiatePlugins(rawConfig.Plugins, handle)
+			require.NoError(t, err, "setup: instantiatePlugins failed")
 
-func (m *mockRequestProcessor) ProcessRequest(ctx context.Context, cycleState *plugin.CycleState, request *requesthandling.InferenceRequest) error {
-	return nil
-}
+			err = applyPluginDefaults(rawConfig, handle)
+			if tc.wantErr && err != nil {
+				return
+			}
 
-// Mock ResponseProcessor
-type mockResponseProcessor struct{ mockPlugin }
+			profiles, errProf := buildProfiles(rawConfig.Profiles, handle)
+			if tc.wantErr {
+				if err == nil && errProf == nil {
+					t.Logf("either applyPluginDefaults or buildProfiles was suppose to fail")
+				}
+				return
+			}
 
-// compile-time type assertion
-var _ requesthandling.ResponseProcessor = &mockResponseProcessor{}
-
-func (m *mockResponseProcessor) ProcessResponse(ctx context.Context, cycleState *plugin.CycleState, request *requesthandling.InferenceResponse) error {
-	return nil
-}
-
-// Mock Scorer
-type mockScorer struct{ mockPlugin }
-
-// compile-time type assertion
-var _ modelselector.Scorer = &mockScorer{}
-
-func (m *mockScorer) Score(ctx context.Context, cycleState *plugin.CycleState, request *requesthandling.InferenceRequest, models []datalayer.Model) map[datalayer.Model]float64 {
-	return nil
-}
-
-// Mock Picker
-type mockPicker struct{ mockPlugin }
-
-// compile-time type assertion
-var _ modelselector.Picker = &mockPicker{}
-
-func (m *mockPicker) Pick(ctx context.Context, cycleState *plugin.CycleState, scoredModels []*modelselector.ScoredModel) *modelselector.ProfileRunResult {
-	return nil
+			require.NoError(t, err, "applyDefaultPlugins failed")
+			require.NoError(t, errProf, "buildProfiles failed")
+			if tc.validate != nil {
+				tc.validate(t, rawConfig, profiles, handle)
+			}
+		})
+	}
 }
 
 func TestBuildDatalayer(t *testing.T) {
@@ -318,6 +375,65 @@ func TestBuildDatalayer(t *testing.T) {
 	}
 }
 
+// --- Mocks ---
+
+type mockPlugin struct {
+	t plugin.TypedName
+}
+
+func (m *mockPlugin) TypedName() plugin.TypedName { return m.t }
+
+// Mock ProfilePicker
+type mockProfilePicker struct{ mockPlugin }
+
+// compiel-time type assertion
+var _ requesthandling.ProfilePicker = &mockProfilePicker{}
+
+func (m *mockProfilePicker) Pick(ctx context.Context, cycleState *plugin.CycleState, request *requesthandling.InferenceRequest,
+	profiles map[string]*requesthandling.Profile) (*requesthandling.Profile, error) {
+	return nil, nil
+}
+
+// Mock RequestProcessor
+type mockRequestProcessor struct{ mockPlugin }
+
+// compile-time type assertion
+var _ requesthandling.RequestProcessor = &mockRequestProcessor{}
+
+func (m *mockRequestProcessor) ProcessRequest(ctx context.Context, cycleState *plugin.CycleState, request *requesthandling.InferenceRequest) error {
+	return nil
+}
+
+// Mock ResponseProcessor
+type mockResponseProcessor struct{ mockPlugin }
+
+// compile-time type assertion
+var _ requesthandling.ResponseProcessor = &mockResponseProcessor{}
+
+func (m *mockResponseProcessor) ProcessResponse(ctx context.Context, cycleState *plugin.CycleState, request *requesthandling.InferenceResponse) error {
+	return nil
+}
+
+// Mock Scorer
+type mockScorer struct{ mockPlugin }
+
+// compile-time type assertion
+var _ modelselector.Scorer = &mockScorer{}
+
+func (m *mockScorer) Score(ctx context.Context, cycleState *plugin.CycleState, request *requesthandling.InferenceRequest, models []datalayer.Model) map[datalayer.Model]float64 {
+	return nil
+}
+
+// Mock Picker
+type mockPicker struct{ mockPlugin }
+
+// compile-time type assertion
+var _ modelselector.Picker = &mockPicker{}
+
+func (m *mockPicker) Pick(ctx context.Context, cycleState *plugin.CycleState, scoredModels []*modelselector.ScoredModel) *modelselector.ProfileRunResult {
+	return nil
+}
+
 func registerTestPlugins(t *testing.T) {
 	t.Helper()
 
@@ -325,6 +441,11 @@ func registerTestPlugins(t *testing.T) {
 	plugin.Register(testPluginType,
 		func(name string, params json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
 			return &mockPlugin{t: plugin.TypedName{Name: name, Type: testPluginType}}, nil
+		})
+
+	plugin.Register(testProfilePicker,
+		func(name string, params json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
+			return &mockProfilePicker{mockPlugin{t: plugin.TypedName{Name: name, Type: testProfilePicker}}}, nil
 		})
 
 	plugin.Register(testRequestProcType,

--- a/pkg/config/loader/defaults.go
+++ b/pkg/config/loader/defaults.go
@@ -73,9 +73,12 @@ func applyRawConfigDefaults(rawConfig *configapi.PayloadProcessorConfig) {
 func applyPluginDefaults(rawConfig *configapi.PayloadProcessorConfig, handle plugin.Handle) error {
 	if rawConfig.ProfilePicker == nil || rawConfig.ProfilePicker.PluginRef == "" {
 		var profilePicker requesthandling.ProfilePicker
-		var ok bool
 		for _, rawPlugin := range handle.GetAllPlugins() {
-			if profilePicker, ok = rawPlugin.(requesthandling.ProfilePicker); ok {
+			if aProfilePicker, ok := rawPlugin.(requesthandling.ProfilePicker); ok {
+				if profilePicker != nil {
+					return errors.New("multiple profile pickers have been defined in the configuration")
+				}
+				profilePicker = aProfilePicker
 				break
 			}
 		}

--- a/pkg/config/loader/defaults.go
+++ b/pkg/config/loader/defaults.go
@@ -79,7 +79,6 @@ func applyPluginDefaults(rawConfig *configapi.PayloadProcessorConfig, handle plu
 					return errors.New("multiple profile pickers have been defined in the configuration")
 				}
 				profilePicker = aProfilePicker
-				break
 			}
 		}
 

--- a/pkg/config/loader/defaults.go
+++ b/pkg/config/loader/defaults.go
@@ -87,7 +87,7 @@ func applyPluginDefaults(rawConfig *configapi.PayloadProcessorConfig, handle plu
 				}
 				profilePicker = handle.Plugin(single.SingleProfilePickerType).(requesthandling.ProfilePicker)
 			} else {
-				return errors.New("more than one profile in the configuration without a profile picker")
+				return errors.New("multiple profiles in the configuration require a profile picker")
 			}
 		}
 

--- a/pkg/config/loader/defaults.go
+++ b/pkg/config/loader/defaults.go
@@ -18,12 +18,17 @@ package loader
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	configapi "github.com/llm-d/llm-d-inference-payload-processor/apix/config/v1alpha1"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/plugin"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/requesthandling"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/plugins/requesthandling/basemodelextractor"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/plugins/requesthandling/bodyfieldtoheader"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/plugins/requesthandling/profilepicker/single"
 )
 
 func loadDefaultConfig() *configapi.PayloadProcessorConfig {
@@ -62,4 +67,61 @@ func applyRawConfigDefaults(rawConfig *configapi.PayloadProcessorConfig) {
 			rawConfig.Plugins[idx].Name = pluginConfig.Type
 		}
 	}
+}
+
+// applyPluginDefaults injects default plugins into the configuration
+func applyPluginDefaults(rawConfig *configapi.PayloadProcessorConfig, handle plugin.Handle) error {
+	if rawConfig.ProfilePicker == nil || rawConfig.ProfilePicker.PluginRef == "" {
+		var profilePicker requesthandling.ProfilePicker
+		var ok bool
+		for _, rawPlugin := range handle.GetAllPlugins() {
+			if profilePicker, ok = rawPlugin.(requesthandling.ProfilePicker); ok {
+				break
+			}
+		}
+
+		if profilePicker == nil {
+			if len(rawConfig.Profiles) == 1 {
+				if err := registerDefaultPlugin(rawConfig, handle, single.SingleProfilePickerType); err != nil {
+					return err
+				}
+				profilePicker = handle.Plugin(single.SingleProfilePickerType).(requesthandling.ProfilePicker)
+			} else {
+				return errors.New("more than one profile in the configuration without a profile picker")
+			}
+		}
+
+		if rawConfig.ProfilePicker == nil {
+			rawConfig.ProfilePicker = &configapi.PluginRef{}
+		}
+		rawConfig.ProfilePicker.PluginRef = profilePicker.TypedName().Name
+	}
+
+	return nil
+}
+
+// registerDefaultPlugin instantiates a plugin with empty configuration (defaults) and adds it to both the handle and
+// the config spec.
+func registerDefaultPlugin(
+	rawConfig *configapi.PayloadProcessorConfig,
+	handle plugin.Handle,
+	pluginType string,
+) error {
+	factory, ok := plugin.Registry[pluginType]
+	if !ok {
+		return fmt.Errorf("plugin type '%s' not found in registry", pluginType)
+	}
+
+	plugin, err := factory(pluginType, nil, handle) // default plugins have no parameters
+	if err != nil {
+		return fmt.Errorf("failed to instantiate default plugin '%s': %w", pluginType, err)
+	}
+
+	handle.AddPlugin(pluginType, plugin)
+	rawConfig.Plugins = append(rawConfig.Plugins, configapi.PluginSpec{
+		Name: pluginType,
+		Type: pluginType,
+	})
+
+	return nil
 }

--- a/pkg/config/loader/testdata_test.go
+++ b/pkg/config/loader/testdata_test.go
@@ -37,6 +37,111 @@ plugins:
   type: test-picker
 `
 
+const successConfigWithProfileText = `
+apiVersion: llm-d.ai/v1alpha1
+kind: PayloadProcessorConfig
+plugins:
+- type: test-profile-picker
+- type: test-request-processor
+- type: test-response-processor
+profilePicker:
+  pluginRef: test-profile-picker
+profiles:
+- name: default
+  plugins:
+    request:
+    - pluginRef: test-request-processor
+    response:
+    - pluginRef: test-response-processor
+`
+
+const successConfigWithTwoProfilesText = `
+apiVersion: llm-d.ai/v1alpha1
+kind: PayloadProcessorConfig
+plugins:
+- type: test-profile-picker
+- type: test-request-processor
+- type: test-response-processor
+profilePicker:
+  pluginRef: test-profile-picker
+profiles:
+- name: one
+  plugins:
+    request:
+    - pluginRef: test-request-processor
+- name: two
+  plugins:
+    response:
+    - pluginRef: test-response-processor
+`
+
+const successConfigWithNoProfilePickerText = `
+apiVersion: llm-d.ai/v1alpha1
+kind: PayloadProcessorConfig
+plugins:
+- type: test-request-processor
+- type: test-response-processor
+profiles:
+- name: default
+  plugins:
+    request:
+    - pluginRef: test-request-processor
+    response:
+    - pluginRef: test-response-processor
+`
+const successConfigWithProfilePickerNotReferencedText = `
+apiVersion: llm-d.ai/v1alpha1
+kind: PayloadProcessorConfig
+plugins:
+- type: test-profile-picker
+- type: test-request-processor
+- type: test-response-processor
+profiles:
+- name: default
+  plugins:
+    request:
+    - pluginRef: test-request-processor
+    response:
+    - pluginRef: test-response-processor
+`
+
+// datalayerSuccessConfigText has a valid notification-source reference.
+const datalayerSuccessConfigText = `
+apiVersion: llm-d.ai/v1alpha1
+kind: PayloadProcessorConfig
+plugins:
+- name: my-notif-source
+  type: notification-source
+notificationSources:
+- pluginRef: my-notif-source
+`
+
+// datalayerMissingRefConfigText references a plugin that does not exist.
+const datalayerMissingRefConfigText = `
+apiVersion: llm-d.ai/v1alpha1
+kind: PayloadProcessorConfig
+plugins:
+- name: test1
+  type: test-plugin
+  parameters:
+    threshold: 10
+notificationSources:
+- pluginRef: does-not-exist
+`
+
+// datalayerWrongTypeConfigText references a plugin that is not a NotificationSource.
+const datalayerWrongTypeConfigText = `
+apiVersion: llm-d.ai/v1alpha1
+kind: PayloadProcessorConfig
+plugins:
+- name: test1
+  type: test-plugin
+  parameters:
+    threshold: 10
+notificationSources:
+- pluginRef: test1
+`
+
 // --- Invalid Configurations (Syntax/Structure) ---
 
 // errorBadYamlText contains invalid YAML syntax.
@@ -93,39 +198,21 @@ plugins:
     threshold: 20
 `
 
-// datalayerSuccessConfigText has a valid notification-source reference.
-const datalayerSuccessConfigText = `
+const errorConfigWithTwoProfilesNoPickerText = `
 apiVersion: llm-d.ai/v1alpha1
 kind: PayloadProcessorConfig
 plugins:
-- name: my-notif-source
-  type: notification-source
-notificationSources:
-- pluginRef: my-notif-source
-`
-
-// datalayerMissingRefConfigText references a plugin that does not exist.
-const datalayerMissingRefConfigText = `
-apiVersion: llm-d.ai/v1alpha1
-kind: PayloadProcessorConfig
-plugins:
-- name: test1
-  type: test-plugin
-  parameters:
-    threshold: 10
-notificationSources:
-- pluginRef: does-not-exist
-`
-
-// datalayerWrongTypeConfigText references a plugin that is not a NotificationSource.
-const datalayerWrongTypeConfigText = `
-apiVersion: llm-d.ai/v1alpha1
-kind: PayloadProcessorConfig
-plugins:
-- name: test1
-  type: test-plugin
-  parameters:
-    threshold: 10
-notificationSources:
-- pluginRef: test1
+- type: test-request-processor
+- type: test-response-processor
+profilePicker:
+  pluginRef: test-profile-picker
+profiles:
+- name: one
+  plugins:
+    request:
+    - pluginRef: test-request-processor
+- name: two
+  plugins:
+    response:
+    - pluginRef: test-response-processor
 `


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR wires the profile picker specified in the configuration text to the IPP's configuration struct.

In addition, if the user did not specify a profile picker and only one profile has been specified a default profile picker (SingleProfilePicker) is added to the configuration.

!note If a profile picker plugin is referenced in the configuration's plugins section, it will be automatically used if one was not referenced in the configuration's profilePicker section.

**Which issue(s) this PR fixes**:
?

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
If a profile picker plugin is not mentioned in the configuration file and tonly one profile was specified, a default profile picker will be added to the configuration.
```
