### PR TITLE
feat: add active health checks for model endpoints

### DIFF
--- a/cmd/runner/runner.go
+++ b/cmd/runner/runner.go
@@ -48,6 +48,9 @@ import (
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/plugin"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/requesthandling"
 	requestmetadata "github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/plugins/datalayer/requestmetadata"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/plugins/datalayer/healthcheck"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/plugins/datalayer/modeldiscovery"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/plugins/modelselector/filter/healthfilter"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/plugins/modelselector/picker/maxscore"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/plugins/modelselector/picker/random"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/plugins/modelselector/picker/weightedrandom"
@@ -283,6 +286,11 @@ func (r *Runner) registerInTreePlugins() {
 	plugin.Register(weightedrandom.WeightedRandomPickerType, weightedrandom.WeightedRandomPickerFactory)
 	plugin.Register(modelselectorplugin.ModelSelectorPluginType, modelselectorplugin.ModelSelectorPluginFactory)
 	plugin.Register(inflightrequestsscorer.PluginType, inflightrequestsscorer.ScorerFactory)
+	// health check plugins
+	plugin.Register(healthcheck.PluginType, healthcheck.DatasourceFactory)
+	plugin.Register(healthfilter.PluginType, healthfilter.FilterFactory)
+	// model discovery plugin (auto-discovers pods from InferencePools)
+	plugin.Register(modeldiscovery.PluginType, modeldiscovery.DatasourceFactory)
 }
 
 // registerHealthServer adds the Health gRPC server as a Runnable to the given manager.

--- a/pkg/framework/plugins/datalayer/healthcheck/checker.go
+++ b/pkg/framework/plugins/datalayer/healthcheck/checker.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package healthcheck
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+)
+
+// Checker performs a single health check probe.
+type Checker interface {
+	Check(ctx context.Context) bool
+}
+
+// modelsResponse represents the OpenAI-compatible /v1/models response.
+type modelsResponse struct {
+	Data []struct {
+		ID string `json:"id"`
+	} `json:"data"`
+}
+
+// ModelHTTPChecker sends GET /v1/models and verifies that the expected model
+// name exists in the returned list. This covers TCP connectivity (connection
+// failure = unhealthy), server liveness (non-2xx = unhealthy), and model
+// availability (model name missing from response = unhealthy).
+type ModelHTTPChecker struct {
+	URL       string
+	ModelName string
+	Client    *http.Client
+}
+
+func (c *ModelHTTPChecker) Check(ctx context.Context) bool {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.URL, nil)
+	if err != nil {
+		return false
+	}
+	resp, err := c.Client.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return false
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return false
+	}
+
+	var models modelsResponse
+	if err := json.Unmarshal(body, &models); err != nil {
+		return false
+	}
+
+	for _, m := range models.Data {
+		if m.ID == c.ModelName {
+			return true
+		}
+	}
+	return false
+}
+
+// CheckConfig is an internal struct used by newChecker to construct a Checker.
+type CheckConfig struct {
+	Model   string
+	Type    string
+	URL     string
+	Timeout Duration
+}
+
+// Duration wraps time.Duration for internal use.
+type Duration struct {
+	time.Duration
+}
+
+// newChecker creates a Checker for the given check configuration.
+func newChecker(cfg CheckConfig) Checker {
+	timeout := cfg.Timeout.Duration
+	if timeout == 0 {
+		timeout = 3 * time.Second
+	}
+
+	var client *http.Client
+	if cfg.Type == "https" {
+		client = &http.Client{
+			Timeout: timeout,
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12},
+			},
+		}
+	} else {
+		client = &http.Client{Timeout: timeout}
+	}
+
+	return &ModelHTTPChecker{URL: cfg.URL, ModelName: cfg.Model, Client: client}
+}

