### PR TITLE
avoid panic in bodiless requests

### DIFF
--- a/pkg/handlers/response.go
+++ b/pkg/handlers/response.go
@@ -71,7 +71,7 @@ func (s *Server) HandleResponseBody(ctx context.Context, reqCtx *RequestContext,
 	})
 
 	logger := log.FromContext(ctx)
-	// if a bodiless request was sent, profile could be left nil. check to avoid panic with nil exception
+	// if a bodiless request is sent, profile could be left nil. check to avoid panic with nil exception
 	if reqCtx.Profile == nil || len(reqCtx.Profile.ResponsePlugins) == 0 {
 		return s.generateEmptyResponseBodyResponse(responseBodyBytes), nil
 	}

--- a/pkg/handlers/response.go
+++ b/pkg/handlers/response.go
@@ -71,7 +71,8 @@ func (s *Server) HandleResponseBody(ctx context.Context, reqCtx *RequestContext,
 	})
 
 	logger := log.FromContext(ctx)
-	if len(reqCtx.Profile.ResponsePlugins) == 0 {
+	// if a bodiless request was sent, profile could be left nil. check to avoid panic with nil exception
+	if reqCtx.Profile == nil || len(reqCtx.Profile.ResponsePlugins) == 0 {
 		return s.generateEmptyResponseBodyResponse(responseBodyBytes), nil
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
in current codebase, if a bodiless request is sent IPP pod will crash, since no profile is selected (it's being selected in request handle body function). in such a case, when checking if the profile has response plugins we hit nil exception and panic:
https://github.com/llm-d/llm-d-inference-payload-processor/blob/ac26114049ffcfe17634981515c90dd9f1f5e329/pkg/handlers/response.go#L74

```
{"level":"info","ts":1782253546.0639248,"caller":"handlers/server.go:153","msg":"Incoming response body chunk","x-
request-id":"72a75031-ed50-4b62-bba7-b9de417eb212","EoS":false}
{"level":"info","ts":1782253546.0639374,"caller":"handlers/server.go:153","msg":"Incoming response body chunk","x-
request-id":"72a75031-ed50-4b62-bba7-b9de417eb212","EoS":true}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x1cd06ab]

panic: runtime error: invalid memory address or nil pointer dereference
github.com/llm-d/llm-d-inference-payload-processor@v0.1.0-rc.1/pkg/handlers/response.go:74
```

This PR is checking if profile is nil, and if so skips the response plugins section.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
