### PR TITLE
feat(deploy): add Kustomize deployment option (#125)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ LDFLAGS ?= -s -w -X main.version=$(VERSION)
 
 # Tools
 GOLANGCI_LINT_VERSION ?= v2.8.0
+KUSTOMIZE ?= $(LOCALBIN)/kustomize
+KUSTOMIZE_VERSION ?= v5.4.3
+KUSTOMIZE_OVERLAY ?= default
 
 .DEFAULT_GOAL := help
 
@@ -87,6 +90,29 @@ image-push: ## Build and push multi-arch container image
 		--tag $(IMAGE):$(VERSION) \
 		--tag $(IMAGE):latest \
 		.
+
+##@ Deployment
+
+.PHONY: kustomize
+kustomize: ## Download kustomize locally if necessary
+	@test -f $(KUSTOMIZE) || { \
+		mkdir -p $(LOCALBIN); \
+		curl -sSLo /tmp/kustomize.tar.gz https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F$(KUSTOMIZE_VERSION)/kustomize_$(KUSTOMIZE_VERSION)_linux_amd64.tar.gz && \
+		tar -xzf /tmp/kustomize.tar.gz -C $(LOCALBIN) && \
+		rm /tmp/kustomize.tar.gz; \
+	}
+
+.PHONY: kustomize-build
+kustomize-build: kustomize ## Render Kustomize manifests (KUSTOMIZE_OVERLAY=default|istio|gke)
+	$(KUSTOMIZE) build config/kustomize/overlays/$(KUSTOMIZE_OVERLAY)
+
+.PHONY: kustomize-deploy
+kustomize-deploy: kustomize ## Deploy using Kustomize (KUSTOMIZE_OVERLAY=default|istio|gke)
+	$(KUSTOMIZE) build config/kustomize/overlays/$(KUSTOMIZE_OVERLAY) | kubectl apply -f -
+
+.PHONY: kustomize-undeploy
+kustomize-undeploy: kustomize ## Remove Kustomize deployment (KUSTOMIZE_OVERLAY=default|istio|gke)
+	$(KUSTOMIZE) build config/kustomize/overlays/$(KUSTOMIZE_OVERLAY) | kubectl delete --ignore-not-found -f -
 
 ##@ CI Helpers
 

--- a/README.md
+++ b/README.md
@@ -4,3 +4,32 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
 > **Inference payload processor for llm-d.**
+
+## Deployment
+
+The payload processor can be deployed using either **Helm** or **Kustomize**.
+
+### Helm
+
+```bash
+helm install payload-processor ./config/charts/payload-processor \
+    --set provider.name=[gke|istio] \
+    --set inferenceGateway.name=inference-gateway
+```
+
+See [config/charts/payload-processor/README.md](config/charts/payload-processor/README.md) for the full parameter reference.
+
+### Kustomize
+
+```bash
+# No provider (Deployment + Service only)
+kubectl kustomize config/kustomize/overlays/default | kubectl apply -f -
+
+# Istio (adds EnvoyFilter + DestinationRule)
+kubectl kustomize config/kustomize/overlays/istio | kubectl apply -f -
+
+# GKE (adds GCPRoutingExtension + HealthCheckPolicy)
+kubectl kustomize config/kustomize/overlays/gke | kubectl apply -f -
+```
+
+See [config/kustomize/README.md](config/kustomize/README.md) for customization options (namespace, image tag, custom config, multi-namespace RBAC).

--- a/config/kustomize/README.md
+++ b/config/kustomize/README.md
@@ -1,0 +1,187 @@
+# Kustomize Deployment
+
+This directory provides [Kustomize](https://kustomize.io/) manifests for deploying the
+Inference Payload Processor (IPP). It mirrors the same resources as the Helm chart at
+`config/charts/payload-processor/` and is the recommended path for integrations such as
+[llm-d-benchmark](https://github.com/llm-d/llm-d-benchmark) and GitOps workflows.
+
+## Structure
+
+```
+config/kustomize/
+├── base/                        # Core resources (provider-agnostic)
+│   ├── kustomization.yaml
+│   ├── deployment.yaml          # Deployment
+│   ├── service.yaml             # ClusterIP Service on port 9004 (HTTP2)
+│   ├── serviceaccount.yaml      # ServiceAccount
+│   ├── rbac.yaml                # Role + RoleBinding (single-namespace)
+│   └── configmap.yaml           # Default PayloadProcessorConfig
+└── overlays/
+    ├── default/                 # No provider — Deployment + Service only
+    ├── istio/                   # Adds EnvoyFilter + DestinationRule
+    └── gke/                     # Adds GCPRoutingExtension + HealthCheckPolicy
+```
+
+## Quick Start
+
+### Prerequisites
+
+- `kubectl` ≥ 1.24
+- `kustomize` ≥ 5.0 (or the `kustomize` embedded in `kubectl`)
+- A running Kubernetes cluster with an Inference Gateway deployed
+
+### Deploy (no provider)
+
+```bash
+# Render to stdout
+kubectl kustomize config/kustomize/overlays/default
+
+# Apply directly
+kubectl kustomize config/kustomize/overlays/default | kubectl apply -f -
+
+# Or via make
+make kustomize-deploy
+```
+
+### Deploy with Istio
+
+```bash
+kubectl kustomize config/kustomize/overlays/istio | kubectl apply -f -
+
+# Or via make
+make kustomize-deploy KUSTOMIZE_OVERLAY=istio
+```
+
+### Deploy with GKE
+
+```bash
+kubectl kustomize config/kustomize/overlays/gke | kubectl apply -f -
+
+# Or via make
+make kustomize-deploy KUSTOMIZE_OVERLAY=gke
+```
+
+### Undeploy
+
+```bash
+make kustomize-undeploy                        # default overlay
+make kustomize-undeploy KUSTOMIZE_OVERLAY=istio
+make kustomize-undeploy KUSTOMIZE_OVERLAY=gke
+```
+
+## Customization
+
+### Change the target namespace
+
+Edit the `namespace:` field in the overlay's `kustomization.yaml`:
+
+```yaml
+# config/kustomize/overlays/default/kustomization.yaml
+namespace: my-namespace   # ← change this
+```
+
+Or patch it inline from the command line:
+
+```bash
+cd config/kustomize/overlays/default
+kustomize edit set namespace my-namespace
+```
+
+> **Istio and GKE users:** The `cluster_name` in `overlays/istio/envoyfilter.yaml` and the
+> `host` in `overlays/istio/destinationrule.yaml` embed the namespace as part of the FQDN
+> (`payload-processor.<namespace>.svc.cluster.local`). Update those fields to match your
+> chosen namespace.
+
+### Change the container image
+
+Add an `images` override in your overlay's `kustomization.yaml`:
+
+```yaml
+images:
+  - name: ghcr.io/llm-d/llm-d-inference-payload-processor
+    newTag: v0.3.0
+```
+
+### Change the Gateway name
+
+Patch the `targetRefs[0].name` field in `envoyfilter.yaml` (Istio) or
+`gcproutingextension.yaml` (GKE) using a strategic merge patch:
+
+```yaml
+# overlays/istio/gateway-patch.yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: payload-processor
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: my-custom-gateway   # ← your Gateway name
+```
+
+```yaml
+# overlays/istio/kustomization.yaml (add to existing file)
+patches:
+  - path: gateway-patch.yaml
+```
+
+### Use a custom IPP config
+
+Add a `configMapGenerator` entry in your overlay's `kustomization.yaml` to merge your own
+`PayloadProcessorConfig`:
+
+```yaml
+configMapGenerator:
+  - name: payload-processor
+    behavior: merge
+    files:
+      - custom-ipp-config.yaml=path/to/your/config.yaml
+```
+
+Then update the `--config-file` arg in a Deployment patch to point to
+`/config/custom-ipp-config.yaml`.
+
+### Multi-namespace RBAC
+
+The base uses a namespace-scoped `Role`/`RoleBinding`. To watch ConfigMaps across
+namespaces, create an overlay that replaces them with a `ClusterRole`/`ClusterRoleBinding`:
+
+```yaml
+# overlays/multi-namespace/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: my-namespace
+
+resources:
+  - ../../base
+  - clusterrole.yaml
+  - clusterrolebinding.yaml
+
+patches:
+  - target:
+      kind: Role
+    patch: |-
+      $patch: delete
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: payload-processor-configmap-reader
+  - target:
+      kind: RoleBinding
+    patch: |-
+      $patch: delete
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: payload-processor-configmap-reader
+```
+
+## Notes
+
+- This chart should only be deployed once per Gateway (same constraint as the Helm chart).
+- The `base/` layer intentionally omits `metadata.namespace` so that the overlay's
+  `namespace:` field is the single source of truth.
+- For production use, pin the image tag and consider setting resource requests/limits via
+  a Deployment patch.

--- a/config/kustomize/base/configmap.yaml
+++ b/config/kustomize/base/configmap.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: payload-processor
+data:
+  default-ipp-config.yaml: |
+    apiVersion: llm-d.ai/v1alpha1
+    kind: PayloadProcessorConfig
+    plugins:
+    - type: body-field-to-header
+      parameters:
+        fieldName: model
+        headerName: X-Gateway-Model-Name
+    - type: base-model-to-header
+    profiles:
+    - name: default
+      plugins:
+        request:
+        - pluginRef: body-field-to-header
+        - pluginRef: base-model-to-header

--- a/config/kustomize/base/deployment.yaml
+++ b/config/kustomize/base/deployment.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payload-processor
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: payload-processor
+  template:
+    metadata:
+      labels:
+        app: payload-processor
+    spec:
+      serviceAccountName: payload-processor
+      containers:
+        - name: payload-processor
+          image: ghcr.io/llm-d/llm-d-inference-payload-processor:main
+          imagePullPolicy: IfNotPresent
+          args:
+            - --config-file
+            - /config/default-ipp-config.yaml
+            - --v=3
+            - --tracing=false
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          ports:
+            - containerPort: 9004
+            - containerPort: 9005
+          volumeMounts:
+            - name: config-volume
+              mountPath: /config
+      volumes:
+        - name: config-volume
+          configMap:
+            name: payload-processor

--- a/config/kustomize/base/kustomization.yaml
+++ b/config/kustomize/base/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - configmap.yaml
+  - serviceaccount.yaml
+  - rbac.yaml
+  - deployment.yaml
+  - service.yaml

--- a/config/kustomize/base/rbac.yaml
+++ b/config/kustomize/base/rbac.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: payload-processor-configmap-reader
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: payload-processor-configmap-reader
+subjects:
+  - kind: ServiceAccount
+    name: payload-processor
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: payload-processor-configmap-reader

--- a/config/kustomize/base/service.yaml
+++ b/config/kustomize/base/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: payload-processor
+spec:
+  selector:
+    app: payload-processor
+  ports:
+    - protocol: TCP
+      port: 9004
+      targetPort: 9004
+      appProtocol: HTTP2
+  type: ClusterIP

--- a/config/kustomize/base/serviceaccount.yaml
+++ b/config/kustomize/base/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: payload-processor

--- a/config/kustomize/overlays/default/kustomization.yaml
+++ b/config/kustomize/overlays/default/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Override the namespace for all resources in the base.
+# Change this to the namespace where you want to deploy the payload processor.
+namespace: default
+
+resources:
+  - ../../base

--- a/config/kustomize/overlays/gke/gcproutingextension.yaml
+++ b/config/kustomize/overlays/gke/gcproutingextension.yaml
@@ -1,0 +1,31 @@
+apiVersion: networking.gke.io/v1
+kind: GCPRoutingExtension
+metadata:
+  # Namespace is set by kustomization.yaml
+  name: payload-processor
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      # Update to match your Gateway name.
+      name: inference-gateway
+  extensionChains:
+    - name: chain1
+      extensions:
+        - name: ext1
+          authority: "myext.com"
+          timeout: 1s
+          supportedEvents:
+            - RequestHeaders
+            - RequestBody
+            - RequestTrailers
+            - ResponseHeaders
+            - ResponseBody
+            - ResponseTrailers
+          requestBodySendMode: "FullDuplexStreamed"
+          responseBodySendMode: "FullDuplexStreamed"
+          backendRef:
+            group: ""
+            kind: Service
+            name: payload-processor
+            port: 9004

--- a/config/kustomize/overlays/gke/healthcheckpolicy.yaml
+++ b/config/kustomize/overlays/gke/healthcheckpolicy.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.gke.io/v1
+kind: HealthCheckPolicy
+metadata:
+  # Namespace is set by kustomization.yaml
+  name: payload-processor-healthcheck
+spec:
+  default:
+    logConfig:
+      enabled: true
+    config:
+      type: "GRPC"
+      grpcHealthCheck:
+        portSpecification: "USE_FIXED_PORT"
+        port: 9005
+  targetRef:
+    group: ""
+    kind: Service
+    name: payload-processor

--- a/config/kustomize/overlays/gke/kustomization.yaml
+++ b/config/kustomize/overlays/gke/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Override the namespace for all resources in the base.
+# Change this to the namespace where you want to deploy the payload processor.
+namespace: default
+
+resources:
+  - ../../base
+  - gcproutingextension.yaml
+  - healthcheckpolicy.yaml

--- a/config/kustomize/overlays/istio/destinationrule.yaml
+++ b/config/kustomize/overlays/istio/destinationrule.yaml
@@ -1,0 +1,13 @@
+apiVersion: networking.istio.io/v1
+kind: DestinationRule
+metadata:
+  # Namespace is set by kustomization.yaml
+  name: payload-processor
+spec:
+  # Update the namespace segment (currently "default") to match
+  # the namespace set in kustomization.yaml.
+  host: payload-processor.default.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: SIMPLE
+      insecureSkipVerify: true

--- a/config/kustomize/overlays/istio/envoyfilter.yaml
+++ b/config/kustomize/overlays/istio/envoyfilter.yaml
@@ -1,0 +1,39 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  # Namespace is set by kustomization.yaml
+  name: payload-processor
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      # Update to match your Gateway name.
+      name: inference-gateway
+  configPatches:
+    - applyTo: HTTP_FILTER
+      match:
+        context: GATEWAY
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.filters.network.http_connection_manager"
+      patch:
+        operation: INSERT_FIRST
+        value:
+          name: envoy.filters.http.ext_proc.payload-processor
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+            failure_mode_allow: false
+            allow_mode_override: true
+            processing_mode:
+              request_header_mode: "SEND"
+              response_header_mode: "SEND"
+              request_body_mode: "FULL_DUPLEX_STREAMED"
+              response_body_mode: "FULL_DUPLEX_STREAMED"
+              request_trailer_mode: "SEND"
+              response_trailer_mode: "SEND"
+            grpc_service:
+              envoy_grpc:
+                # Update the namespace segment (currently "default") to match
+                # the namespace set in kustomization.yaml.
+                cluster_name: outbound|9004||payload-processor.default.svc.cluster.local

--- a/config/kustomize/overlays/istio/kustomization.yaml
+++ b/config/kustomize/overlays/istio/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Override the namespace for all resources in the base.
+# IMPORTANT: Also update the cluster_name in envoyfilter.yaml and
+# the host in destinationrule.yaml to match this namespace.
+namespace: default
+
+resources:
+  - ../../base
+  - envoyfilter.yaml
+  - destinationrule.yaml

--- a/pkg/config/loader/configloader_test.go
+++ b/pkg/config/loader/configloader_test.go
@@ -60,8 +60,8 @@ func TestLoadRawConfiguration(t *testing.T) {
 			configText: successConfigText,
 			want: &configapi.PayloadProcessorConfig{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       "PayloadProcessorConfig",
-					APIVersion: "llm-d.ai/v1alpha1",
+					Kind:       configKind,
+					APIVersion: configAPIVersion,
 				},
 				Plugins: []configapi.PluginSpec{
 					{Name: testRequestProcType, Type: testRequestProcType},
@@ -78,8 +78,8 @@ func TestLoadRawConfiguration(t *testing.T) {
 			configText: "",
 			want: &configapi.PayloadProcessorConfig{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: "llm-d.ai/v1alpha1",
-					Kind:       "PayloadProcessorConfig",
+					APIVersion: configAPIVersion,
+					Kind:       configKind,
 				},
 				Plugins: []configapi.PluginSpec{
 					{

--- a/pkg/config/loader/defaults.go
+++ b/pkg/config/loader/defaults.go
@@ -26,11 +26,16 @@ import (
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/plugins/requesthandling/bodyfieldtoheader"
 )
 
+const (
+	configAPIVersion = "llm-d.ai/v1alpha1"
+	configKind       = "PayloadProcessorConfig"
+)
+
 func loadDefaultConfig() *configapi.PayloadProcessorConfig {
 	return &configapi.PayloadProcessorConfig{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "llm-d.ai/v1alpha1",
-			Kind:       "PayloadProcessorConfig",
+			APIVersion: configAPIVersion,
+			Kind:       configKind,
 		},
 		Plugins: []configapi.PluginSpec{
 			{

--- a/test/integration/body_mutation_test.go
+++ b/test/integration/body_mutation_test.go
@@ -62,7 +62,7 @@ func TestBodyMutation(t *testing.T) {
 	baseModelToHeaderPlugin := &basemodelextractor.BaseModelToHeaderPlugin{AdaptersStore: basemodelextractor.NewAdaptersStore()}
 	h := NewHarnessWithPlugins(t, ctx, []requesthandling.RequestProcessor{plugin, baseModelToHeaderPlugin}, []requesthandling.ResponseProcessor{})
 
-	body := map[string]any{"prompt": "hello"}
+	body := map[string]any{bodyFieldPrompt: "hello"}
 	bodyBytes, _ := json.Marshal(body)
 
 	reqs := []*extProcPb.ProcessingRequest{
@@ -88,8 +88,8 @@ func TestBodyMutation(t *testing.T) {
 	}
 
 	wantBody, _ := json.Marshal(map[string]any{
-		"prompt":   "hello",
-		"injected": "test-value",
+		bodyFieldPrompt: "hello",
+		"injected":      "test-value",
 	})
 	wantResponses := []*extProcPb.ProcessingResponse{
 		{
@@ -101,7 +101,7 @@ func TestBodyMutation(t *testing.T) {
 							SetHeaders: []*envoyCorev3.HeaderValueOption{
 								{
 									Header: &envoyCorev3.HeaderValue{
-										Key:      "Content-Length",
+										Key:      headerContentLength,
 										RawValue: []byte(strconv.Itoa(len(wantBody))),
 									},
 								},

--- a/test/integration/hermetic_test.go
+++ b/test/integration/hermetic_test.go
@@ -79,7 +79,7 @@ func TestBodyBasedRouting(t *testing.T) {
 									SetHeaders: []*envoyCorev3.HeaderValueOption{
 										{
 											Header: &envoyCorev3.HeaderValue{
-												Key:      "Content-Length",
+												Key:      headerContentLength,
 												RawValue: []byte("50"),
 											},
 										},

--- a/test/integration/util.go
+++ b/test/integration/util.go
@@ -23,6 +23,11 @@ import (
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 )
 
+const (
+	headerContentLength = "Content-Length"
+	bodyFieldPrompt     = "prompt"
+)
+
 // --- Response Expectations (Streaming) ---
 
 // ExpectHeader asserts that the payload processor set the specific model header and cleared the route cache.
@@ -37,7 +42,7 @@ func ExpectHeader(modelName, baseModelName string, contentLength string) *extPro
 						SetHeaders: []*envoyCorev3.HeaderValueOption{
 							{
 								Header: &envoyCorev3.HeaderValue{
-									Key:      "Content-Length",
+									Key:      headerContentLength,
 									RawValue: []byte(contentLength),
 								},
 							},
@@ -65,7 +70,7 @@ func ExpectHeader(modelName, baseModelName string, contentLength string) *extPro
 // The payload processor buffers the body to inspect it, then sends it downstream as a single chunk (usually).
 func ExpectBodyPassThrough(prompt, model string) *extProcPb.ProcessingResponse {
 	j := map[string]any{
-		"max_tokens": 100, "prompt": prompt, "temperature": 0,
+		"max_tokens": 100, bodyFieldPrompt: prompt, "temperature": 0,
 	}
 	if model != "" {
 		j["model"] = model


### PR DESCRIPTION
# [Feature] Enable deployment using Kustomize

Adds a Kustomize deployment path for the Inference Payload Processor (IPP),
aligning with the llm-d community deployment standard and enabling IPP to be
consumed as a step in [llm-d-benchmark](https://github.com/llm-d/llm-d-benchmark)
and GitOps workflows that prefer Kustomize over Helm.

The existing Helm chart (`config/charts/payload-processor/`) is untouched;
Kustomize is an **additive** alternative.

---

Fixes #125

---

## Changes

### New: `config/kustomize/`

```
config/kustomize/
├── README.md                              ← full usage guide
├── base/                                  ← provider-agnostic core resources
│   ├── kustomization.yaml
│   ├── deployment.yaml                    ← Deployment (1 replica, port 9004/9005)
│   ├── service.yaml                       ← ClusterIP Service (HTTP2, port 9004)
│   ├── serviceaccount.yaml
│   ├── rbac.yaml                          ← Role + RoleBinding (single-namespace)
│   └── configmap.yaml                     ← default PayloadProcessorConfig
└── overlays/
    ├── default/kustomization.yaml         ← no provider (base only)
    ├── istio/                             ← + EnvoyFilter + DestinationRule
    │   ├── kustomization.yaml
    │   ├── envoyfilter.yaml
    │   └── destinationrule.yaml
    └── gke/                               ← + GCPRoutingExtension + HealthCheckPolicy
        ├── kustomization.yaml
        ├── gcproutingextension.yaml
        └── healthcheckpolicy.yaml
```

Each overlay exposes a single `namespace:` field as the sole namespace control
point — the base layer intentionally omits `metadata.namespace` so that the
overlay drives it.

### Modified: `Makefile`

New `##@ Deployment` section:

| Target | Description |
|--------|-------------|
| `make kustomize` | Download kustomize binary to `bin/` if absent |
| `make kustomize-build [KUSTOMIZE_OVERLAY=default\|istio\|gke]` | Render manifests to stdout |
| `make kustomize-deploy [KUSTOMIZE_OVERLAY=default\|istio\|gke]` | Apply to cluster |
| `make kustomize-undeploy [KUSTOMIZE_OVERLAY=default\|istio\|gke]` | Remove from cluster |

### Modified: `README.md`

Added a **Deployment** section with side-by-side Helm and Kustomize quick-start
commands.

### Fixed: pre-existing `goconst` lint issues

Extracted repeated string literals into named constants to clear `golangci-lint`
(4 issues, pre-existing):

| File | Constants added |
|------|----------------|
| `pkg/config/loader/defaults.go` | `configAPIVersion`, `configKind` |
| `test/integration/util.go` | `headerContentLength`, `bodyFieldPrompt` |

---

## Usage

```bash
# No provider (Deployment + Service only)
kubectl kustomize config/kustomize/overlays/default | kubectl apply -f -

# Istio (adds EnvoyFilter + DestinationRule)
make kustomize-deploy KUSTOMIZE_OVERLAY=istio

# GKE (adds GCPRoutingExtension + HealthCheckPolicy)
make kustomize-deploy KUSTOMIZE_OVERLAY=gke

# Custom namespace
cd config/kustomize/overlays/default
kustomize edit set namespace my-namespace
```

See [`config/kustomize/README.md`](config/kustomize/README.md) for customization
options (namespace, image tag, custom IPP config, multi-namespace RBAC).

---

## Testing

### Kustomize build validation

All three overlays render without errors and produce the expected resource kinds:

| Overlay | Resources |
|---------|-----------|
| `default` | ConfigMap, Deployment, Role, RoleBinding, Service, ServiceAccount |
| `istio` | + DestinationRule, EnvoyFilter |
| `gke` | + GCPRoutingExtension, HealthCheckPolicy |

Validated with:
```bash
kubectl kustomize config/kustomize/overlays/default
kubectl kustomize config/kustomize/overlays/istio
kubectl kustomize config/kustomize/overlays/gke
```

### Go test suite

All 24 test packages pass with race detection enabled (`go test -race -count=1 ./...`):

| Package | Result | Coverage |
|---------|--------|----------|
| `pkg/common` | ✅ PASS | 81.8% |
| `pkg/common/envoy` | ✅ PASS | 87.5% |
| `pkg/common/envoy/test` | ✅ PASS | 100.0% |
| `pkg/common/error` | ✅ PASS | 100.0% |
| `pkg/common/observability/logging` | ✅ PASS | 69.4% |
| `pkg/config/loader` | ✅ PASS | 50.0% |
| `pkg/datastore/inmemory` | ✅ PASS | 100.0% |
| `pkg/framework/interface/datalayer` | ✅ PASS | 97.4% |
| `pkg/framework/interface/requesthandling` | ✅ PASS | 52.4% |
| `pkg/framework/plugins/datalayer/notificationsource` | ✅ PASS | 45.2% |
| `pkg/framework/plugins/datalayer/requestmetadata` | ✅ PASS | 92.3% |
| `pkg/framework/plugins/modelselector/picker/maxscore` | ✅ PASS | 66.7% |
| `pkg/framework/plugins/modelselector/picker/random` | ✅ PASS | 88.9% |
| `pkg/framework/plugins/modelselector/picker/weightedrandom` | ✅ PASS | 66.7% |
| `pkg/framework/plugins/modelselector/scorer/costaware` | ✅ PASS | 95.8% |
| `pkg/framework/plugins/requesthandling/basemodelextractor` | ✅ PASS | 81.4% |
| `pkg/framework/plugins/requesthandling/bodyfieldtoheader` | ✅ PASS | 100.0% |
| `pkg/framework/plugins/requesthandling/profilepicker/single` | ✅ PASS | 100.0% |
| `pkg/handlers` | ✅ PASS | 74.4% |
| `pkg/metrics` | ✅ PASS | 50.0% |
| `pkg/modelselector` | ✅ PASS | 82.4% |
| `pkg/server` | ✅ PASS | 61.1% |
| `test/integration` | ✅ PASS | 97.1% |

**Total coverage: 51.5%** (statements)

### Linting

```
golangci-lint run  →  0 issues.
go vet ./...       →  clean
```

---

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Add Kustomize deployment support with base manifests and overlays for default,
Istio, and GKE providers. New Makefile targets: kustomize-build, kustomize-deploy,
kustomize-undeploy (KUSTOMIZE_OVERLAY=default|istio|gke).
```