--- a/pkg/framework/plugins/datalayer/healthcheck/datasource.go
+++ b/pkg/framework/plugins/datalayer/healthcheck/datasource.go
@@ -1,0 +1,324 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package healthcheck
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/datalayer"
+	dlsrc "github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/datalayer/datasource"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/plugin"
+)
+
+// PluginType is the identifier used when registering this datasource.
+const PluginType = "health-check-datasource"
+
+// compile-time interface assertion
+var _ dlsrc.DataSource = &HealthCheckDataSource{}
+
+const defaultReconcileInterval = 5 * time.Second
+
+// DatasourcePluginConfig holds optional plugin-level defaults.
+type DatasourcePluginConfig struct {
+	ReconcileInterval string `json:"reconcileInterval,omitempty"`
+}
+
+// endpointState tracks consecutive successes/failures for one model.
+type endpointState struct {
+	consecutiveSuccesses int
+	consecutiveFailures  int
+	status               HealthStatus
+	cancel               context.CancelFunc
+}
+
+// HealthCheckDataSource discovers health check configuration from the Datastore
+// (written by model-config-datasource) and runs background probes accordingly.
+// It reconciles periodically to pick up additions/removals at runtime.
+type HealthCheckDataSource struct {
+	typedName         plugin.TypedName
+	ds                datalayer.Datastore
+	reconcileInterval time.Duration
+	states            map[string]*endpointState
+	mu                sync.RWMutex
+	stopCh            chan struct{}
+	doneCh            chan struct{}
+	wg                sync.WaitGroup
+}
+
+// DatasourceFactory creates a HealthCheckDataSource from plugin configuration.
+func DatasourceFactory(name string, rawCfg json.RawMessage, h plugin.Handle) (plugin.Plugin, error) {
+	reconcileInterval := defaultReconcileInterval
+
+	if rawCfg != nil && len(rawCfg) > 0 {
+		var cfg DatasourcePluginConfig
+		if err := json.Unmarshal(rawCfg, &cfg); err == nil && cfg.ReconcileInterval != "" {
+			if d, err := time.ParseDuration(cfg.ReconcileInterval); err == nil {
+				reconcileInterval = d
+			}
+		}
+	}
+
+	return &HealthCheckDataSource{
+		typedName:         plugin.TypedName{Type: PluginType, Name: name},
+		ds:                h.Datastore(),
+		reconcileInterval: reconcileInterval,
+		states:            make(map[string]*endpointState),
+		stopCh:            make(chan struct{}),
+		doneCh:            make(chan struct{}),
+	}, nil
+}
+
+func (d *HealthCheckDataSource) TypedName() plugin.TypedName { return d.typedName }
+
+// Start launches a reconcile loop that periodically scans the Datastore for
+// models with health check configuration and starts/stops probes dynamically.
+func (d *HealthCheckDataSource) Start(ctx context.Context) error {
+	logger := log.FromContext(ctx).WithName("health-check-datasource")
+
+	d.reconcile(ctx)
+
+	d.wg.Add(1)
+	go func() {
+		defer d.wg.Done()
+		ticker := time.NewTicker(d.reconcileInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-d.stopCh:
+				return
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				d.reconcile(ctx)
+			}
+		}
+	}()
+
+	go func() {
+		d.wg.Wait()
+		close(d.doneCh)
+	}()
+
+	logger.Info("started health check datasource", "reconcileInterval", d.reconcileInterval)
+	return nil
+}
+
+// Stop signals all goroutines to exit and blocks until they finish.
+func (d *HealthCheckDataSource) Stop() {
+	close(d.stopCh)
+
+	d.mu.Lock()
+	for _, state := range d.states {
+		if state.cancel != nil {
+			state.cancel()
+		}
+	}
+	d.mu.Unlock()
+
+	<-d.doneCh
+}
+
+// reconcile scans the Datastore for models with HealthCheckConfigKey attribute
+// and starts/stops probe goroutines as needed.
+func (d *HealthCheckDataSource) reconcile(ctx context.Context) {
+	logger := log.FromContext(ctx).WithName("health-check-datasource")
+
+	models := d.ds.GetModels(func(m datalayer.Model) bool {
+		_, ok := m.GetAttributes().Get(HealthCheckConfigKey)
+		return ok
+	})
+
+	activeModels := make(map[string]struct{})
+
+	for _, model := range models {
+		name := model.GetName()
+		activeModels[name] = struct{}{}
+
+		raw, _ := model.GetAttributes().Get(HealthCheckConfigKey)
+		cfg, ok := raw.(HealthCheckConfig)
+		if !ok {
+			continue
+		}
+
+		d.mu.RLock()
+		_, exists := d.states[name]
+		d.mu.RUnlock()
+
+		if !exists {
+			d.startCheck(ctx, name, cfg)
+			logger.Info("started health check", "model", name, "url", cfg.URL)
+		}
+	}
+
+	d.mu.Lock()
+	for name, state := range d.states {
+		if _, ok := activeModels[name]; !ok {
+			if state.cancel != nil {
+				state.cancel()
+			}
+			delete(d.states, name)
+			logger.Info("stopped health check (model removed)", "model", name)
+		}
+	}
+	d.mu.Unlock()
+}
+
+// startCheck launches a goroutine that probes the given model endpoint.
+func (d *HealthCheckDataSource) startCheck(ctx context.Context, modelName string, cfg HealthCheckConfig) {
+	interval := parseDurationOrDefault(cfg.Interval, 10*time.Second)
+	timeout := parseDurationOrDefault(cfg.Timeout, 3*time.Second)
+	unhealthyThreshold := cfg.UnhealthyThreshold
+	if unhealthyThreshold == 0 {
+		unhealthyThreshold = 3
+	}
+	healthyThreshold := cfg.HealthyThreshold
+	if healthyThreshold == 0 {
+		healthyThreshold = 2
+	}
+
+	checkType := cfg.Type
+	if checkType == "" {
+		checkType = "http"
+	}
+
+	checker := newChecker(CheckConfig{
+		Model:   modelName,
+		Type:    checkType,
+		URL:     cfg.URL,
+		Timeout: Duration{timeout},
+	})
+
+	checkCtx, cancel := context.WithCancel(ctx)
+
+	d.mu.Lock()
+	d.states[modelName] = &endpointState{status: Unknown, cancel: cancel}
+	d.mu.Unlock()
+
+	d.wg.Add(1)
+	go func() {
+		defer d.wg.Done()
+		d.runCheck(checkCtx, modelName, checker, interval, timeout, unhealthyThreshold, healthyThreshold)
+	}()
+}
+
+func (d *HealthCheckDataSource) runCheck(ctx context.Context, modelName string, checker Checker, interval, timeout time.Duration, unhealthyThreshold, healthyThreshold int) {
+	logger := log.FromContext(ctx).WithName("health-check-datasource")
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-d.stopCh:
+			return
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			probeCtx, cancel := context.WithTimeout(ctx, timeout)
+			success := checker.Check(probeCtx)
+			cancel()
+
+			d.mu.RLock()
+			state, exists := d.states[modelName]
+			if !exists {
+				d.mu.RUnlock()
+				return
+			}
+			prevStatus := state.status
+			d.mu.RUnlock()
+
+			d.updateState(modelName, success, unhealthyThreshold, healthyThreshold)
+
+			d.mu.RLock()
+			newStatus := d.states[modelName].status
+			d.mu.RUnlock()
+
+			if prevStatus != newStatus {
+				logger.Info("health status changed",
+					"model", modelName,
+					"from", string(prevStatus),
+					"to", string(newStatus))
+			}
+
+			d.syncToDatastore(modelName)
+		}
+	}
+}
+
+func (d *HealthCheckDataSource) updateState(modelName string, probeSuccess bool, unhealthyThreshold, healthyThreshold int) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	state, ok := d.states[modelName]
+	if !ok {
+		return
+	}
+
+	if probeSuccess {
+		state.consecutiveSuccesses++
+		state.consecutiveFailures = 0
+		if state.consecutiveSuccesses >= healthyThreshold {
+			state.status = Healthy
+		}
+	} else {
+		state.consecutiveFailures++
+		state.consecutiveSuccesses = 0
+		if state.consecutiveFailures >= unhealthyThreshold {
+			state.status = Unhealthy
+		}
+	}
+}
+
+func (d *HealthCheckDataSource) syncToDatastore(modelName string) {
+	d.mu.RLock()
+	state, ok := d.states[modelName]
+	if !ok {
+		d.mu.RUnlock()
+		return
+	}
+	status := state.status
+	d.mu.RUnlock()
+
+	model := d.ds.GetOrCreateModel(modelName)
+	model.GetAttributes().Put(HealthAttributeKey, status)
+}
+
+// GetStatus returns the current health status of a model (for testing).
+func (d *HealthCheckDataSource) GetStatus(model string) HealthStatus {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	if s, ok := d.states[model]; ok {
+		return s.status
+	}
+	return Unknown
+}
+
+func parseDurationOrDefault(s string, def time.Duration) time.Duration {
+	if s == "" {
+		return def
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return def
+	}
+	return d
+}

