### PR TITLE
Add README for request-metadata-extractor plugin

### DIFF
--- a/pkg/framework/plugins/datalayer/requestmetadata/README.md
+++ b/pkg/framework/plugins/datalayer/requestmetadata/README.md
@@ -1,0 +1,46 @@
+# Request Metadata Extractor
+
+Tracks in-flight request counts and token sums per model and writes them to the datastore on every event batch.
+
+It is registered as type `request-metadata-extractor` and runs as a datalayer extractor.
+
+## What it does
+
+1. Receives a batch of `Event` values from the notification source event loop.
+2. On a `RequestEventType` event: increments the request count and adds `max_tokens` to the token sum for the model named in the request body.
+3. On a `ResponseEventType` event: decrements the request count and token sum for the same model (floored at zero).
+4. Writes the updated `RequestMetadataCount` to each affected model's attribute store under the key `request-metadata`.
+
+## Behavioral Intent
+
+This extractor gives downstream plugins a live view of how many requests are currently in-flight for each model and how many tokens those requests represent. Scorers can use this data to steer traffic away from overloaded models.
+
+**Known limitation:** counters will drift if a request ends without a corresponding `ResponseEventType` (e.g. connection drop, upstream error, context cancellation). The call site is expected to fire a synthetic `ResponseEventType` in its error/EOF path to keep counts accurate.
+
+**Concurrency:** `Extract` is assumed to be called from a single goroutine (the notification source event loop). If parallel dispatch is introduced, a mutex around the counters and datastore write must be added.
+
+## Attribute written
+
+| Key                | Type                   | Description                                        |
+|--------------------|------------------------|----------------------------------------------------|
+| `request-metadata` | `RequestMetadataCount` | In-flight request count and token sum for a model. |
+
+`RequestMetadataCount` fields:
+
+| Field      | Type    | Description                                       |
+|------------|---------|---------------------------------------------------|
+| `Requests` | `int64` | Number of requests currently in-flight.           |
+| `Tokens`   | `int64` | Sum of `max_tokens` across in-flight requests.    |
+
+## Inputs consumed
+
+- `RequestEventType` events: reads `model` and `max_tokens` from the request body.
+- `ResponseEventType` events: reads `model` and `max_tokens` from the request body to reverse the earlier increment.
+
+## Outputs produced
+
+- `request-metadata` attribute updated on the matching model entry in the shared `Datastore`.
+
+## Configuration
+
+The plugin has no config.


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:

Adds a `README.md` to the `request-metadata-extractor` datalayer plugin (`pkg/framework/plugins/datalayer/requestmetadata/`).

The README documents:
- What the plugin does (tracks in-flight request counts and token sums per model using `RequestEventType` / `ResponseEventType` events)
- The `request-metadata` attribute written to the datastore and its fields (`Requests`, `Tokens`)
- Known limitation: counters drift if a request ends without a corresponding `ResponseEventType` (e.g. connection drop)
- Concurrency assumption: `Extract` is called from a single goroutine
- Inputs consumed and outputs produced

This follows the same documentation convention established by other plugins in the repository (e.g. `pkg/framework/plugins/modelselector/picker/maxscore/README.md`).

**Which issue(s) this PR fixes**:
Fixes #194 

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
