### PR TITLE
Load Pre-Processors and P post processor config

### DIFF
--- a/pkg/config/loader/configloader.go
+++ b/pkg/config/loader/configloader.go
@@ -74,6 +74,18 @@ func LoadConfiguration(configBytes []byte, handle plugin.Handle, logger logr.Log
 		return nil, err
 	}
 
+	preProcessors, err := buildPreProcessors(rawConfig.PreProcessing, handle)
+	if err != nil {
+		logger.Error(err, "failed to load one or more pre-processors")
+		return nil, err
+	}
+
+	postProcessors, err := buildPostProcessors(rawConfig.PostProcessing, handle)
+	if err != nil {
+		logger.Error(err, "failed to load one or more post-processors")
+		return nil, err
+	}
+
 	notificationSources, err := buildNotificationSources(rawConfig.NotificationSources, handle)
 	if err != nil {
 		logger.Error(err, "failed to load one or more notification sources")
@@ -83,7 +95,9 @@ func LoadConfiguration(configBytes []byte, handle plugin.Handle, logger logr.Log
 	pollingSources, err := buildPollingSources(rawConfig.PollingSources, handle)
 	if err != nil {
 		logger.Error(err, "failed to load one or more polling sources")
+		return nil, err
 	}
+
 	if err = buildModelSelector(profiles, handle); err != nil {
 		logger.Error(err, "failed to build model selector profiles")
 		return nil, err
@@ -92,6 +106,8 @@ func LoadConfiguration(configBytes []byte, handle plugin.Handle, logger logr.Log
 	return &config.Config{
 		ProfilePicker:       profilePicker,
 		Profiles:            profiles,
+		PreProcessors:       preProcessors,
+		PostProcessors:      postProcessors,
 		NotificationSources: notificationSources,
 		PollingSources:      pollingSources,
 	}, nil
@@ -246,6 +262,50 @@ func buildProfiles(rawProfiles []configapi.Profile, handle plugin.Handle) (map[s
 	}
 
 	return profiles, nil
+}
+
+func buildPreProcessors(rawConfig *configapi.PluginRefList, handle plugin.Handle) ([]requesthandling.PreProcessor, error) {
+	if rawConfig == nil || len(rawConfig.Plugins) == 0 {
+		return []requesthandling.PreProcessor{}, nil
+	}
+
+	preProcessors := make([]requesthandling.PreProcessor, len(rawConfig.Plugins))
+
+	for idx, pluginRef := range rawConfig.Plugins {
+		rawPlugin := handle.Plugin(pluginRef.PluginRef)
+		if rawPlugin == nil {
+			return nil, fmt.Errorf("the referenced pre-processor plugin %s doesn't exist in the configuration", pluginRef.PluginRef)
+		}
+		if preProcessor, ok := rawPlugin.(requesthandling.PreProcessor); ok {
+			preProcessors[idx] = preProcessor
+		} else {
+			return nil, fmt.Errorf("the referenced plugin %s is not a pre-processor", pluginRef.PluginRef)
+		}
+	}
+
+	return preProcessors, nil
+}
+
+func buildPostProcessors(rawConfig *configapi.PluginRefList, handle plugin.Handle) ([]requesthandling.PostProcessor, error) {
+	if rawConfig == nil || len(rawConfig.Plugins) == 0 {
+		return []requesthandling.PostProcessor{}, nil
+	}
+
+	postProcessors := make([]requesthandling.PostProcessor, len(rawConfig.Plugins))
+
+	for idx, pluginRef := range rawConfig.Plugins {
+		rawPlugin := handle.Plugin(pluginRef.PluginRef)
+		if rawPlugin == nil {
+			return nil, fmt.Errorf("the referenced post-processor plugin %s doesn't exist in the configuration", pluginRef.PluginRef)
+		}
+		if postProcessor, ok := rawPlugin.(requesthandling.PostProcessor); ok {
+			postProcessors[idx] = postProcessor
+		} else {
+			return nil, fmt.Errorf("the referenced plugin %s is not a post-processor", pluginRef.PluginRef)
+		}
+	}
+
+	return postProcessors, nil
 }
 
 // buildModelSelector iterates all built profiles and, for each model-selector plugin found in

--- a/pkg/config/loader/configloader_test.go
+++ b/pkg/config/loader/configloader_test.go
@@ -48,6 +48,8 @@ const (
 	testFilterType       = "test-filter"
 	testPickerType       = "test-picker"
 	testPluginType       = "test-plugin"
+	testPostProcessor    = "test-post-processor"
+	testPreProcessor     = "test-pre-processor"
 	testProfilePicker    = "test-profile-picker"
 	testRequestProcType  = "test-request-processor"
 	testResponseProcType = "test-response-processor"
@@ -326,6 +328,88 @@ func TestBuildProfiles(t *testing.T) {
 	}
 }
 
+func TestBuildPreAndPostProcessors(t *testing.T) {
+	// Not parallel because it modifies global plugin registry.
+	registerTestPlugins(t)
+
+	tests := []struct {
+		name       string
+		configText string
+		preLen     int
+		postLen    int
+		wantErr    bool
+	}{
+		{
+			name:       "successConfigPreAndPostProcessors",
+			configText: successConfigPreAndPostProcessorsText,
+			preLen:     2,
+			postLen:    1,
+		},
+		{
+			name:       "successConfigPreProcessorsOnly",
+			configText: successConfigPreProcessorsOnlyText,
+			preLen:     2,
+			postLen:    0,
+		},
+		{
+			name:       "successConfigPostProcessorsOnly",
+			configText: successConfigPostProcessorsOnlyText,
+			preLen:     0,
+			postLen:    1,
+		},
+		{
+			name:       "errorBadPreProcessors",
+			configText: errorBadPreProcessorsText,
+			wantErr:    true,
+		},
+		{
+			name:       "errorBadPostProcessors",
+			configText: errorBadPostProcessorsText,
+			wantErr:    true,
+		},
+		{
+			name:       "errorMissingPreProcessors",
+			configText: errorMissingPreProcessorsText,
+			wantErr:    true,
+		},
+		{
+			name:       "errorMissingPostProcessors",
+			configText: errorMissingPostProcessorsText,
+			wantErr:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			logger := logging.NewTestLogger()
+
+			rawConfig, err := loadRawConfiguration([]byte(tc.configText), logger)
+			require.NoError(t, err, "setup: loadRawConfiguration failed")
+
+			handle := plugin.NewHandle(context.Background(), nil, nil)
+			err = instantiatePlugins(rawConfig.Plugins, handle)
+			require.NoError(t, err, "setup: instantiatePlugins failed")
+
+			preProcessors, preErr := buildPreProcessors(rawConfig.PreProcessing, handle)
+			postProcessors, postErr := buildPostProcessors(rawConfig.PostProcessing, handle)
+
+			if tc.wantErr {
+				if preErr == nil && postErr == nil {
+					t.Logf("either buildPreProcessors or buildPostProcessors was suppose to fail")
+				}
+				t.Log("preErr=", preErr)
+				t.Log("postErr=", postErr)
+			} else {
+				require.NoError(t, preErr, "buildPreProcessors wasn't suppose to fail")
+				require.NoError(t, postErr, "buildPostProcessors wasn't suppose to fail")
+
+				require.Equal(t, tc.preLen, len(preProcessors), "buildPreProcessors didn't return the correct number of pre-processors")
+				require.Equal(t, tc.postLen, len(postProcessors), "buildPostProcessors didn't return the correct number of post-processors")
+			}
+		})
+	}
+}
+
 // TestBuildNotificationSources verifies that notification source plugins are resolved and built from config refs.
 func TestBuildNotificationSources(t *testing.T) {
 	// Not parallel because it modifies global plugin registry.
@@ -448,10 +532,30 @@ type mockPlugin struct {
 
 func (m *mockPlugin) TypedName() plugin.TypedName { return m.t }
 
+// Mock PreProcessor
+type mockPreProcessor struct{ mockPlugin }
+
+// compile time assertion
+var _ requesthandling.PreProcessor = &mockPreProcessor{}
+
+func (m *mockPreProcessor) PreProcess(ctx context.Context, cycleState *plugin.CycleState, request *requesthandling.InferenceRequest) error {
+	return nil
+}
+
+// Mock PostProcessor
+type mockPostProcessor struct{ mockPlugin }
+
+// compile time assertion
+var _ requesthandling.PostProcessor = &mockPostProcessor{}
+
+func (m *mockPostProcessor) PostProcess(ctx context.Context, cycleState *plugin.CycleState, request *requesthandling.InferenceResponse) error {
+	return nil
+}
+
 // Mock ProfilePicker
 type mockProfilePicker struct{ mockPlugin }
 
-// compiel-time type assertion
+// compile-time type assertion
 var _ requesthandling.ProfilePicker = &mockProfilePicker{}
 
 func (m *mockProfilePicker) Pick(ctx context.Context, cycleState *plugin.CycleState, request *requesthandling.InferenceRequest,
@@ -516,6 +620,16 @@ func registerTestPlugins(t *testing.T) {
 	plugin.Register(testPluginType,
 		func(name string, params json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
 			return &mockPlugin{t: plugin.TypedName{Name: name, Type: testPluginType}}, nil
+		})
+
+	plugin.Register(testPreProcessor,
+		func(name string, params json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
+			return &mockPreProcessor{mockPlugin{t: plugin.TypedName{Name: name, Type: testPreProcessor}}}, nil
+		})
+
+	plugin.Register(testPostProcessor,
+		func(name string, params json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
+			return &mockPostProcessor{mockPlugin{t: plugin.TypedName{Name: name, Type: testPostProcessor}}}, nil
 		})
 
 	plugin.Register(testProfilePicker,

--- a/pkg/config/loader/configloader_test.go
+++ b/pkg/config/loader/configloader_test.go
@@ -315,7 +315,7 @@ func TestBuildProfiles(t *testing.T) {
 			profiles, errProf := buildProfiles(rawConfig.Profiles, handle)
 			if tc.wantErr {
 				if err == nil && errProf == nil {
-					t.Logf("either applyPluginDefaults or buildProfiles was suppose to fail")
+					t.Errorf("either applyPluginDefaults or buildProfiles was suppose to fail")
 				}
 				return
 			}
@@ -395,7 +395,7 @@ func TestBuildPreAndPostProcessors(t *testing.T) {
 
 			if tc.wantErr {
 				if preErr == nil && postErr == nil {
-					t.Logf("either buildPreProcessors or buildPostProcessors was suppose to fail")
+					t.Errorf("either buildPreProcessors or buildPostProcessors was suppose to fail")
 				}
 				t.Log("preErr=", preErr)
 				t.Log("postErr=", postErr)

--- a/pkg/config/loader/testdata_test.go
+++ b/pkg/config/loader/testdata_test.go
@@ -105,6 +105,56 @@ profiles:
     - pluginRef: test-response-processor
 `
 
+// successConfigPreAndPostProcessorsText represents both pre-processors and post-processors.
+const successConfigPreAndPostProcessorsText = `
+apiVersion: llm-d.ai/v1alpha1
+kind: PayloadProcessorConfig
+plugins:
+- type: test-pre-processor
+- name: pre-processor-2
+  type: test-pre-processor
+- type: test-post-processor
+preProcessing:
+  plugins:
+  - pluginRef: pre-processor-2
+  - pluginRef: test-pre-processor
+postProcessing:
+  plugins:
+  - pluginRef: test-post-processor
+`
+
+// successConfigPreProcessorsOnlyText represents only pre-processors.
+const successConfigPreProcessorsOnlyText = `
+apiVersion: llm-d.ai/v1alpha1
+kind: PayloadProcessorConfig
+plugins:
+- type: test-pre-processor
+- name: pre-processor-2
+  type: test-pre-processor
+- type: test-post-processor
+preProcessing:
+  plugins:
+  - pluginRef: pre-processor-2
+  - pluginRef: test-pre-processor
+postProcessing:
+  plugins:
+`
+
+// successConfigPreAndPostProcessorsText represents only post-processors.
+const successConfigPostProcessorsOnlyText = `
+apiVersion: llm-d.ai/v1alpha1
+kind: PayloadProcessorConfig
+plugins:
+- type: test-pre-processor
+- name: pre-processor-2
+  type: test-pre-processor
+- type: test-post-processor
+preProcessing:
+postProcessing:
+  plugins:
+  - pluginRef: test-post-processor
+`
+
 // datalayerSuccessConfigText has a valid notification-source reference.
 const datalayerSuccessConfigText = `
 apiVersion: llm-d.ai/v1alpha1
@@ -140,6 +190,27 @@ plugins:
     threshold: 10
 notificationSources:
 - pluginRef: test1
+`
+
+// modelSelectorAllPluginTypesText wires a Filter, a weighted Scorer, and a Picker
+// alongside a model-selector RequestProcessor plugin in the same profile.
+const modelSelectorAllPluginTypesText = `
+apiVersion: llm-d.ai/v1alpha1
+kind: PayloadProcessorConfig
+plugins:
+- type: model-selector
+- type: test-filter
+- type: cost-scorer
+- type: max-score-picker
+profiles:
+- name: default
+  plugins:
+    request:
+    - pluginRef: model-selector
+    - pluginRef: test-filter
+    - pluginRef: cost-scorer
+      weight: 2.5
+    - pluginRef: max-score-picker
 `
 
 // --- Invalid Configurations (Syntax/Structure) ---
@@ -217,27 +288,6 @@ profiles:
     - pluginRef: test-response-processor
 `
 
-// modelSelectorAllPluginTypesText wires a Filter, a weighted Scorer, and a Picker
-// alongside a model-selector RequestProcessor plugin in the same profile.
-const modelSelectorAllPluginTypesText = `
-apiVersion: llm-d.ai/v1alpha1
-kind: PayloadProcessorConfig
-plugins:
-- type: model-selector
-- type: test-filter
-- type: cost-scorer
-- type: max-score-picker
-profiles:
-- name: default
-  plugins:
-    request:
-    - pluginRef: model-selector
-    - pluginRef: test-filter
-    - pluginRef: cost-scorer
-      weight: 2.5
-    - pluginRef: max-score-picker
-`
-
 // modelSelectorScorerMissingWeightText is an error case: scorer without a weight.
 const modelSelectorScorerMissingWeightText = `
 apiVersion: llm-d.ai/v1alpha1
@@ -306,4 +356,48 @@ plugins:
     threshold: 10
 pollingSources:
 - pluginRef: test1
+`
+
+// errorBadPreProcessorsText represents a reference to a plugin that is not a pre-processor
+const errorBadPreProcessorsText = `
+apiVersion: llm-d.ai/v1alpha1
+kind: PayloadProcessorConfig
+plugins:
+- type: test-request-processor
+preProcessing:
+  plugins:
+  - pluginRef: test-request-processor
+`
+
+// errorBadPostProcessorsText represents a reference to a plugin that is not a post-processor
+const errorBadPostProcessorsText = `
+apiVersion: llm-d.ai/v1alpha1
+kind: PayloadProcessorConfig
+plugins:
+- type: test-response-processor
+postProcessing:
+  plugins:
+  - pluginRef: test-response-processor
+`
+
+// errorMissingPreProcessorsText represents a reference to an unknown pre-processor
+const errorMissingPreProcessorsText = `
+apiVersion: llm-d.ai/v1alpha1
+kind: PayloadProcessorConfig
+plugins:
+- type: test-request-processor
+preProcessing:
+  plugins:
+  - pluginRef: test-pre-processor
+`
+
+// errorMissingPostProcessorsText represents a reference to an unknown post-processor
+const errorMissingPostProcessorsText = `
+apiVersion: llm-d.ai/v1alpha1
+kind: PayloadProcessorConfig
+plugins:
+- type: test-response-processor
+postProcessing:
+  plugins:
+  - pluginRef: test-post-processor
 `

--- a/pkg/config/loader/testdata_test.go
+++ b/pkg/config/loader/testdata_test.go
@@ -275,8 +275,6 @@ kind: PayloadProcessorConfig
 plugins:
 - type: test-request-processor
 - type: test-response-processor
-profilePicker:
-  pluginRef: test-profile-picker
 profiles:
 - name: one
   plugins:

--- a/pkg/framework/interface/requesthandling/plugins.go
+++ b/pkg/framework/interface/requesthandling/plugins.go
@@ -54,5 +54,5 @@ type PostProcessor interface {
 	plugin.Plugin
 
 	// PostProcess is invoked to post-process requests after the response plugins of the selected profile run.
-	PostProcess(ctx context.Context, cycleState *plugin.CycleState, request *InferenceRequest) error
+	PostProcess(ctx context.Context, cycleState *plugin.CycleState, response *InferenceResponse) error
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR loads the configuration with the pre-processor and post-processor plugins from the textual configuration

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