--- a/pkg/framework/plugins/datalayer/healthcheck/types.go
+++ b/pkg/framework/plugins/datalayer/healthcheck/types.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package healthcheck
+
+import "github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/datalayer"
+
+const (
+	// HealthAttributeKey is the attribute key for the computed health status.
+	HealthAttributeKey = "health-status"
+
+	// HealthCheckConfigKey is the attribute key for per-model health check configuration.
+	// Written by model-config-datasource or k8s-model-discovery-datasource,
+	// read by health-check-datasource.
+	HealthCheckConfigKey = "health-check-config"
+)
+
+// HealthStatus represents the health state of a model endpoint.
+type HealthStatus string
+
+const (
+	Healthy   HealthStatus = "healthy"
+	Unhealthy HealthStatus = "unhealthy"
+	Unknown   HealthStatus = "unknown"
+)
+
+// Clone implements datalayer.Cloneable.
+func (h HealthStatus) Clone() datalayer.Cloneable { return h }
+
+// HealthCheckConfig is the per-model health check configuration stored in the Datastore.
+// It is written by model-config-datasource (manual config) or k8s-model-discovery-datasource
+// (auto-discovered from InferencePools), and consumed by health-check-datasource to probe.
+type HealthCheckConfig struct {
+	URL                string `json:"url"`
+	Type               string `json:"type"`
+	Interval           string `json:"interval"`
+	Timeout            string `json:"timeout"`
+	UnhealthyThreshold int    `json:"unhealthyThreshold"`
+	HealthyThreshold   int    `json:"healthyThreshold"`
+}
+
+// Clone implements datalayer.Cloneable.
+func (c HealthCheckConfig) Clone() datalayer.Cloneable {
+	return c
+}

