### PR TITLE
feat: parse SSE streaming responses for response plugins

### DIFF
--- a/pkg/handlers/response.go
+++ b/pkg/handlers/response.go
@@ -17,6 +17,7 @@ limitations under the License.
 package handlers
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -44,9 +45,9 @@ func (s *Server) HandleResponseHeaders(ctx context.Context, reqCtx *RequestConte
 
 	if !headers.GetEndOfStream() {
 		log.FromContext(ctx).V(logutil.VERBOSE).Info("captured response headers, deferring response until body arrives...")
-		return nil
 	}
-	// EndOfStream means no body is expected, return HeadersResponse immediately
+	// Always respond to response headers so Envoy proceeds with body chunks.
+	// In STREAMED/FULL_DUPLEX_STREAMED mode, Envoy blocks until we respond.
 	return []*eppb.ProcessingResponse{
 		{
 			Response: &eppb.ProcessingResponse_ResponseHeaders{
@@ -64,8 +65,15 @@ func (s *Server) HandleResponseBody(ctx context.Context, reqCtx *RequestContext,
 	}
 
 	if err := json.Unmarshal(responseBodyBytes, &reqCtx.Response.Body); err != nil {
-		logger.Error(err, "Failed to parse response body as JSON, skipping response plugins")
-		return s.generateEmptyResponseBodyResponse(responseBodyBytes), nil
+		// Try parsing as SSE (Server-Sent Events) — streaming responses from providers
+		// like Anthropic use SSE format which isn't valid JSON.
+		if sseBody, sseErr := parseSSEResponseBody(responseBodyBytes); sseErr == nil && sseBody != nil {
+			reqCtx.Response.Body = sseBody
+			logger.V(logutil.VERBOSE).Info("parsed SSE response body for response plugins")
+		} else {
+			logger.Error(err, "Failed to parse response body as JSON or SSE, skipping response plugins")
+			return s.generateEmptyResponseBodyResponse(responseBodyBytes), nil
+		}
 	}
 
 	if err := s.runResponsePlugins(ctx, reqCtx.CycleState, reqCtx.Response); err != nil {
@@ -128,6 +136,62 @@ func (s *Server) HandleResponseTrailers(trailers *eppb.HttpTrailers) ([]*eppb.Pr
 			},
 		},
 	}, nil
+}
+
+// parseSSEResponseBody extracts a composite response body from an SSE (Server-Sent Events)
+// stream. It scans all "data:" lines for JSON objects and merges usage/model fields into
+// a single map that response plugins can process. This enables usage-tracking and metering
+// plugins to work with streaming responses from providers like Anthropic and OpenAI.
+func parseSSEResponseBody(body []byte) (map[string]any, error) {
+	result := map[string]any{}
+	lines := bytes.Split(body, []byte("\n"))
+
+	for _, line := range lines {
+		line = bytes.TrimSpace(line)
+		if !bytes.HasPrefix(line, []byte("data:")) {
+			continue
+		}
+		data := bytes.TrimSpace(line[5:])
+		if len(data) == 0 || bytes.Equal(data, []byte("[DONE]")) {
+			continue
+		}
+
+		var event map[string]any
+		if err := json.Unmarshal(data, &event); err != nil {
+			continue
+		}
+
+		if model, ok := event["model"].(string); ok && model != "" {
+			result["model"] = model
+		}
+
+		// Check for usage at top level (Anthropic) or nested in response (OpenAI Responses API)
+		usage, _ := event["usage"].(map[string]any)
+		if usage == nil {
+			if resp, ok := event["response"].(map[string]any); ok {
+				usage, _ = resp["usage"].(map[string]any)
+				if m, ok := resp["model"].(string); ok && m != "" {
+					result["model"] = m
+				}
+			}
+		}
+		if usage != nil {
+			existing, _ := result["usage"].(map[string]any)
+			if existing == nil {
+				existing = map[string]any{}
+			}
+			for k, v := range usage {
+				existing[k] = v
+			}
+			result["usage"] = existing
+		}
+	}
+
+	if len(result) == 0 {
+		return nil, fmt.Errorf("no parseable SSE data events found")
+	}
+
+	return result, nil
 }
 
 // runResponsePlugins executes response plugins in the order they were registered.

--- a/pkg/handlers/server.go
+++ b/pkg/handlers/server.go
@@ -141,6 +141,16 @@ func (s *Server) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
 			loggerVerbose.Info("Incoming response body chunk", "EoS", v.ResponseBody.EndOfStream)
 			responseBody = append(responseBody, v.ResponseBody.Body...)
 			if !v.ResponseBody.EndOfStream {
+				// Send an immediate response for this chunk so Envoy continues
+				// streaming. Without this, Envoy blocks waiting for our response
+				// and stops forwarding subsequent chunks.
+				if sendErr := srv.Send(&extProcPb.ProcessingResponse{
+					Response: &extProcPb.ProcessingResponse_ResponseBody{
+						ResponseBody: &extProcPb.BodyResponse{},
+					},
+				}); sendErr != nil {
+					return status.Errorf(codes.Unknown, "failed to send streaming response ack: %v", sendErr)
+				}
 				continue
 			}
 			responses, err = s.HandleResponseBody(ctx, reqCtx, responseBody)


### PR DESCRIPTION
When the response body is not valid JSON (e.g., SSE/Server-Sent Events from streaming providers like Anthropic), parse the SSE data lines to extract usage and model information. This enables response plugins (usage-tracking, metering) to process streaming responses that were previously skipped with "Failed to parse response body as JSON".

Also fixes two issues with streaming response handling:
1. Always respond to response headers so Envoy proceeds with body chunks (previously returned nil, causing per-message timeout)
2. Send an immediate ack for each non-EoS response body chunk so Envoy continues forwarding subsequent chunks instead of blocking

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
