### PR TITLE
feat: add WithCustomControllers for registering controllers outside plugin chain

### DIFF
--- a/cmd/runner/runner.go
+++ b/cmd/runner/runner.go
@@ -29,7 +29,9 @@ import (
 	healthPb "google.golang.org/grpc/health/grpc_health_v1"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlbuilder "sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -66,6 +68,7 @@ func NewRunner() *Runner {
 		payloadProcessorExecutableName: "payload-processor",
 		profiles:                       map[string]*requesthandling.Profile{},
 		customCollectors:               []prometheus.Collector{},
+		customControllers:              []func(client.Client, *ctrlbuilder.Builder) error{},
 	}
 }
 
@@ -77,8 +80,9 @@ type Runner struct {
 	// profiles is the set of named profiles loaded from the configuration
 	profiles map[string]*requesthandling.Profile
 
-	customCollectors []prometheus.Collector
-	processor        datasource.DatalayerProcessor
+	customCollectors  []prometheus.Collector
+	customControllers []func(client.Client, *ctrlbuilder.Builder) error
+	processor         datasource.DatalayerProcessor
 }
 
 // WithExecutableName sets the name of the executable containing the runner.
@@ -91,6 +95,18 @@ func (r *Runner) WithExecutableName(exeName string) *Runner {
 // WithCustomCollectors sets custom prometheus metrics collectors
 func (r *Runner) WithCustomCollectors(collectors ...prometheus.Collector) *Runner {
 	r.customCollectors = collectors
+	return r
+}
+
+// WithCustomControllers registers controller setup functions that run outside
+// the plugin chain. Use this for control-plane controllers that create
+// infrastructure resources (Services, HTTPRoutes, etc.) and should not be
+// coupled to data-plane plugin lifecycle.
+// Each function receives a client (for scheme access and reconciler construction)
+// and a builder scoped to the manager — matching the Handle.ReconcilerBuilder()
+// pattern used by plugins.
+func (r *Runner) WithCustomControllers(setupFuncs ...func(client.Client, *ctrlbuilder.Builder) error) *Runner {
+	r.customControllers = setupFuncs
 	return r
 }
 
@@ -174,6 +190,13 @@ func (r *Runner) Run(ctx context.Context) error {
 		setupLog.Info("Setting pprof handlers")
 		if err = profiling.SetupPprofHandlers(mgr); err != nil {
 			setupLog.Error(err, "Failed to setup pprof handlers")
+			return err
+		}
+	}
+
+	for _, customControllerFunc := range r.customControllers {
+		if err := customControllerFunc(mgr.GetClient(), ctrl.NewControllerManagedBy(mgr)); err != nil {
+			setupLog.Error(err, "Failed to register custom controller")
 			return err
 		}
 	}

--- a/cmd/runner/runner.go
+++ b/cmd/runner/runner.go
@@ -98,13 +98,10 @@ func (r *Runner) WithCustomCollectors(collectors ...prometheus.Collector) *Runne
 	return r
 }
 
-// WithCustomControllers registers controller setup functions that run outside
-// the plugin chain. Use this for control-plane controllers that create
+// WithCustomControllers registers custom controllers within the 
+// controller manager. Use this for control-plane controllers that create
 // infrastructure resources (Services, HTTPRoutes, etc.) and should not be
 // coupled to data-plane plugin lifecycle.
-// Each function receives a client (for scheme access and reconciler construction)
-// and a builder scoped to the manager — matching the Handle.ReconcilerBuilder()
-// pattern used by plugins.
 func (r *Runner) WithCustomControllers(setupFuncs ...func(client.Client, *ctrlbuilder.Builder) error) *Runner {
 	r.customControllers = setupFuncs
 	return r

--- a/cmd/runner/runner.go
+++ b/cmd/runner/runner.go
@@ -98,7 +98,7 @@ func (r *Runner) WithCustomCollectors(collectors ...prometheus.Collector) *Runne
 	return r
 }
 
-// WithCustomControllers registers custom controllers within the 
+// WithCustomControllers registers custom controllers within the
 // controller manager. Use this for control-plane controllers that create
 // infrastructure resources (Services, HTTPRoutes, etc.) and should not be
 // coupled to data-plane plugin lifecycle.


### PR DESCRIPTION
## Summary

Add a `WithCustomControllers` option to the Runner for registering controller-runtime controllers directly on the manager, outside the plugin lifecycle.

**Problem:** Downstream consumers (e.g. [ai-gateway-payload-processing](https://github.com/opendatahub-io/ai-gateway-payload-processing)) need to register control-plane controllers that create infrastructure resources (Services, HTTPRoutes, Istio resources) from CRDs. Currently, the only way to register controllers is inside a plugin via the Handle's `ReconcilerBuilder`. However, plugins are data-plane components — adding `Owns()` watchers for Services and HTTPRoutes inside a plugin adds heavy informer caches that interfere with the ext-proc gRPC server startup and responsiveness.

**Solution:** `WithCustomControllers` accepts one or more `func(ctrl.Manager) error` setup functions that run after manager creation and before plugin construction. This follows the existing `With*` pattern (`WithExecutableName`, `WithCustomCollectors`).

```go
runner.NewRunner().
    WithExecutableName("my-processor").
    WithCustomControllers(
        func(mgr ctrl.Manager) error {
            return ctrl.NewControllerManagedBy(mgr).
                For(&MyResource{}).
                Owns(&corev1.Service{}).
                Complete(&MyReconciler{Client: mgr.GetClient()})
        },
    ).
    Run(ctx)
```

## Changes

- `Runner` struct: new `customControllerSetupFuncs` field
- `WithCustomControllers()`: functional option method
- `Run()`: executes setup funcs after manager creation, before plugin loading

20 lines added, 1 file changed.

## Test plan

- [x] `make test` — all tests pass
- [x] `make lint` — 0 issues
- [x] `go build ./...` — compiles

## References

- opendatahub-io/ai-gateway-payload-processing#310 — blocked by this framework gap
- Discussion with @nirrozenbaum about separating control-plane vs data-plane controller registration