--- a/pkg/framework/plugins/datalayer/modelconfigcollector/plugin.go
+++ b/pkg/framework/plugins/datalayer/modelconfigcollector/plugin.go
@@ -30,6 +30,7 @@ import (
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/datalayer"
 	dlsrc "github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/datalayer/datasource"
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/plugin"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/plugins/datalayer/healthcheck"
 )
 
 const PluginType = "model-config-datasource"
@@ -44,7 +45,8 @@ type PluginConfig struct {
 
 // ModelConfiguration is a single model entry in the config file.
 type ModelConfiguration struct {
-	Name string `json:"name"`
+	Name        string                        `json:"name"`
+	HealthCheck *healthcheck.HealthCheckConfig `json:"healthCheck,omitempty"`
 }
 
 // ModelsConfig is the schema of the JSON config file.
@@ -191,7 +193,12 @@ func (c *ModelConfigDataSource) syncModels(ctx context.Context) error {
 			continue
 		}
 		desired[m.Name] = struct{}{}
-		c.ds.GetOrCreateModel(m.Name)
+		model := c.ds.GetOrCreateModel(m.Name)
+		if m.HealthCheck != nil {
+			model.GetAttributes().Put(healthcheck.HealthCheckConfigKey, *m.HealthCheck)
+		} else {
+			model.GetAttributes().Delete(healthcheck.HealthCheckConfigKey)
+		}
 	}
 
 	for _, existing := range c.ds.Models() {

--- a/pkg/framework/plugins/datalayer/modeldiscovery/plugin.go
+++ b/pkg/framework/plugins/datalayer/modeldiscovery/plugin.go
@@ -1,0 +1,354 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package modeldiscovery
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	inferenceapi "sigs.k8s.io/gateway-api-inference-extension/api/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/datalayer"
+	dlsrc "github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/datalayer/datasource"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/plugin"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/plugins/datalayer/healthcheck"
+)
+
+const PluginType = "k8s-model-discovery-datasource"
+
+var _ dlsrc.DataSource = &ModelDiscoveryDataSource{}
+
+// PluginConfig holds the plugin configuration.
+type PluginConfig struct {
+	DiscoveryInterval   string              `json:"discoveryInterval,omitempty"`
+	Namespace           string              `json:"namespace,omitempty"`
+	HealthCheckDefaults HealthCheckDefaults `json:"healthCheckDefaults,omitempty"`
+}
+
+// HealthCheckDefaults provides default health check parameters for discovered models.
+type HealthCheckDefaults struct {
+	Interval           string `json:"interval,omitempty"`
+	Timeout            string `json:"timeout,omitempty"`
+	UnhealthyThreshold int    `json:"unhealthyThreshold,omitempty"`
+	HealthyThreshold   int    `json:"healthyThreshold,omitempty"`
+}
+
+// ModelDiscoveryDataSource watches InferencePools to discover model server pods
+// and writes HealthCheckConfig to the Datastore for each discovered model.
+// The health-check-datasource then picks up these configs and runs probes.
+type ModelDiscoveryDataSource struct {
+	typedName         plugin.TypedName
+	k8sClient         client.Client
+	ds                datalayer.Datastore
+	namespace         string
+	discoveryInterval time.Duration
+	defaults          HealthCheckDefaults
+	httpClient        *http.Client
+
+	// discoveredModels tracks which models we discovered (model → pool name)
+	discoveredModels map[string]string
+	mu               sync.RWMutex
+	stopCh           chan struct{}
+	doneCh           chan struct{}
+}
+
+// DatasourceFactory creates a ModelDiscoveryDataSource from plugin configuration.
+func DatasourceFactory(name string, rawCfg json.RawMessage, h plugin.Handle) (plugin.Plugin, error) {
+	cfg := PluginConfig{
+		DiscoveryInterval: "30s",
+		HealthCheckDefaults: HealthCheckDefaults{
+			Interval:           "10s",
+			Timeout:            "3s",
+			UnhealthyThreshold: 3,
+			HealthyThreshold:   2,
+		},
+	}
+
+	if rawCfg != nil && len(rawCfg) > 0 {
+		if err := json.Unmarshal(rawCfg, &cfg); err != nil {
+			return nil, fmt.Errorf("failed to parse config: %w", err)
+		}
+	}
+
+	discoveryInterval, err := time.ParseDuration(cfg.DiscoveryInterval)
+	if err != nil {
+		discoveryInterval = 30 * time.Second
+	}
+
+	namespace := cfg.Namespace
+	if namespace == "" {
+		namespace = os.Getenv("NAMESPACE")
+	}
+
+	timeout, _ := time.ParseDuration(cfg.HealthCheckDefaults.Timeout)
+	if timeout == 0 {
+		timeout = 3 * time.Second
+	}
+
+	return &ModelDiscoveryDataSource{
+		typedName:         plugin.TypedName{Type: PluginType, Name: name},
+		k8sClient:         h.Client(),
+		ds:                h.Datastore(),
+		namespace:         namespace,
+		discoveryInterval: discoveryInterval,
+		defaults:          cfg.HealthCheckDefaults,
+		httpClient:        &http.Client{Timeout: timeout},
+		discoveredModels:  make(map[string]string),
+		stopCh:            make(chan struct{}),
+		doneCh:            make(chan struct{}),
+	}, nil
+}
+
+func (d *ModelDiscoveryDataSource) TypedName() plugin.TypedName { return d.typedName }
+
+// Start launches the periodic discovery loop.
+func (d *ModelDiscoveryDataSource) Start(ctx context.Context) error {
+	logger := log.FromContext(ctx).WithName("model-discovery")
+
+	d.discover(ctx)
+
+	go func() {
+		defer close(d.doneCh)
+		ticker := time.NewTicker(d.discoveryInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-d.stopCh:
+				return
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				d.discover(ctx)
+			}
+		}
+	}()
+
+	logger.Info("started model discovery", "namespace", d.namespace, "interval", d.discoveryInterval)
+	return nil
+}
+
+// Stop signals the discovery loop to exit and blocks until it finishes.
+func (d *ModelDiscoveryDataSource) Stop() {
+	close(d.stopCh)
+	<-d.doneCh
+}
+
+// discover lists InferencePools, finds matching pods, probes /v1/models,
+// and writes HealthCheckConfig to the Datastore for each discovered model.
+func (d *ModelDiscoveryDataSource) discover(ctx context.Context) {
+	logger := log.FromContext(ctx).WithName("model-discovery")
+
+	pools, err := d.listInferencePools(ctx)
+	if err != nil {
+		logger.Error(err, "failed to list InferencePools")
+		return
+	}
+
+	currentModels := make(map[string]string) // model → pool
+
+	for i := range pools {
+		pool := &pools[i]
+		poolName := pool.Name
+		selector := pool.Spec.Selector.MatchLabels
+		if len(selector) == 0 || len(pool.Spec.TargetPorts) == 0 {
+			continue
+		}
+
+		port := int(pool.Spec.TargetPorts[0].Number)
+
+		pods, err := d.listReadyPods(ctx, selector)
+		if err != nil {
+			logger.Error(err, "failed to list pods for pool", "pool", poolName)
+			continue
+		}
+
+		if len(pods) == 0 {
+			logger.V(1).Info("no ready pods for pool", "pool", poolName)
+			continue
+		}
+
+		// Probe pods to discover models and build the endpoint list
+		podEndpoints := make([]string, 0, len(pods))
+		allModels := make(map[string]struct{})
+
+		for j := range pods {
+			pod := &pods[j]
+			endpoint := fmt.Sprintf("http://%s:%d/v1/models", pod.Status.PodIP, port)
+			podEndpoints = append(podEndpoints, endpoint)
+
+			models, err := d.probeModels(ctx, endpoint)
+			if err != nil {
+				logger.V(1).Info("probe failed", "pod", pod.Name, "endpoint", endpoint, "error", err)
+				continue
+			}
+			for _, m := range models {
+				allModels[m] = struct{}{}
+			}
+		}
+
+		if len(podEndpoints) == 0 {
+			continue
+		}
+
+		// Write HealthCheckConfig for each discovered model using the first ready pod endpoint.
+		// The health-check-datasource will probe this endpoint to validate model presence.
+		for modelName := range allModels {
+			currentModels[modelName] = poolName
+			d.writeHealthCheckConfig(modelName, podEndpoints[0])
+		}
+
+		logger.V(1).Info("discovered models from pool",
+			"pool", poolName,
+			"modelCount", len(allModels),
+			"podCount", len(pods))
+	}
+
+	// Prune models that are no longer discovered from any pool
+	d.mu.Lock()
+	for model, oldPool := range d.discoveredModels {
+		if _, ok := currentModels[model]; !ok {
+			logger.Info("model no longer discovered, cleaning up", "model", model, "pool", oldPool)
+			m := d.ds.GetOrCreateModel(model)
+			m.GetAttributes().Delete(healthcheck.HealthCheckConfigKey)
+		}
+	}
+	d.discoveredModels = currentModels
+	d.mu.Unlock()
+}
+
+// writeHealthCheckConfig writes a HealthCheckConfig attribute to the Datastore.
+func (d *ModelDiscoveryDataSource) writeHealthCheckConfig(modelName, url string) {
+	model := d.ds.GetOrCreateModel(modelName)
+	cfg := healthcheck.HealthCheckConfig{
+		URL:                url,
+		Type:               "http",
+		Interval:           d.defaults.Interval,
+		Timeout:            d.defaults.Timeout,
+		UnhealthyThreshold: d.defaults.UnhealthyThreshold,
+		HealthyThreshold:   d.defaults.HealthyThreshold,
+	}
+	model.GetAttributes().Put(healthcheck.HealthCheckConfigKey, cfg)
+}
+
+// listInferencePools returns all InferencePools in the configured namespace.
+func (d *ModelDiscoveryDataSource) listInferencePools(ctx context.Context) ([]inferenceapi.InferencePool, error) {
+	list := &inferenceapi.InferencePoolList{}
+	opts := &client.ListOptions{}
+	if d.namespace != "" {
+		opts.Namespace = d.namespace
+	}
+	if err := d.k8sClient.List(ctx, list, opts); err != nil {
+		return nil, err
+	}
+	return list.Items, nil
+}
+
+// listReadyPods returns pods matching the selector that are Ready and have an IP.
+func (d *ModelDiscoveryDataSource) listReadyPods(ctx context.Context, selector map[inferenceapi.LabelKey]inferenceapi.LabelValue) ([]corev1.Pod, error) {
+	// Convert GAIE LabelSelector types to standard string map
+	labelMap := make(map[string]string, len(selector))
+	for k, v := range selector {
+		labelMap[string(k)] = string(v)
+	}
+
+	podList := &corev1.PodList{}
+	opts := &client.ListOptions{
+		LabelSelector: labels.SelectorFromSet(labelMap),
+	}
+	if d.namespace != "" {
+		opts.Namespace = d.namespace
+	}
+
+	if err := d.k8sClient.List(ctx, podList, opts); err != nil {
+		return nil, err
+	}
+
+	ready := make([]corev1.Pod, 0, len(podList.Items))
+	for i := range podList.Items {
+		if isPodReady(&podList.Items[i]) {
+			ready = append(ready, podList.Items[i])
+		}
+	}
+	return ready, nil
+}
+
+// modelsResponse represents the OpenAI-compatible /v1/models response.
+type modelsResponse struct {
+	Data []struct {
+		ID string `json:"id"`
+	} `json:"data"`
+}
+
+// probeModels sends GET /v1/models to the endpoint and returns all model IDs.
+func (d *ModelDiscoveryDataSource) probeModels(ctx context.Context, url string) ([]string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := d.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var models modelsResponse
+	if err := json.Unmarshal(body, &models); err != nil {
+		return nil, err
+	}
+
+	names := make([]string, 0, len(models.Data))
+	for _, m := range models.Data {
+		if m.ID != "" {
+			names = append(names, m.ID)
+		}
+	}
+	return names, nil
+}
+
+// isPodReady returns true if the pod has the Ready condition and a PodIP assigned.
+func isPodReady(pod *corev1.Pod) bool {
+	if pod.Status.PodIP == "" {
+		return false
+	}
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/framework/plugins/modelselector/filter/healthfilter/plugin.go
+++ b/pkg/framework/plugins/modelselector/filter/healthfilter/plugin.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package healthfilter
+
+import (
+	"context"
+	"encoding/json"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/datalayer"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/modelselector"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/plugin"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/requesthandling"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/plugins/datalayer/healthcheck"
+)
+
+const PluginType = "health-filter"
+
+// compile-time interface assertion
+var _ modelselector.Filter = &HealthFilterPlugin{}
+
+// HealthFilterPlugin removes models marked as unhealthy from the candidate list.
+// Models with no health attribute or "unknown" status are kept (safe default).
+type HealthFilterPlugin struct {
+	typedName plugin.TypedName
+}
+
+// FilterFactory creates a HealthFilterPlugin instance.
+func FilterFactory(name string, _ json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
+	return NewHealthFilterPlugin().WithName(name), nil
+}
+
+// NewHealthFilterPlugin returns a new HealthFilterPlugin.
+func NewHealthFilterPlugin() *HealthFilterPlugin {
+	return &HealthFilterPlugin{
+		typedName: plugin.TypedName{Type: PluginType, Name: PluginType},
+	}
+}
+
+// TypedName returns the type and name tuple of this plugin instance.
+func (p *HealthFilterPlugin) TypedName() plugin.TypedName { return p.typedName }
+
+// WithName sets the instance name.
+func (p *HealthFilterPlugin) WithName(name string) *HealthFilterPlugin {
+	p.typedName.Name = name
+	return p
+}
+
+// Filter removes unhealthy models from the candidate list.
+// A model is excluded if its health-status attribute is "unhealthy".
+// Models without a health status attribute (e.g., external models) or with "unknown" status pass through.
+func (p *HealthFilterPlugin) Filter(ctx context.Context, _ *plugin.CycleState, _ *requesthandling.InferenceRequest, models []datalayer.Model) []datalayer.Model {
+	logger := log.FromContext(ctx).WithName("health-filter")
+
+	healthy := make([]datalayer.Model, 0, len(models))
+	for _, model := range models {
+		status := getHealthStatus(model)
+
+		if status == healthcheck.Unhealthy {
+			logger.V(1).Info("filtering out unhealthy model",
+				"model", model.GetName(),
+				"status", status)
+			continue
+		}
+		healthy = append(healthy, model)
+	}
+
+	if len(healthy) == 0 && len(models) > 0 {
+		logger.Info("all models are unhealthy, returning empty list")
+	}
+
+	return healthy
+}
+
+// getHealthStatus reads the health-status attribute from a model.
+// Returns Unknown if the attribute is not set (external models, cold start).
+func getHealthStatus(model datalayer.Model) healthcheck.HealthStatus {
+	raw, ok := model.GetAttributes().Get(healthcheck.HealthAttributeKey)
+	if !ok {
+		return healthcheck.Unknown
+	}
+	status, ok := raw.(healthcheck.HealthStatus)
+	if !ok {
+		return healthcheck.Unknown
+	}
+	return status
+}


### PR DESCRIPTION
## What type of PR is this?

/kind feature

## What this PR does / why we need it:

Adds active health checks for model endpoints in the AI Gateway (IPP) with automatic model server discovery from InferencePools. The health check system periodically probes internal model endpoints using `GET /v1/models` to verify both server liveness and model availability. Models that fail consecutive health checks are automatically withdrawn from routing, and are re-included once they recover.

## Key changes:

- **HealthCheckDataSource plugin:** Runs background probes per model at a configurable interval. Uses `ModelHTTPChecker` that validates the model name is present in the `/v1/models` response (not just a 2xx status), catching cases where the server is up but the model is unloaded (e.g. OOM). Dynamically starts/stops probes via a reconcile loop that reads config from the Datastore.
- **HealthFilter plugin:** Reads health status from the Datastore and excludes unhealthy models from the candidate list during model selection. Models with no health attribute (e.g. external models like OpenAI) pass through by default.
- **k8s-model-discovery-datasource plugin:** Automatically discovers model server pods by watching `InferencePool` CRDs — uses `spec.selector` to find matching pods and `spec.targetPorts` to determine endpoints. Probes each pod's `/v1/models` to discover which models are served, then writes `HealthCheckConfig` to the Datastore. No manual URL configuration required.
- **model-config-datasource extension:** Extended to support an optional `healthCheck` field per model in the `models.json` ConfigMap, allowing manual health check configuration as an alternative to auto-discovery.
- Configurable per-model: interval, timeout, healthy/unhealthy thresholds.
- External models are assumed always healthy and are not probed.

## Which issue(s) this PR fixes:

Fixes #182

## Release note (write NONE if no user-facing change):

Added active health check support for model endpoints with automatic discovery from InferencePools. The IPP discovers model server pods via InferencePool selectors and targetPorts, probes them via `GET /v1/models`, and automatically removes unhealthy models from routing decisions — re-including them upon recovery.