### PR TITLE
Add GetModels(predicate) to Datastore interface

### DIFF
--- a/pkg/datastore/fakedatastore.go
+++ b/pkg/datastore/fakedatastore.go
@@ -38,3 +38,15 @@ func (f *fakeDataStore) Models() []string {
 	}
 	return names
 }
+
+func (f *fakeDataStore) GetModels(predicate func(datalayer.Model) bool) []datalayer.Model {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	result := make([]datalayer.Model, 0, len(f.models))
+	for _, m := range f.models {
+		if predicate(m) {
+			result = append(result, m)
+		}
+	}
+	return result
+}

--- a/pkg/datastore/inmemory/datastore.go
+++ b/pkg/datastore/inmemory/datastore.go
@@ -67,3 +67,17 @@ func (s *store) Models() []string {
 	}
 	return names
 }
+
+// GetModels returns all models matching predicate under a single read lock.
+// Pass a predicate that always returns true to retrieve all models.
+func (s *store) GetModels(predicate func(datalayer.Model) bool) []datalayer.Model {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	result := make([]datalayer.Model, 0, len(s.models))
+	for _, m := range s.models {
+		if predicate(m) {
+			result = append(result, m)
+		}
+	}
+	return result
+}

--- a/pkg/datastore/inmemory/datastore_test.go
+++ b/pkg/datastore/inmemory/datastore_test.go
@@ -155,6 +155,74 @@ func TestAttributeNilValue(t *testing.T) {
 	}
 }
 
+// TestGetModelsAll tests that GetModels with an always-true predicate returns all models.
+func TestGetModelsAll(t *testing.T) {
+	s := NewDatastore()
+	s.GetOrCreateModel("gpt-4")
+	s.GetOrCreateModel("llama-3")
+	s.GetOrCreateModel("mistral")
+
+	models := s.GetModels(func(datalayer.Model) bool { return true })
+	if len(models) != 3 {
+		t.Errorf("expected 3 models, got %d", len(models))
+	}
+
+	names := make(map[string]bool)
+	for _, m := range models {
+		names[m.GetName()] = true
+	}
+	for _, expected := range []string{"gpt-4", "llama-3", "mistral"} {
+		if !names[expected] {
+			t.Errorf("missing expected model: %s", expected)
+		}
+	}
+}
+
+// TestGetModelsWithPredicate tests that GetModels filters correctly.
+func TestGetModelsWithPredicate(t *testing.T) {
+	s := NewDatastore()
+	s.GetOrCreateModel("gpt-4").GetAttributes().Put("vendor", testValue{Value: 1})
+	s.GetOrCreateModel("llama-3").GetAttributes().Put("vendor", testValue{Value: 2})
+	s.GetOrCreateModel("mistral").GetAttributes().Put("vendor", testValue{Value: 1})
+
+	models := s.GetModels(func(m datalayer.Model) bool {
+		v, ok := m.GetAttributes().Get("vendor")
+		return ok && v.(testValue).Value == 1
+	})
+	if len(models) != 2 {
+		t.Errorf("expected 2 models matching predicate, got %d", len(models))
+	}
+
+	names := make(map[string]bool)
+	for _, m := range models {
+		names[m.GetName()] = true
+	}
+	if !names["gpt-4"] || !names["mistral"] {
+		t.Errorf("expected gpt-4 and mistral, got %v", names)
+	}
+}
+
+// TestGetModelsNoneMatch tests that GetModels returns empty when no models match.
+func TestGetModelsNoneMatch(t *testing.T) {
+	s := NewDatastore()
+	s.GetOrCreateModel("gpt-4")
+	s.GetOrCreateModel("llama-3")
+
+	models := s.GetModels(func(datalayer.Model) bool { return false })
+	if len(models) != 0 {
+		t.Errorf("expected 0 models, got %d", len(models))
+	}
+}
+
+// TestGetModelsEmpty tests that GetModels on an empty store returns empty.
+func TestGetModelsEmpty(t *testing.T) {
+	s := NewDatastore()
+	models := s.GetModels(func(datalayer.Model) bool { return true })
+	if len(models) != 0 {
+		t.Errorf("expected 0 models on empty store, got %d", len(models))
+	}
+}
+
 // TestConcurrentAttributeAccess tests concurrent reads and writes to model attributes.
 func TestConcurrentAttributeAccess(t *testing.T) {
 	s := NewDatastore()

--- a/pkg/framework/interface/datalayer/datastore.go
+++ b/pkg/framework/interface/datalayer/datastore.go
@@ -21,4 +21,7 @@ type Datastore interface {
 	GetOrCreateModel(name string) Model
 	DeleteModel(name string)
 	Models() []string
+	// GetModels returns all models matching predicate in a single call.
+	// Pass a predicate that always returns true to retrieve all models.
+	GetModels(predicate func(Model) bool) []Model
 }


### PR DESCRIPTION
## Summary

- Add `GetModels(predicate func(Model) bool) []Model` to the `Datastore` interface
- Implement in the in-memory store under a single read lock
- Update the test fake datastore to satisfy the new interface

Closes #141

## Details

The current `Datastore` interface forces callers to use a two-step pattern to retrieve models: call `Models()` to get a list of names, then loop over each name calling `GetOrCreateModel(name)` individually. This leaks the internal representation (a list of names) and imposes per-call locking overhead on the hot path.

`GetModels(predicate)` returns all matching models in a single call under one read lock. Callers that want all models pass a predicate that always returns true. The existing `Models()` and `GetOrCreateModel()` methods are unchanged for backward compatibility.

## Test plan

- [x] `TestGetModelsAll`: always-true predicate returns all models
- [x] `TestGetModelsWithPredicate`: attribute-based filtering returns correct subset
- [x] `TestGetModelsNoneMatch`: always-false predicate returns empty slice
- [x] `TestGetModelsEmpty`: empty store returns empty slice
- [x] All existing tests pass (12 tests in inmemory, full `./pkg/...` suite green)