### PR TITLE
updated size labeler workflow, don't put hold

### DIFF
--- a/.github/workflows/pr-size-labeler.yml
+++ b/.github/workflows/pr-size-labeler.yml
@@ -32,20 +32,3 @@ jobs:
               "500": "XL",
               "1000": "XXL"
             }
-
-      - name: Hold large PRs
-        if: contains(steps.size.outputs.sizeLabel, 'XL')
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh pr edit ${{ github.event.pull_request.number }} \
-            --repo ${{ github.repository }} \
-            --add-label "do-not-merge/hold"
-          
-          gh pr comment ${{ github.event.pull_request.number }} \
-            --repo ${{ github.repository }} \
-            --body "⚠️ **Large PR detected**
-
-          Your PR is large. Please consider breaking it into multiple PRs.
-
-          The \`do-not-merge/hold\` label has been added and can be removed by the reviewers based on their judgement."


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
remove the functionality to auto label a PR with `hold` based on its size. This is disturbing in identifying which PRs were put on hold by maintainers (or authors) and which were labeled automatically. maintainers do not really need this functionality since they can look on the size label.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
