### PR TITLE
docs: establish the IPP documentation set

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Helm chart provisions the provider-specific integration automatically:
 
 - **Istio** — Installs an `EnvoyFilter` that inserts the ext-proc filter into the Gateway's filter chain.
 - **GKE** — Installs a `GCPRoutingExtension` that registers IPP as a routing extension.
-- **None** — Deploys only the IPP Deployment and Service; you wire the proxy integration yourself.
+- **None** — Deploys the core IPP resources (Deployment, Service, config, RBAC) but no proxy integration; you wire that up yourself.
 
 ## Documentation
 
@@ -48,8 +48,7 @@ Helm chart provisions the provider-specific integration automatically:
 | [Helm Chart](config/charts/payload-processor/README.md) | Chart install reference and values table. |
 | [ModelSelector Proposal](docs/proposals/043-model-selection-framework/README.md) | Design of the model-selection framework. |
 
-For the end-to-end deployment walkthrough, see the **Multi-Model Routing guide** in the
-[llm-d] documentation.
+For end-to-end deployment, see the [llm-d] project documentation and guides.
 
 ## Terminology
 

--- a/README.md
+++ b/README.md
@@ -6,14 +6,17 @@
 # llm-d Inference Payload Processor
 
 The **Inference Payload Processor (IPP)** is a pluggable framework for inspecting and mutating
-inference request and response payloads as they flow through the [llm-d Router]. It runs as an
-[External Processing (ext-proc)] service alongside the Proxy, contributing real-time signals and
-mutations to the data plane *before* a routing decision is made.
+inference request and response payloads in the llm-d data plane. It runs as an
+[External Processing (ext-proc)] service alongside the inference gateway's Proxy, which streams each
+request and response to IPP for real-time, payload-aware processing.
 
-Where the [Endpoint Picker (EPP)] answers **"which pod within a pool?"**, IPP answers **"which pool
-should serve this request?"** — enabling a single Gateway endpoint to front many models and LoRA
-adapters. The two components compose: IPP performs **pool-level** routing, the EPP performs
-**endpoint-level** routing.
+Because IPP sees the full payload, it can shape requests and responses in arbitrary ways — any logic
+that benefits from reading or rewriting the body, headers, or trailers can be expressed as a plugin.
+Its flagship use is **payload-aware routing**: extracting signals from the request (such as the model
+name) and injecting headers so a single Gateway endpoint can front many models and LoRA adapters. This
+composes with the [llm-d Router]'s [Endpoint Picker (EPP)] — IPP can decide **which pool** serves a
+request while the EPP decides **which pod** within that pool — but routing is one application of a
+general framework, not its limit.
 
 <p align="center">
   <img src="docs/images/ipp-request-flow.svg" width="800" alt="IPP Request Flow">
@@ -23,7 +26,7 @@ adapters. The two components compose: IPP performs **pool-level** routing, the E
 
 - **Request processing** — Inspect and mutate request headers, body, or trailers before routing.
 - **Response processing** — Inspect and mutate response headers, body, or trailers on the way back to the client.
-- **Model-aware routing** — Extract the model name from the request body and inject a routing header so the Proxy can select the correct [InferencePool]. This powers **multi-pool routing**: serving multiple base models and LoRA adapters behind one OpenAI-compatible endpoint.
+- **Payload-aware routing** — Extract signals from the request body (e.g. the model name) and inject routing headers so the Proxy can select the correct [InferencePool]. This powers **multi-pool routing**: serving multiple base models and LoRA adapters behind one OpenAI-compatible endpoint.
 - **Model selection** — A pluggable `Filter → Score → Pick` pipeline that chooses *which* model serves a request (e.g. for cost- or load-aware routing), adapting the upstream [Scheduler Architecture] pattern at the model level. See the [ModelSelector proposal].
 - **Extensibility** — All behavior is implemented as plugins configured via a YAML `PayloadProcessorConfig`. Add your own without forking the framework — see [Creating a Plugin].
 
@@ -52,7 +55,7 @@ For end-to-end deployment, see the [llm-d] project documentation and guides.
 
 ## Terminology
 
-- **IPP (Inference Payload Processor)** — This service. Processes request/response payloads via ext-proc and contributes pool-level routing signals.
+- **IPP (Inference Payload Processor)** — This service. Inspects and mutates request/response payloads via ext-proc; among other things, it can contribute pool-level routing signals.
 - **Plugin** — A user-configurable unit of behavior (request processor, response processor, model-selector Filter/Scorer/Picker, profile picker, or data-layer collector/extractor/datasource). Plugins are selected and ordered in the `PayloadProcessorConfig`.
 - **Profile** — A named set of request and response plugins. A request executes exactly one profile, chosen by the profile picker.
 - **ModelSelector** — The `Filter → Score → Pick` framework that selects a *model* (not an endpoint) for a request.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,75 @@
-# llm-d-inference-payload-processor
-
 [![CI](https://github.com/llm-d/llm-d-inference-payload-processor/actions/workflows/ci-pr-checks.yaml/badge.svg)](https://github.com/llm-d/llm-d-inference-payload-processor/actions/workflows/ci-pr-checks.yaml)
+[![Go Reference](https://pkg.go.dev/badge/github.com/llm-d/llm-d-inference-payload-processor.svg)](https://pkg.go.dev/github.com/llm-d/llm-d-inference-payload-processor)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+[![Join Slack](https://img.shields.io/badge/Join_Slack-blue?logo=slack)](https://llm-d.slack.com/archives/C08SBNRRSBD)
 
-> **Inference payload processor for llm-d.**
+# llm-d Inference Payload Processor
+
+The **Inference Payload Processor (IPP)** is a pluggable framework for inspecting and mutating
+inference request and response payloads as they flow through the [llm-d Router]. It runs as an
+[External Processing (ext-proc)] service alongside the Proxy, contributing real-time signals and
+mutations to the data plane *before* a routing decision is made.
+
+Where the [Endpoint Picker (EPP)] answers **"which pod within a pool?"**, IPP answers **"which pool
+should serve this request?"** — enabling a single Gateway endpoint to front many models and LoRA
+adapters. The two components compose: IPP performs **pool-level** routing, the EPP performs
+**endpoint-level** routing.
+
+<p align="center">
+  <img src="docs/images/ipp-request-flow.svg" width="800" alt="IPP Request Flow">
+</p>
+
+## Core Capabilities
+
+- **Request processing** — Inspect and mutate request headers, body, or trailers before routing.
+- **Response processing** — Inspect and mutate response headers, body, or trailers on the way back to the client.
+- **Model-aware routing** — Extract the model name from the request body and inject a routing header so the Proxy can select the correct [InferencePool]. This powers **multi-pool routing**: serving multiple base models and LoRA adapters behind one OpenAI-compatible endpoint.
+- **Model selection** — A pluggable `Filter → Score → Pick` pipeline that chooses *which* model serves a request (e.g. for cost- or load-aware routing), adapting the upstream [Scheduler Architecture] pattern at the model level. See the [ModelSelector proposal].
+- **Extensibility** — All behavior is implemented as plugins configured via a YAML `PayloadProcessorConfig`. Add your own without forking the framework — see [Creating a Plugin].
+
+## Modes of Operation
+
+IPP is deployed once per Gateway as a standalone service and wired into the Proxy via ext-proc. The
+Helm chart provisions the provider-specific integration automatically:
+
+- **Istio** — Installs an `EnvoyFilter` that inserts the ext-proc filter into the Gateway's filter chain.
+- **GKE** — Installs a `GCPRoutingExtension` that registers IPP as a routing extension.
+- **None** — Deploys only the IPP Deployment and Service; you wire the proxy integration yourself.
+
+## Documentation
+
+| Document | Description |
+|----------|-------------|
+| [Architecture](docs/architecture.md) | How IPP works: ext-proc integration, the processing pipeline, profiles, model selection, and multi-pool routing. |
+| [Configuration](docs/configuration.md) | Full configuration reference: the `PayloadProcessorConfig` API, Helm values, env vars, CLI flags, ConfigMaps, and proxy integration. |
+| [Plugins](docs/plugins.md) | Reference for all in-tree plugins and how the pipeline composes them. |
+| [Creating a Plugin](docs/create_new_plugin.md) | Tutorial for writing and registering a custom plugin. |
+| [Metrics](docs/metrics.md) | Prometheus metrics exposed by IPP. |
+| [Helm Chart](config/charts/payload-processor/README.md) | Chart install reference and values table. |
+| [ModelSelector Proposal](docs/proposals/043-model-selection-framework/README.md) | Design of the model-selection framework. |
+
+For the end-to-end deployment walkthrough, see the **Multi-Model Routing guide** in the
+[llm-d] documentation.
+
+## Terminology
+
+- **IPP (Inference Payload Processor)** — This service. Processes request/response payloads via ext-proc and contributes pool-level routing signals.
+- **Plugin** — A user-configurable unit of behavior (request processor, response processor, model-selector Filter/Scorer/Picker, profile picker, or data-layer collector/extractor/datasource). Plugins are selected and ordered in the `PayloadProcessorConfig`.
+- **Profile** — A named set of request and response plugins. A request executes exactly one profile, chosen by the profile picker.
+- **ModelSelector** — The `Filter → Score → Pick` framework that selects a *model* (not an endpoint) for a request.
+- **Proxy** — The L7 proxy (e.g. Envoy) that invokes IPP over ext-proc.
+
+## Contributing
+
+Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md). Active docs work lands on the
+`docs` branch first; branch from it and open PRs against it so the documentation can be reviewed and
+assembled collaboratively before merging to `main`.
+
+[llm-d]: https://github.com/llm-d/llm-d
+[llm-d Router]: https://github.com/llm-d/llm-d-router
+[Endpoint Picker (EPP)]: https://github.com/llm-d/llm-d-router
+[InferencePool]: https://gateway-api-inference-extension.sigs.k8s.io
+[External Processing (ext-proc)]: https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/ext_proc_filter
+[Scheduler Architecture]: https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals/0845-scheduler-architecture-proposal
+[ModelSelector proposal]: docs/proposals/043-model-selection-framework/README.md
+[Creating a Plugin]: docs/create_new_plugin.md

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ general framework, not its limit.
 
 - **Request processing** — Inspect and mutate request headers, body, or trailers before routing.
 - **Response processing** — Inspect and mutate response headers, body, or trailers on the way back to the client.
-- **Payload-aware routing** — Extract signals from the request body (e.g. the model name) and inject routing headers so the Proxy can select the correct [InferencePool]. This powers **multi-pool routing**: serving multiple base models and LoRA adapters behind one OpenAI-compatible endpoint.
-- **Model selection** — A pluggable `Filter → Score → Pick` pipeline that chooses *which* model serves a request (e.g. for cost- or load-aware routing), adapting the upstream [Scheduler Architecture] pattern at the model level. See the [ModelSelector proposal].
+- **Payload-aware routing** — Extract signals from the request body (e.g. the model name) and inject routing headers so the Proxy can select the correct destination (e.g., [InferencePool]). This powers **multi-pool routing**: serving multiple base models and LoRA adapters behind one OpenAI-compatible endpoint.
+- **Model selection** — A pluggable `Filter → Score → Pick` pipeline that chooses *which* model serves a request (e.g. for cost or load-aware routing), adapting the upstream [Scheduler Architecture] pattern at the model level. See the [ModelSelector proposal].
 - **Extensibility** — All behavior is implemented as plugins configured via a YAML `PayloadProcessorConfig`. Add your own without forking the framework — see [Creating a Plugin].
 
 ## Modes of Operation

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -83,20 +83,23 @@ automatically for the selected provider (Istio `EnvoyFilter`, GKE `GCPRoutingExt
 IPP executes plugins in a fixed sequence of stages:
 
 ```
-PreProcessing → ProfilePicker → Profile Request Plugins → [Model Server] → Profile Response Plugins → PostProcessing
+ProfilePicker → Profile Request Plugins → [Model Server] → Profile Response Plugins
 ```
 
 | Stage | Scope | Purpose |
 |-------|-------|---------|
-| **PreProcessing** | Global | Runs for every request before a profile is selected. |
 | **ProfilePicker** | Global | Selects which profile to execute for the request. |
 | **Profile Request Plugins** | Per-profile | Process the request before it is routed. |
 | **Profile Response Plugins** | Per-profile | Process the response after the model server replies. |
-| **PostProcessing** | Global | Runs for every request after the profile's response plugins. |
 
 The pipeline is declared in a `PayloadProcessorConfig`: all plugins are instantiated under a top-level
-`plugins` list and then referenced by name within profiles and the pre/post stages. See [Plugins] for
-the full configuration model and [Configuration] for the API schema.
+`plugins` list and then referenced by name within profiles. See [Plugins] for the full configuration
+model and [Configuration] for the API schema.
+
+> [!NOTE]
+> The config API also defines global **PreProcessing** and **PostProcessing** stages — intended to run
+> for every request before profile selection and after the response plugins. These are reserved
+> extension points: they are accepted in the configuration but are not yet invoked by the request path.
 
 ### Profiles
 
@@ -117,9 +120,9 @@ configured, the built-in [`single-profile-picker`] is enabled automatically.
 
 ### Pre- and Post-Processing
 
-**PreProcessors** run before profile selection, for logic common to all requests. **PostProcessors**
-run after the selected profile's response plugins. There are no in-tree pre/post processors;
-both are extension points for custom plugins.
+**PreProcessing** and **PostProcessing** are reserved global extension points in the config API —
+intended for logic common to all requests, before profile selection and after the response plugins.
+They are not yet wired into the request path, and there are no in-tree pre/post processors.
 
 ---
 
@@ -147,16 +150,17 @@ and its phases are specified in the [ModelSelector proposal]; the available plug
 
 ## Data Layer
 
-The **data layer** maintains cross-request state that Filters and Scorers consume to make data-driven
-decisions. It is an event-driven subsystem populated by three kinds of plugins:
+The **data layer** maintains cross-request state that Scorers (and Filters) consume to make data-driven
+decisions. It is populated by three kinds of plugins that run continuously, decoupled from any single
+request:
 
-- **Collectors** — Aggregate signals over time.
-- **Extractors** — Pull metadata out of request/response events.
-- **Datasources** — Import external configuration (e.g. model metadata) into the store.
+- **Collectors** — Aggregate signals over time, on a timer.
+- **Extractors** — Pull metadata out of request/response events as they arrive.
+- **Datasources** — Import external configuration (e.g. model metadata) into the store, watching for changes.
 
-Data-layer plugins are registered under the `datalayer` section of the config and run continuously as
-events arrive, decoupled from any single request. This is how runtime signals such as in-flight request
-counts become available to scoring decisions.
+Data-layer plugins are registered under the `datalayer` section of the config and run in the background,
+decoupled from any single request. This is how runtime signals such as in-flight request counts become
+available to scoring decisions.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,14 +20,15 @@
 ## Overview
 
 The **Inference Payload Processor (IPP)** is a pluggable service that inspects and mutates inference
-request and response payloads as they pass through the [llm-d Router]. It runs alongside the Proxy
+request and response payloads in the llm-d data plane. It runs alongside the inference gateway's Proxy
 (e.g. Envoy) and is invoked over Envoy's [External Processing (ext-proc)] protocol on each HTTP
 lifecycle event.
 
-IPP's primary role in llm-d is **model-aware, pool-level routing**: it reads the model name from the
-request body and injects a routing header, allowing a single Gateway endpoint to serve many base
-models and LoRA adapters. Beyond routing, IPP is a general framework — any request- or
-response-shaping logic can be expressed as a plugin and composed into the pipeline.
+IPP is a general, payload-aware framework: any request- or response-shaping logic can be expressed as
+a plugin and composed into the pipeline. Its flagship use is **payload-aware routing** — reading
+signals such as the model name from the request body and injecting headers so a single Gateway
+endpoint can serve many base models and LoRA adapters — but that is one application of the framework,
+not its boundary.
 
 A request flows through the system as follows:
 
@@ -191,7 +192,7 @@ The model-name-to-base-model mapping is supplied through labeled ConfigMaps; the
 
 ## Relationship to the Router (EPP)
 
-IPP and the EPP are complementary halves of llm-d routing:
+When IPP is used for routing, it and the EPP play complementary roles:
 
 | | IPP | EPP (llm-d Router) |
 |---|-----|--------------------|

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,9 +39,9 @@ A request flows through the system as follows:
 1. A **client** sends an inference request to the Proxy.
 2. The **Proxy** invokes IPP over ext-proc.
 3. **IPP** runs the request through its configured plugin pipeline and returns any mutations (headers, body edits).
-4. The **Proxy** applies the mutations and routes to the selected [InferencePool].
-5. The **EPP** picks the optimal pod within that pool.
-6. The **model server** processes the request; the response travels back through the Proxy, where IPP may process it again before it reaches the client.
+4. The **Proxy** applies the mutations and routes to the selected destination.
+5. If the selected destination is [InferencePool], the **EPP** picks the optimal pod within that pool.
+6. The **model server** processes the request; the response travels back through the Proxy, where IPP may process it again (including response headers/body mutations) before it reaches the client.
 
 ---
 
@@ -84,17 +84,19 @@ automatically for the selected provider (Istio `EnvoyFilter`, GKE `GCPRoutingExt
 IPP executes plugins in a fixed sequence of stages:
 
 ```
-ProfilePicker → Profile Request Plugins → [Model Server] → Profile Response Plugins
+PreProcessor Plugins → ProfilePicker → Profile Request Plugins → [Model Server] → Profile Response Plugins → PostProcessor Plugins
 ```
 
 | Stage | Scope | Purpose |
 |-------|-------|---------|
+| **PreProcessor Plugins** | Global | Process the request before ProfilePicker. This may include a subset of request plugins that should always run, no matter which profile is selected. |
 | **ProfilePicker** | Global | Selects which profile to execute for the request. |
 | **Profile Request Plugins** | Per-profile | Process the request before it is routed. |
 | **Profile Response Plugins** | Per-profile | Process the response after the model server replies. |
+| **PostProcessor Plugins** | Global | Process the response after the model server replies. This may include a subset of response plugins that should always run, no matter which profile is selected. |
 
 The pipeline is declared in a `PayloadProcessorConfig`: all plugins are instantiated under a top-level
-`plugins` list and then referenced by name within profiles. See [Plugins] for the full configuration
+`plugins` list and then referenced by name within other sections. See [Plugins] for the full configuration
 model and [Configuration] for the API schema.
 
 > [!NOTE]
@@ -115,8 +117,8 @@ on the interface the plugin implements.
 
 ### Profile Picker
 
-When more than one profile is configured, a **profile picker** plugin inspects the request (headers,
-body) and chooses which profile to run. When exactly one profile is defined and no picker is
+When more than one profile is configured, a **profile picker** plugin may inspect the request (headers,
+body), system state (e.g., datastore) or any other parameter, and chooses which profile to run. When exactly one profile is defined and no picker is
 configured, the built-in [`single-profile-picker`] is enabled automatically.
 
 ### Pre- and Post-Processing
@@ -138,12 +140,12 @@ Filter → Score → Pick
 ```
 
 - **Filter** — Removes candidate models that cannot serve the request (e.g. unavailable or rate-limited). If filtering leaves zero candidates, the framework returns an error to the client.
-- **Score** — Each remaining candidate is scored, conventionally in `[0, 1]`. Multiple scorers combine via per-reference weights configured in the profile.
+- **Score** — Each remaining candidate is scored, conventionally in `[0, 1]`. Multiple scorers combine via per-scorer weights configured in the profile.
 - **Pick** — Exactly one picker selects the final model from the scored candidates.
 
 The selected model is written into the request body, after which the request continues through the
 normal pipeline exactly as if the client had requested that model directly. A typical use is sending
-`{"model": "auto"}` and letting cost- or load-aware scorers choose the concrete model. The framework
+`{"model": "auto"}` and letting cost, load or latency aware scorers (or any combination of them) choose the concrete model. The framework
 and its phases are specified in the [ModelSelector proposal]; the available plugins are listed in
 [Plugins].
 
@@ -151,7 +153,7 @@ and its phases are specified in the [ModelSelector proposal]; the available plug
 
 ## Data Layer
 
-The **data layer** maintains cross-request state that Scorers (and Filters) consume to make data-driven
+The **data layer** maintains cross-request state that other plugins (e.g., Scorer, Filter, ProfilerPicker) consume to make data-driven
 decisions. It is populated by three kinds of plugins that run continuously, decoupled from any single
 request:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,219 @@
+# IPP Architecture
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Design Principles](#design-principles)
+- [ext-proc Integration](#ext-proc-integration)
+- [Processing Pipeline](#processing-pipeline)
+  - [Profiles](#profiles)
+  - [Profile Picker](#profile-picker)
+  - [Pre- and Post-Processing](#pre--and-post-processing)
+- [Model Selection](#model-selection)
+- [Data Layer](#data-layer)
+- [Multi-Pool Routing](#multi-pool-routing)
+- [Relationship to the Router (EPP)](#relationship-to-the-router-epp)
+- [References](#references)
+
+---
+
+## Overview
+
+The **Inference Payload Processor (IPP)** is a pluggable service that inspects and mutates inference
+request and response payloads as they pass through the [llm-d Router]. It runs alongside the Proxy
+(e.g. Envoy) and is invoked over Envoy's [External Processing (ext-proc)] protocol on each HTTP
+lifecycle event.
+
+IPP's primary role in llm-d is **model-aware, pool-level routing**: it reads the model name from the
+request body and injects a routing header, allowing a single Gateway endpoint to serve many base
+models and LoRA adapters. Beyond routing, IPP is a general framework — any request- or
+response-shaping logic can be expressed as a plugin and composed into the pipeline.
+
+A request flows through the system as follows:
+
+<p align="center">
+  <img src="images/ipp-request-flow.svg" width="820" alt="IPP Request Flow">
+</p>
+
+1. A **client** sends an inference request to the Proxy.
+2. The **Proxy** invokes IPP over ext-proc.
+3. **IPP** runs the request through its configured plugin pipeline and returns any mutations (headers, body edits).
+4. The **Proxy** applies the mutations and routes to the selected [InferencePool].
+5. The **EPP** picks the optimal pod within that pool.
+6. The **model server** processes the request; the response travels back through the Proxy, where IPP may process it again before it reaches the client.
+
+---
+
+## Design Principles
+
+IPP follows the design principles established by the [ModelSelector proposal] and the broader llm-d
+framework conventions:
+
+- **The framework is opinion-free; plugins hold the opinions.** The core defines the pipeline and the
+  extension points; concrete behavior lives in plugins.
+- **Clear API surface.** Entry and exit points are defined by the framework, forming a stable contract
+  between the Proxy, the pipeline, and the plugins.
+- **Pluggable everything.** Request processing, response processing, model selection, profile
+  selection, and data collection are all swappable via configuration.
+- **Explicit state boundaries.** Per-request state is shared across plugins through an in-memory cycle
+  state for the duration of a single request; cross-request state lives in the data layer.
+
+---
+
+## ext-proc Integration
+
+IPP implements the Envoy [External Processing (ext-proc)] gRPC API. The Proxy streams HTTP lifecycle
+events — request headers, request body, request trailers, and the corresponding response events — to
+IPP, which replies with mutations. IPP requires `FULL_DUPLEX_STREAMED` body mode so it can observe and
+mutate full request/response bodies.
+
+Each event type can be enabled or disabled independently (see [Configuration]). Every enabled event is
+an extra network hop between the Proxy and IPP, so deployments should enable only the events their
+configured plugins actually consume — for example, a routing-only deployment can disable all response
+events.
+
+IPP is deployed **once per Gateway**. The Helm chart wires the ext-proc integration into the Proxy
+automatically for the selected provider (Istio `EnvoyFilter`, GKE `GCPRoutingExtension`); see
+[Configuration] for the generated resources.
+
+---
+
+## Processing Pipeline
+
+IPP executes plugins in a fixed sequence of stages:
+
+```
+PreProcessing → ProfilePicker → Profile Request Plugins → [Model Server] → Profile Response Plugins → PostProcessing
+```
+
+| Stage | Scope | Purpose |
+|-------|-------|---------|
+| **PreProcessing** | Global | Runs for every request before a profile is selected. |
+| **ProfilePicker** | Global | Selects which profile to execute for the request. |
+| **Profile Request Plugins** | Per-profile | Process the request before it is routed. |
+| **Profile Response Plugins** | Per-profile | Process the response after the model server replies. |
+| **PostProcessing** | Global | Runs for every request after the profile's response plugins. |
+
+The pipeline is declared in a `PayloadProcessorConfig`: all plugins are instantiated under a top-level
+`plugins` list and then referenced by name within profiles and the pre/post stages. See [Plugins] for
+the full configuration model and [Configuration] for the API schema.
+
+### Profiles
+
+A **profile** is a named set of `request` and `response` plugin references. Exactly one profile runs
+per request. Splitting behavior across profiles lets a single IPP deployment apply different processing
+logic to different classes of traffic (e.g. a lightweight header-extraction profile vs. a full
+model-selection profile).
+
+A profile's `request` list may contain both request-processor plugins and model-selector plugins
+(Filter / Scorer / Picker); the config loader routes each reference to the right extension point based
+on the interface the plugin implements.
+
+### Profile Picker
+
+When more than one profile is configured, a **profile picker** plugin inspects the request (headers,
+body) and chooses which profile to run. When exactly one profile is defined and no picker is
+configured, the built-in [`single-profile-picker`] is enabled automatically.
+
+### Pre- and Post-Processing
+
+**PreProcessors** run before profile selection, for logic common to all requests. **PostProcessors**
+run after the selected profile's response plugins. There are no in-tree pre/post processors;
+both are extension points for custom plugins.
+
+---
+
+## Model Selection
+
+The **ModelSelector** framework selects a *model* to serve a request — as opposed to the EPP, which
+selects an *endpoint*. It is invoked by the `model-selector` request plugin and runs a three-phase
+pipeline:
+
+```
+Filter → Score → Pick
+```
+
+- **Filter** — Removes candidate models that cannot serve the request (e.g. unavailable or rate-limited). If filtering leaves zero candidates, the framework returns an error to the client.
+- **Score** — Each remaining candidate is scored, conventionally in `[0, 1]`. Multiple scorers combine via per-reference weights configured in the profile.
+- **Pick** — Exactly one picker selects the final model from the scored candidates.
+
+The selected model is written into the request body, after which the request continues through the
+normal pipeline exactly as if the client had requested that model directly. A typical use is sending
+`{"model": "auto"}` and letting cost- or load-aware scorers choose the concrete model. The framework
+and its phases are specified in the [ModelSelector proposal]; the available plugins are listed in
+[Plugins].
+
+---
+
+## Data Layer
+
+The **data layer** maintains cross-request state that Filters and Scorers consume to make data-driven
+decisions. It is an event-driven subsystem populated by three kinds of plugins:
+
+- **Collectors** — Aggregate signals over time.
+- **Extractors** — Pull metadata out of request/response events.
+- **Datasources** — Import external configuration (e.g. model metadata) into the store.
+
+Data-layer plugins are registered under the `datalayer` section of the config and run continuously as
+events arrive, decoupled from any single request. This is how runtime signals such as in-flight request
+counts become available to scoring decisions.
+
+---
+
+## Multi-Pool Routing
+
+Multi-pool routing is IPP's flagship capability: serving multiple LLMs — and their LoRA adapters —
+behind a single Gateway endpoint.
+
+<p align="center">
+  <img src="images/multi-pool-routing.svg" width="820" alt="Multi-Pool Routing Architecture">
+</p>
+
+Each [InferencePool] serves one base model. Clients call a single OpenAI-compatible endpoint and name
+the model in the request body. IPP extracts that name, maps a LoRA adapter back to its base model when
+needed, and injects a routing header (e.g. `X-Gateway-Base-Model-Name`). The Proxy's `HTTPRoute` rules
+match on that header to select the correct pool.
+
+This pattern supports:
+
+- **Multiple base models** — Different pools for different architectures (e.g. Qwen for chat, DeepSeek for reasoning).
+- **LoRA adapters** — Many fine-tuned adapters served by one base-model pool, with IPP mapping adapter names to their base.
+- **A unified API endpoint** — One endpoint for all models, following the OpenAI API convention.
+
+The model-name-to-base-model mapping is supplied through labeled ConfigMaps; the routing header and
+`HTTPRoute` wiring are detailed in [Configuration].
+
+---
+
+## Relationship to the Router (EPP)
+
+IPP and the EPP are complementary halves of llm-d routing:
+
+| | IPP | EPP (llm-d Router) |
+|---|-----|--------------------|
+| **Question answered** | Which **pool** serves this request? | Which **pod** within the pool? |
+| **Granularity** | Pool-level | Endpoint-level |
+| **Signal** | Request/response payload (model name, body fields) | InferencePool state (KV-cache, load, priority) |
+| **Integration** | ext-proc, before routing | ext-proc, backend of an InferencePool |
+
+A request first passes through IPP (which selects the pool via header injection) and then the EPP
+(which selects the endpoint within that pool). They are configured and deployed independently.
+
+---
+
+## References
+
+- [Configuration] — Full configuration reference.
+- [Plugins] — In-tree plugin reference and pipeline configuration model.
+- [Creating a Plugin](create_new_plugin.md) — Tutorial for writing a custom plugin.
+- [ModelSelector proposal] — Design of the model-selection framework.
+- [llm-d Router] — The router (EPP) that performs endpoint-level routing.
+- [External Processing (ext-proc)] — The Envoy protocol IPP implements.
+
+[Configuration]: configuration.md
+[Plugins]: plugins.md
+[ModelSelector proposal]: proposals/043-model-selection-framework/README.md
+[`single-profile-picker`]: plugins.md#profile-picker-plugins
+[llm-d Router]: https://github.com/llm-d/llm-d-router
+[InferencePool]: https://gateway-api-inference-extension.sigs.k8s.io
+[External Processing (ext-proc)]: https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/ext_proc_filter

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,599 @@
+# Configuration
+
+## Table of Contents
+
+- [Overview](#overview)
+- [The PayloadProcessorConfig API](#the-payloadprocessorconfig-api)
+  - [Top-Level Fields](#top-level-fields)
+  - [PluginSpec](#pluginspec)
+  - [PluginRef and PluginRefList](#pluginref-and-pluginreflist)
+  - [Profiles](#profiles)
+  - [Data Layer](#data-layer)
+  - [Annotated Example](#annotated-example)
+- [Model Mapping ConfigMaps](#model-mapping-configmaps)
+  - [Structure](#structure)
+  - [Mapping Rules](#mapping-rules)
+  - [Multi-Model Example](#multi-model-example)
+- [Deployment (Helm)](#deployment-helm)
+  - [Representative Values](#representative-values)
+  - [Supplying a Custom Config](#supplying-a-custom-config)
+- [Command-Line Arguments](#command-line-arguments)
+- [Environment Variables](#environment-variables)
+- [Proxy Integration](#proxy-integration)
+  - [Istio (EnvoyFilter)](#istio-envoyfilter)
+  - [GKE (GCPRoutingExtension)](#gke-gcproutingextension)
+  - [HTTPRoute Configuration](#httproute-configuration)
+  - [Tuning ext-proc Events](#tuning-ext-proc-events)
+- [Monitoring](#monitoring)
+- [References](#references)
+
+---
+
+## Overview
+
+The Inference Payload Processor (IPP) is configured through three layers:
+
+- **Command-line arguments** — Process-level settings: ports, logging verbosity, tracing, and the path to the config file. See [Command-Line Arguments](#command-line-arguments).
+- **A YAML config file** — The `PayloadProcessorConfig`, which declares the plugin pipeline: every plugin instance and how it is composed into profiles and the pre/post stages. This is the heart of IPP's behavior. See [The PayloadProcessorConfig API](#the-payloadprocessorconfig-api).
+- **ConfigMaps** — Consumed by certain plugins at runtime. The [`base-model-to-header`] plugin watches labeled ConfigMaps that map model names (base models and LoRA adapters) to base models. See [Model Mapping ConfigMaps](#model-mapping-configmaps).
+
+In a Helm deployment, the config file is rendered into a ConfigMap and mounted into the IPP container; CLI flags are passed through Helm values. See [Deployment (Helm)](#deployment-helm).
+
+---
+
+## The PayloadProcessorConfig API
+
+The `PayloadProcessorConfig` is a YAML document that declares the entire plugin pipeline. The first
+two lines are constant and must appear as written:
+
+```yaml
+apiVersion: llm-d.ai/v1alpha1
+kind: PayloadProcessorConfig
+```
+
+All plugins are instantiated once under a top-level `plugins` list and then **referenced by name**
+from profiles and the pre/post stages. This mirrors the [llm-d Router]'s `EndpointPickerConfig`
+model — the same plugin type can be instantiated multiple times under different names.
+
+> [!NOTE]
+> IPP does not use a real CRD. The config is read with Kubernetes machinery, but no JSON-Schema
+> validation is enforced at admission time; the Kubernetes validation markers in the API types are
+> documentation only. Validation happens in the loader at startup.
+
+### Top-Level Fields
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `plugins` | **Yes** | `[]PluginSpec` | The plugin instances to create. Every reference elsewhere resolves to a `name` declared here. |
+| `preProcessing` | No | `PluginRefList` | Ordered plugin references run for **every** request, before a profile is selected. |
+| `profilePicker` | No | `PluginRef` | The plugin that chooses which profile to run. When exactly one profile is defined and no picker is set, the built-in [`single-profile-picker`] is enabled automatically. |
+| `profiles` | **Yes** (min 1) | `[]Profile` | The named profiles. Exactly one runs per request. |
+| `postProcessing` | No | `PluginRefList` | Ordered plugin references run for **every** request, after the selected profile's response plugins. |
+| `datalayer` | No | `DatalayerConfig` | Data-layer plugin references: `collectors`, `extractors`, and `datasources`. |
+
+### PluginSpec
+
+Each entry in the top-level `plugins` list declares one plugin instance:
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `name` | No | string | Name by which other entries reference this instance. Defaults to the value of `type` when omitted. |
+| `type` | **Yes** | string | The plugin type to instantiate (e.g. `body-field-to-header`). See [Plugins] for available types. |
+| `parameters` | No | raw JSON/YAML | Opaque parameters passed to the plugin's factory function, which is responsible for parsing them. The schema varies per plugin. |
+
+### PluginRef and PluginRefList
+
+A `PluginRef` points at an instance declared in `plugins`:
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `pluginRef` | **Yes** | string | The `name` of a plugin instance in the top-level `plugins` list. |
+| `weight` | No | float | Weight applied if the referenced plugin is a Scorer. Defaults to `1.0` when omitted. Ignored for non-scorer references. |
+
+A `PluginRefList` (used by `preProcessing` and `postProcessing`) is simply an object with a `plugins`
+list of `PluginRef` entries.
+
+### Profiles
+
+A **profile** is a named set of request and response plugin references. Exactly one profile runs per
+request, chosen by the profile picker.
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `name` | **Yes** | string | The profile's name. |
+| `plugins` | **Yes** | object | Holds two ordered lists: `request` (`[]PluginRef`) and `response` (`[]PluginRef`). |
+
+A `request` entry may reference **either** a request-processor plugin **or** a model-selector plugin
+(Filter / Scorer / Picker); the config loader routes each reference to the correct extension point
+based on the interface the referenced plugin implements. Scorer references may carry a `weight`. See
+the [Architecture] doc for how the `Filter → Score → Pick` pipeline composes.
+
+### Data Layer
+
+The optional `datalayer` section registers plugins that maintain cross-request state consumed by
+Filters and Scorers. It holds three `PluginRef` lists:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `collectors` | `[]PluginRef` | Collector plugins that aggregate signals over time. |
+| `extractors` | `[]PluginRef` | Extractor plugins that pull metadata out of request/response events. |
+| `datasources` | `[]PluginRef` | DataSource plugins that import external configuration into the store. |
+
+### Annotated Example
+
+A complete config that performs multi-pool routing (model-name extraction plus LoRA-to-base mapping)
+under a single auto-selected profile:
+
+```yaml
+apiVersion: llm-d.ai/v1alpha1
+kind: PayloadProcessorConfig
+
+# Instantiate every plugin once. Each instance is addressable by `name`
+# (which defaults to `type` when omitted).
+plugins:
+- type: body-field-to-header           # copy `model` from the body into a header
+  parameters:
+    fieldName: model
+    headerName: X-Gateway-Model-Name
+- type: base-model-to-header           # map model/adapter name to its base model
+                                       # and inject X-Gateway-Base-Model-Name
+
+# Optional: runs for every request before profile selection.
+# preProcessing:
+#   plugins:
+#   - pluginRef: some-preprocessor
+
+# Optional: when a single profile is defined, `single-profile-picker`
+# is enabled automatically, so this can be omitted.
+# profilePicker:
+#   pluginRef: single-profile-picker
+
+# At least one profile is required; exactly one runs per request.
+profiles:
+- name: default
+  plugins:
+    request:                           # ordered request-side pipeline
+    - pluginRef: body-field-to-header
+    - pluginRef: base-model-to-header
+    response: []                       # no response-side processing
+
+# Optional: runs for every request after the profile's response plugins.
+# postProcessing:
+#   plugins:
+#   - pluginRef: some-postprocessor
+
+# Optional: cross-request state for Filters/Scorers.
+# datalayer:
+#   collectors: []
+#   extractors: []
+#   datasources: []
+```
+
+A model-selection profile mixes request processors with model-selector plugins in the same `request`
+list and weights a scorer:
+
+```yaml
+profiles:
+- name: model-selection
+  plugins:
+    request:
+    - pluginRef: model-selector            # entry point for Filter → Score → Pick
+    - pluginRef: inflight-requests-scorer  # a Scorer
+      weight: 1.0
+    - pluginRef: max-score-picker          # the Picker
+    response: []
+```
+
+---
+
+## Model Mapping ConfigMaps
+
+Multi-pool routing requires IPP to know which base model each requested model name corresponds to.
+This mapping is supplied by Kubernetes ConfigMaps that the [`base-model-to-header`] plugin watches and
+loads at runtime — no IPP restart is needed when they change.
+
+### Structure
+
+Each ConfigMap defines **one** base model and its LoRA adapters. To be watched by IPP, a ConfigMap
+must carry the label `inference.llm-d.ai/ipp-managed: "true"`.
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: qwen-model-mapping
+  labels:
+    inference.llm-d.ai/ipp-managed: "true"
+data:
+  baseModel: Qwen/Qwen2.5-1.5B-Instruct
+  adapters: |
+    - qwen-summarizer
+    - qwen-classifier
+```
+
+| Data field | Required | Type | Description |
+|------------|----------|------|-------------|
+| `baseModel` | **Yes** | string | The base model name. Requests naming this model map to itself. |
+| `adapters` | No | YAML list | LoRA adapter names served by this base model. Each adapter name maps back to `baseModel`. |
+
+### Mapping Rules
+
+- A requested model name that matches a `baseModel` maps to that base model.
+- A requested model name that matches an entry in an `adapters` list maps to that ConfigMap's `baseModel`.
+- The resolved base model is injected as the `X-Gateway-Base-Model-Name` header, which `HTTPRoute` rules match on to select the [InferencePool]. See [HTTPRoute Configuration](#httproute-configuration).
+- A name that matches nothing yields an empty base-model header; configure your `HTTPRoute` rules accordingly.
+
+> [!IMPORTANT]
+> Model names — both base models and adapters — must be **globally unique across all pools**. Because
+> IPP resolves a name to exactly one base model, a name appearing in more than one ConfigMap (or
+> reused as both a base model and an adapter) makes routing ambiguous. Keep one ConfigMap per base
+> model and ensure no name collisions across them.
+
+### Multi-Model Example
+
+Two base models, each in its own ConfigMap, with their adapters:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: qwen-model-mapping
+  labels:
+    inference.llm-d.ai/ipp-managed: "true"
+data:
+  baseModel: Qwen/Qwen2.5-1.5B-Instruct
+  adapters: |
+    - qwen-summarizer
+    - qwen-classifier
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: deepseek-model-mapping
+  labels:
+    inference.llm-d.ai/ipp-managed: "true"
+data:
+  baseModel: deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B
+  # adapters is optional; this base model serves no LoRA adapters.
+```
+
+With this mapping, a request for `qwen-summarizer` resolves to `Qwen/Qwen2.5-1.5B-Instruct`, while a
+request for `deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B` resolves to itself — each routed to its own
+pool by the `HTTPRoute` rules below.
+
+> [!NOTE]
+> By default IPP watches only the namespace it is deployed in (the `NAMESPACE` env var). To watch
+> ConfigMaps across namespaces, set the Helm value `payloadProcessor.multiNamespace=true`, which
+> omits the `NAMESPACE` env var. See [Environment Variables](#environment-variables).
+
+---
+
+## Deployment (Helm)
+
+IPP ships a Helm chart that provisions the Deployment, Service, RBAC, the config ConfigMap, and the
+provider-specific proxy integration. The chart is deployed **once per Gateway**.
+
+```bash
+helm install payload-processor ./config/charts/payload-processor \
+    --set provider.name=istio \
+    --set inferenceGateway.name=inference-gateway
+```
+
+The full values table is documented in the chart README — see the [Helm Chart] reference. This section
+only highlights the values most relevant to configuration; it does not re-document every value.
+
+### Representative Values
+
+```yaml
+payloadProcessor:
+  name: payload-processor
+  replicas: 1
+  port: 9004              # ext_proc gRPC port
+  healthCheckPort: 9005   # gRPC health/readiness port
+  multiNamespace: false   # true → watch ConfigMaps across namespaces
+  image:
+    registry: ghcr.io/llm-d
+    repository: llm-d-inference-payload-processor
+    tag: main
+    pullPolicy: IfNotPresent
+
+  # CLI flags passed through to the binary as --<key>=<value>.
+  flags:
+    v: 3                  # log verbosity
+
+  # Tracing (OTEL). When enabled, the chart injects OTEL_* env vars.
+  tracing:
+    enabled: false
+    otelServiceName: "inference.llm-d.ai/inference-payload-processor"
+    otelExporterEndpoint: "http://localhost:4317"
+    sampling:
+      sampler: "parentbased_traceidratio"
+      samplerArg: "0.1"
+
+provider:
+  name: none              # istio | gke | none
+  supportedEvents:
+    requestHeaders: true
+    requestBody: true
+    requestTrailers: true
+    responseHeaders: true
+    responseBody: true
+    responseTrailers: true
+
+inferenceGateway:
+  name: inference-gateway
+```
+
+### Supplying a Custom Config
+
+By default the chart mounts a built-in `PayloadProcessorConfig`. To supply your own pipeline, set
+`payloadProcessor.customConfig` to a full `PayloadProcessorConfig` document; the chart renders it into
+the mounted ConfigMap and points `--config-file` at it.
+
+```yaml
+payloadProcessor:
+  customConfig:
+    apiVersion: llm-d.ai/v1alpha1
+    kind: PayloadProcessorConfig
+    plugins:
+    - type: body-field-to-header
+      parameters:
+        fieldName: model
+        headerName: X-Gateway-Model-Name
+    - type: base-model-to-header
+    profiles:
+    - name: default
+      plugins:
+        request:
+        - pluginRef: body-field-to-header
+        - pluginRef: base-model-to-header
+```
+
+> [!NOTE]
+> The custom config is the same `PayloadProcessorConfig` schema documented in
+> [The PayloadProcessorConfig API](#the-payloadprocessorconfig-api). Model-mapping ConfigMaps are
+> applied separately from the chart, not embedded in `customConfig`.
+
+---
+
+## Command-Line Arguments
+
+IPP reads its process configuration from these flags (defined in `pkg/server/options.go` and the
+logging options). In Helm, set them via `payloadProcessor.flags` (which renders each as
+`--<key>=<value>`); `--config-file`, `NAMESPACE`, and the OTEL flags are wired by the chart.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--config-file` | _(empty)_ | Path to the `PayloadProcessorConfig` YAML file. |
+| `--config-text` | _(empty)_ | The `PayloadProcessorConfig` provided inline as text, in lieu of a file. |
+| `--grpc-port` | `9004` | gRPC port used for ext_proc communication with the proxy. |
+| `--grpc-health-port` | `9005` | Port for gRPC liveness and readiness probes. |
+| `--metrics-port` | `9090` | Port exposing the Prometheus `/metrics` endpoint. |
+| `--metrics-endpoint-auth` | `true` | Enable authentication and authorization on the metrics endpoint. |
+| `--secure-serving` | `true` | Enable secure serving. |
+| `--tracing` | `true` | Enable emitting OpenTelemetry traces. |
+| `--enable-pprof` | `true` | Enable pprof handlers. Set to `false` to disable. |
+| `-v`, `--v` | `0` | Log verbosity level. |
+| `--zap-log-level` | _(derived from `-v`)_ | Zap log level. When unset, it is derived as `-1 × v`. |
+
+> [!NOTE]
+> `--config-file` and `--config-text` are mutually exclusive ways to supply the config; if both are
+> set, `--config-text` takes precedence. The three server ports (`--grpc-port`,
+> `--grpc-health-port`, `--metrics-port`) are validated to be in `1–65535` and must all differ.
+
+---
+
+## Environment Variables
+
+| Variable | Set by | Description |
+|----------|--------|-------------|
+| `NAMESPACE` | Helm (unless `multiNamespace=true`) | Restricts the controller cache — and therefore ConfigMap watching — to this single namespace. When unset, IPP watches all namespaces. |
+| `OTEL_SERVICE_NAME` | Helm (tracing) | Service name reported on traces. Defaults to `llm-d-ipp` if unset. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Helm (tracing) | OTLP collector endpoint. Defaults to `http://localhost:4317` if unset. |
+| `OTEL_TRACES_EXPORTER` | Helm (tracing) | Traces exporter (the chart sets `otlp`). |
+| `OTEL_TRACES_SAMPLER` | Helm (tracing) | Sampler type (e.g. `parentbased_traceidratio`). |
+| `OTEL_TRACES_SAMPLER_ARG` | Helm (tracing) | Sampler argument (e.g. `0.1`). |
+| `OTEL_RESOURCE_ATTRIBUTES` | Helm (tracing) | Resource attributes attached to traces (namespace, node, pod). |
+
+> [!NOTE]
+> The `OTEL_*` variables only take effect when tracing is enabled (`--tracing=true`, set via
+> `payloadProcessor.tracing.enabled` in Helm). The chart also populates `OTEL_RESOURCE_ATTRIBUTES`
+> from the pod's namespace, node, and pod name via the downward API.
+
+---
+
+## Proxy Integration
+
+IPP runs as an ext-proc service that the proxy invokes over Envoy's [External Processing (ext-proc)]
+protocol. The Helm chart provisions the provider-specific integration based on `provider.name`:
+`istio` generates an `EnvoyFilter`, `gke` generates a `GCPRoutingExtension`, and `none` deploys only
+the IPP Deployment and Service (you wire the proxy integration yourself). In all cases the request
+body is streamed using ext-proc's `FULL_DUPLEX_STREAMED` body mode, which IPP requires to observe and
+mutate full bodies.
+
+### Istio (EnvoyFilter)
+
+With `provider.name=istio`, the chart installs an `EnvoyFilter` that inserts the ext_proc filter into
+the target Gateway's HTTP filter chain (and a `DestinationRule` for the IPP service). The processing
+mode for each event reflects the `provider.supportedEvents` values — enabled events use `SEND`/
+`FULL_DUPLEX_STREAMED`, disabled ones use `SKIP`/`NONE`:
+
+```yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: payload-processor
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: inference-gateway
+  configPatches:
+  - applyTo: HTTP_FILTER
+    match:
+      context: GATEWAY
+      listener:
+        filterChain:
+          filter:
+            name: "envoy.filters.network.http_connection_manager"
+    patch:
+      operation: INSERT_FIRST
+      value:
+        name: envoy.filters.http.ext_proc.payload-processor
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+          failure_mode_allow: false
+          allow_mode_override: true
+          processing_mode:
+            request_header_mode: "SEND"
+            response_header_mode: "SEND"
+            request_body_mode: "FULL_DUPLEX_STREAMED"
+            response_body_mode: "FULL_DUPLEX_STREAMED"
+            request_trailer_mode: "SEND"
+            response_trailer_mode: "SEND"
+          grpc_service:
+            envoy_grpc:
+              cluster_name: outbound|9004||payload-processor.<namespace>.svc.cluster.local
+```
+
+The filter insertion point is controlled by `provider.istio.envoyFilter.operation` (default
+`INSERT_FIRST`) and `provider.istio.envoyFilter.anchorSubFilter`.
+
+### GKE (GCPRoutingExtension)
+
+With `provider.name=gke`, the chart registers IPP as a routing extension via a `GCPRoutingExtension`
+(and a `HealthCheckPolicy`). The `supportedEvents` list and body send modes again follow
+`provider.supportedEvents`:
+
+```yaml
+kind: GCPRoutingExtension
+apiVersion: networking.gke.io/v1
+metadata:
+  name: payload-processor
+spec:
+  targetRefs:
+  - group: "gateway.networking.k8s.io"
+    kind: Gateway
+    name: inference-gateway
+  extensionChains:
+  - name: chain1
+    extensions:
+    - name: ext1
+      authority: "myext.com"
+      timeout: 1s
+      supportedEvents:
+      - RequestHeaders
+      - RequestBody
+      - RequestTrailers
+      - ResponseHeaders
+      - ResponseBody
+      - ResponseTrailers
+      requestBodySendMode: "FullDuplexStreamed"
+      responseBodySendMode: "FullDuplexStreamed"
+      backendRef:
+        group: ""
+        kind: Service
+        name: payload-processor
+        port: 9004
+```
+
+### HTTPRoute Configuration
+
+IPP injects a routing header (the [`base-model-to-header`] plugin uses `X-Gateway-Base-Model-Name`);
+**you** then configure `HTTPRoute` resources that match on that header and route to the right
+[InferencePool]. These `HTTPRoute` resources are **not** created by the chart — they are part of your
+deployment.
+
+A two-pool example routing on the injected base-model header:
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: qwen-route
+spec:
+  parentRefs:
+  - name: inference-gateway
+  rules:
+  - matches:
+    - headers:
+      - type: Exact
+        name: X-Gateway-Base-Model-Name
+        value: Qwen/Qwen2.5-1.5B-Instruct
+    backendRefs:
+    - group: inference.networking.k8s.io
+      kind: InferencePool
+      name: qwen-pool
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: deepseek-route
+spec:
+  parentRefs:
+  - name: inference-gateway
+  rules:
+  - matches:
+    - headers:
+      - type: Exact
+        name: X-Gateway-Base-Model-Name
+        value: deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B
+    backendRefs:
+    - group: inference.networking.k8s.io
+      kind: InferencePool
+      name: deepseek-pool
+```
+
+A request for the LoRA adapter `qwen-summarizer` is mapped to `Qwen/Qwen2.5-1.5B-Instruct` by IPP and
+matched by the first route; a request for the DeepSeek base model is matched by the second.
+
+### Tuning ext-proc Events
+
+The six ext-proc events — `requestHeaders`, `requestBody`, `requestTrailers`, `responseHeaders`,
+`responseBody`, `responseTrailers` — are individually toggleable through `provider.supportedEvents`.
+**Each enabled event is an extra network hop** between the proxy and IPP, so enable only the events
+your configured plugins actually consume. For example, a routing-only deployment (which acts on the
+request body alone) can disable all response events:
+
+```yaml
+provider:
+  name: istio
+  supportedEvents:
+    requestHeaders: true
+    requestBody: true
+    requestTrailers: true
+    responseHeaders: false
+    responseBody: false
+    responseTrailers: false
+```
+
+---
+
+## Monitoring
+
+IPP exposes Prometheus metrics on an HTTP endpoint (default port `9090`, path `/metrics`), configured
+via `--metrics-port` and `--metrics-endpoint-auth`. The full list of metrics — their names, types,
+labels, and intended use — is documented in [Metrics]. Tracing is handled separately via OpenTelemetry;
+see [Environment Variables](#environment-variables).
+
+---
+
+## References
+
+- [Architecture] — How IPP works: ext-proc integration, the processing pipeline, profiles, model selection, and multi-pool routing.
+- [Plugins] — In-tree plugin reference and the pipeline configuration model.
+- [Metrics] — Prometheus metrics exposed by IPP.
+- [Helm Chart] — Chart install reference and the full values table.
+- [llm-d] — The end-to-end **Multi-Model Routing guide** lives in the llm-d repo.
+- [External Processing (ext-proc)] — The Envoy protocol IPP implements.
+
+[Architecture]: architecture.md
+[Plugins]: plugins.md
+[Metrics]: metrics.md
+[Helm Chart]: ../config/charts/payload-processor/README.md
+[`base-model-to-header`]: plugins.md
+[`single-profile-picker`]: plugins.md
+[llm-d]: https://github.com/llm-d/llm-d
+[llm-d Router]: https://github.com/llm-d/llm-d-router
+[InferencePool]: https://gateway-api-inference-extension.sigs.k8s.io
+[External Processing (ext-proc)]: https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/ext_proc_filter

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -65,10 +65,10 @@ model — the same plugin type can be instantiated multiple times under differen
 | Field | Required | Type | Description |
 |-------|----------|------|-------------|
 | `plugins` | **Yes** | `[]PluginSpec` | The plugin instances to create. Every reference elsewhere resolves to a `name` declared here. |
-| `preProcessing` | No | `PluginRefList` | Ordered plugin references run for **every** request, before a profile is selected. |
+| `preProcessing` | No | `PluginRefList` | Ordered references intended to run for **every** request before a profile is selected. _Reserved: accepted by the config but not yet invoked by the request path._ |
 | `profilePicker` | No | `PluginRef` | The plugin that chooses which profile to run. When exactly one profile is defined and no picker is set, the built-in [`single-profile-picker`] is enabled automatically. |
 | `profiles` | **Yes** (min 1) | `[]Profile` | The named profiles. Exactly one runs per request. |
-| `postProcessing` | No | `PluginRefList` | Ordered plugin references run for **every** request, after the selected profile's response plugins. |
+| `postProcessing` | No | `PluginRefList` | Ordered references intended to run for **every** request after the selected profile's response plugins. _Reserved: accepted by the config but not yet invoked by the request path._ |
 | `datalayer` | No | `DatalayerConfig` | Data-layer plugin references: `collectors`, `extractors`, and `datasources`. |
 
 ### PluginSpec
@@ -88,7 +88,7 @@ A `PluginRef` points at an instance declared in `plugins`:
 | Field | Required | Type | Description |
 |-------|----------|------|-------------|
 | `pluginRef` | **Yes** | string | The `name` of a plugin instance in the top-level `plugins` list. |
-| `weight` | No | float | Weight applied if the referenced plugin is a Scorer. Defaults to `1.0` when omitted. Ignored for non-scorer references. |
+| `weight` | For scorers | float | Weight applied to a Scorer's contribution. **Required** when the referenced plugin is a Scorer (the loader rejects a scorer reference with no weight); ignored for non-scorer references. |
 
 A `PluginRefList` (used by `preProcessing` and `postProcessing`) is simply an object with a `plugins`
 list of `PluginRef` entries.
@@ -326,15 +326,15 @@ inferenceGateway:
 
 ### Supplying a Custom Config
 
-By default the chart mounts a built-in `PayloadProcessorConfig`. To supply your own pipeline, set
-`payloadProcessor.customConfig` to a full `PayloadProcessorConfig` document; the chart renders it into
-the mounted ConfigMap and points `--config-file` at it.
+By default the chart mounts a built-in `PayloadProcessorConfig` (the shipped default lives in
+[`deploy/config/ipp-config.yaml`](../deploy/config/ipp-config.yaml)). To supply your own pipeline, set
+`payloadProcessor.customConfig` to a `PayloadProcessorConfig` body; the chart renders it into the
+mounted ConfigMap and points `--config-file` at it.
 
 ```yaml
 payloadProcessor:
   customConfig:
-    apiVersion: llm-d.ai/v1alpha1
-    kind: PayloadProcessorConfig
+    # The chart adds the apiVersion/kind header automatically — start at `plugins`.
     plugins:
     - type: body-field-to-header
       parameters:
@@ -370,16 +370,19 @@ logging options). In Helm, set them via `payloadProcessor.flags` (which renders 
 | `--grpc-health-port` | `9005` | Port for gRPC liveness and readiness probes. |
 | `--metrics-port` | `9090` | Port exposing the Prometheus `/metrics` endpoint. |
 | `--metrics-endpoint-auth` | `true` | Enable authentication and authorization on the metrics endpoint. |
-| `--secure-serving` | `true` | Enable secure serving. |
+| `--secure-serving` | `true` | Serve the ext-proc gRPC endpoint over TLS (a self-signed certificate is generated at startup). Set to `false` for plaintext. |
 | `--tracing` | `true` | Enable emitting OpenTelemetry traces. |
 | `--enable-pprof` | `true` | Enable pprof handlers. Set to `false` to disable. |
-| `-v`, `--v` | `0` | Log verbosity level. |
+| `-v`, `--v` | `2` | Log verbosity level. |
 | `--zap-log-level` | _(derived from `-v`)_ | Zap log level. When unset, it is derived as `-1 × v`. |
 
+The logger also accepts the standard controller-runtime `--zap-*` flags (`--zap-devel`,
+`--zap-encoder`, `--zap-stacktrace-level`, `--zap-time-encoding`) for additional tuning.
+
 > [!NOTE]
-> `--config-file` and `--config-text` are mutually exclusive ways to supply the config; if both are
-> set, `--config-text` takes precedence. The three server ports (`--grpc-port`,
-> `--grpc-health-port`, `--metrics-port`) are validated to be in `1–65535` and must all differ.
+> `--config-file` and `--config-text` are two ways to supply the config; if both are set,
+> `--config-text` takes precedence. The three server ports (`--grpc-port`, `--grpc-health-port`,
+> `--metrics-port`) are validated to be in `1–65535` and must all differ.
 
 ---
 
@@ -406,8 +409,9 @@ logging options). In Helm, set them via `payloadProcessor.flags` (which renders 
 
 IPP runs as an ext-proc service that the proxy invokes over Envoy's [External Processing (ext-proc)]
 protocol. The Helm chart provisions the provider-specific integration based on `provider.name`:
-`istio` generates an `EnvoyFilter`, `gke` generates a `GCPRoutingExtension`, and `none` deploys only
-the IPP Deployment and Service (you wire the proxy integration yourself). In all cases the request
+`istio` generates an `EnvoyFilter`, `gke` generates a `GCPRoutingExtension`, and `none` provisions the
+core IPP resources (Deployment, Service, config, RBAC) but no proxy-integration resources — you wire
+the proxy integration yourself. In all cases the request
 body is streamed using ext-proc's `FULL_DUPLEX_STREAMED` body mode, which IPP requires to observe and
 mutate full bodies.
 

--- a/docs/create_new_plugin.md
+++ b/docs/create_new_plugin.md
@@ -34,7 +34,7 @@ satisfies and routes it to the matching pipeline stage:
 
 | Interface | Package | Role |
 |-----------|---------|------|
-| `PreProcessor` / `PostProcessor` | [`requesthandling`][requesthandling-src] | Run for every request before profile selection / after the profile's response plugins. |
+| `PreProcessor` / `PostProcessor` | [`requesthandling`][requesthandling-src] | Reserved global stages (before profile selection / after the response plugins). Defined in the API but not yet invoked by the request path. |
 | `RequestProcessor` | [`requesthandling`][requesthandling-src] | Inspect and mutate the request before routing. |
 | `ResponseProcessor` | [`requesthandling`][requesthandling-src] | Inspect and mutate the response on its way back. |
 | `ProfilePicker` | [`requesthandling`][requesthandling-src] | Choose which profile runs for a request. |
@@ -173,9 +173,10 @@ A model-selector plugin has the same shape but implements one of the
 [`modelselector`][modelselector-src] interfaces (`Filter`, `Scorer`, or `Picker`) instead of
 `RequestProcessor`. For example, a `Scorer` implements `Score(...) map[datalayer.Model]float64`,
 returning a score per candidate. The [`cost-scorer`][costaware-src] is a concrete reference; its
-factory, `WithName`, and `plugin.Register` wiring mirror this tutorial exactly. In configuration, a
-Scorer is referenced from a profile's `request` list alongside the `model-selector` entry and may
-carry a `weight`. See [Plugins][Plugins] for the full Filter/Scorer/Picker set.
+factory and `WithName` follow this tutorial (it ships in-tree but, like `model-config-datasource`, is
+not registered in the default runner — add its factory to `registerInTreePlugins` to use it). In
+configuration, a Scorer is referenced from a profile's `request` list alongside the `model-selector`
+entry and **requires** a `weight`. See [Plugins][Plugins] for the full Filter/Scorer/Picker set.
 
 ## Testing
 

--- a/docs/create_new_plugin.md
+++ b/docs/create_new_plugin.md
@@ -1,0 +1,217 @@
+# Extending IPP with a custom plugin
+
+## Goal
+
+This tutorial walks through writing a custom plugin for the Inference Payload Processor (IPP),
+registering it so the configuration loader can instantiate it, and wiring it into a profile.
+
+The worked example is [`body-field-to-header`][body-field-to-header-src], a small request-processing
+plugin that copies a request-body field into an HTTP header. It exercises every part of the plugin
+contract — a struct, a factory, parameter parsing, an extension-point method, and a `TypedName` — and
+the same recipe applies to every other plugin kind.
+
+For the pipeline model (profiles, ext-proc lifecycle, model selection, data layer) see
+[Architecture][Architecture]; for the in-tree plugin catalogue and full configuration model see
+[Plugins][Plugins].
+
+## The plugin model
+
+Every plugin implements the base [`plugin.Plugin`][plugin-src] interface, a single method:
+
+```go
+type Plugin interface {
+    // TypedName returns the type and name tuple of this plugin instance.
+    TypedName() TypedName
+}
+```
+
+`TypedName` is a `{Type, Name}` tuple: `Type` is the registered type-name constant, `Name` is the
+per-instance name from configuration. Because instances are named, one plugin type can be instantiated
+multiple times with different parameters.
+
+A plugin then **additionally implements** one extension-point interface; the loader inspects which it
+satisfies and routes it to the matching pipeline stage:
+
+| Interface | Package | Role |
+|-----------|---------|------|
+| `PreProcessor` / `PostProcessor` | [`requesthandling`][requesthandling-src] | Run for every request before profile selection / after the profile's response plugins. |
+| `RequestProcessor` | [`requesthandling`][requesthandling-src] | Inspect and mutate the request before routing. |
+| `ResponseProcessor` | [`requesthandling`][requesthandling-src] | Inspect and mutate the response on its way back. |
+| `ProfilePicker` | [`requesthandling`][requesthandling-src] | Choose which profile runs for a request. |
+| `Filter` / `Scorer` / `Picker` | [`modelselector`][modelselector-src] | The `Filter → Score → Pick` phases that select a *model*. |
+| `Collector` / `Extractor` / `DataSource` | [`datalayer/datasource`][datalayer-src] | Maintain cross-request state consumed by Filters and Scorers. |
+
+This tutorial implements `RequestProcessor`; see [Other extension points](#other-extension-points)
+for the rest.
+
+## Code walkthrough
+
+The example lives in [`body_field_to_header.go`][body-field-to-header-src]. The plugin declares its
+registered type, a parameters struct, the plugin struct, and a compile-time interface assertion:
+
+```go
+const BodyFieldToHeaderPluginType = "body-field-to-header"
+
+// compile-time check that the plugin satisfies the RequestProcessor interface
+var _ requesthandling.RequestProcessor = &BodyFieldToHeaderPlugin{}
+
+// BodyFieldToHeaderConfig is the JSON/YAML parameter shape.
+type BodyFieldToHeaderConfig struct {
+    FieldName  string `json:"fieldName"`
+    HeaderName string `json:"headerName"`
+}
+
+type BodyFieldToHeaderPlugin struct {
+    typedName  plugin.TypedName
+    fieldName  string
+    headerName string
+}
+```
+
+Plugins are constructed by a **factory** matching the [`plugin.FactoryFunc`][registry-src] signature.
+It receives the instance name, the raw parameters, and a [`plugin.Handle`][handle-src]; it parses the
+parameters and stamps the configured name with `WithName`:
+
+```go
+func BodyFieldToHeaderPluginFactory(name string, rawParameters json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
+    var config BodyFieldToHeaderConfig
+    if len(rawParameters) > 0 {
+        if err := json.Unmarshal(rawParameters, &config); err != nil {
+            return nil, fmt.Errorf("failed to parse parameters of '%s': %w", BodyFieldToHeaderPluginType, err)
+        }
+    }
+    plugin, err := NewBodyFieldToHeaderPlugin(config.FieldName, config.HeaderName) // validates inputs, seeds TypedName
+    if err != nil {
+        return nil, err
+    }
+    return plugin.WithName(name), nil
+}
+```
+
+The extension-point method does the work. `RequestProcessor` requires:
+
+```go
+ProcessRequest(ctx context.Context, cycleState *plugin.CycleState, request *InferenceRequest) error
+```
+
+The implementation reads the body field and sets the header, treating an absent or empty field as a
+no-op:
+
+```go
+func (p *BodyFieldToHeaderPlugin) ProcessRequest(ctx context.Context, _ *plugin.CycleState, request *requesthandling.InferenceRequest) error {
+    rawFieldValue, exists := request.Body[p.fieldName]
+    if !exists {
+        metrics.RecordBodyFieldNotFound(p.fieldName)
+        return nil
+    }
+    fieldStr := fmt.Sprintf("%v", rawFieldValue)
+    if fieldStr == "" {
+        metrics.RecordBodyFieldEmpty(p.fieldName)
+        return nil
+    }
+    request.SetHeader(p.headerName, fieldStr)
+    return nil
+}
+```
+
+Key points about the contract:
+
+- Plugins **mutate the request in place** rather than returning mutations. `request.SetHeader(...)`
+  (and `SetBody`, `SetBodyField`, `RemoveHeader`, ...) record changes on the embedded
+  [`InferenceMessage`][requesthandling-types-src]; the framework translates them into the ext-proc
+  response the Proxy applies. Returning `nil` with no mutation is a valid no-op.
+- A non-nil `error` aborts processing for that request.
+- `cycleState` is a [per-request key/value store][cycle-state-src] for passing data between plugins in
+  the same request (`Write`/`Read`, or the typed `plugin.ReadCycleStateKey[T]`). This plugin does not
+  use it.
+
+## Registering the plugin
+
+A type must be registered before the loader can instantiate it. [`plugin.Register`][registry-src] maps
+a type string to a factory; in-tree plugins register in `registerInTreePlugins` in
+[`cmd/runner/runner.go`][runner-src]:
+
+```go
+func (r *Runner) registerInTreePlugins() {
+    plugin.Register(bodyfieldtoheader.BodyFieldToHeaderPluginType, bodyfieldtoheader.BodyFieldToHeaderPluginFactory)
+    // ...existing registrations...
+}
+```
+
+The first argument is the string clients put under `type:` in the config; the second is the factory
+the loader calls per configured instance.
+
+## Configuring the plugin
+
+Declare each plugin **once** under the top-level `plugins` list, then reference it by name from a
+profile's `request` list with `pluginRef`:
+
+```yaml
+apiVersion: llm-d.ai/v1alpha1
+kind: PayloadProcessorConfig
+plugins:
+- type: body-field-to-header
+  name: model-to-header        # optional; defaults to the type
+  parameters:
+    fieldName: model
+    headerName: X-Gateway-Model-Name
+profiles:
+- name: default
+  plugins:
+    request:
+    - pluginRef: model-to-header
+```
+
+The `parameters` block is opaque to the framework — it is handed to the factory as raw JSON/YAML.
+With a single profile and no `profilePicker`, [`single-profile-picker`] is enabled automatically. See
+[Configuration][Configuration] for the full schema (pre/post processing, the `datalayer` section,
+scorer `weight`, proxy integration).
+
+## Other extension points
+
+A model-selector plugin has the same shape but implements one of the
+[`modelselector`][modelselector-src] interfaces (`Filter`, `Scorer`, or `Picker`) instead of
+`RequestProcessor`. For example, a `Scorer` implements `Score(...) map[datalayer.Model]float64`,
+returning a score per candidate. The [`cost-scorer`][costaware-src] is a concrete reference; its
+factory, `WithName`, and `plugin.Register` wiring mirror this tutorial exactly. In configuration, a
+Scorer is referenced from a profile's `request` list alongside the `model-selector` entry and may
+carry a `weight`. See [Plugins][Plugins] for the full Filter/Scorer/Picker set.
+
+## Testing
+
+Each in-tree plugin ships a unit test next to its source — use them as templates:
+
+- [`body_field_to_header_test.go`][body-field-to-header-test-src] — constructs the plugin, calls
+  `ProcessRequest` on a hand-built `InferenceRequest`, and asserts the header mutations (including the
+  absent and empty no-op paths).
+- [`plugin_test.go`][costaware-test-src] — asserts the `cost-scorer` score map for various price
+  distributions.
+
+Tests call the factory or constructor directly and read mutations back through the message helpers
+(`MutatedHeaders()`, `BodyMutated()`, ...).
+
+## References
+
+- [Architecture][Architecture] — the IPP pipeline, profiles, model selection, and data layer.
+- [Configuration][Configuration] — the full `PayloadProcessorConfig` schema.
+- [Plugins][Plugins] — the in-tree plugin reference and configuration model.
+- [`plugin.Plugin`][plugin-src] / [registry][registry-src] — the base contract and registration.
+- [`requesthandling`][requesthandling-src] / [`modelselector`][modelselector-src] interfaces.
+
+[Architecture]: architecture.md
+[Configuration]: configuration.md
+[Plugins]: plugins.md
+[`single-profile-picker`]: plugins.md#profile-picker-plugins
+[plugin-src]: https://github.com/llm-d/llm-d-inference-payload-processor/blob/main/pkg/framework/interface/plugin/plugins.go
+[registry-src]: https://github.com/llm-d/llm-d-inference-payload-processor/blob/main/pkg/framework/interface/plugin/registry.go
+[handle-src]: https://github.com/llm-d/llm-d-inference-payload-processor/blob/main/pkg/framework/interface/plugin/handle.go
+[cycle-state-src]: https://github.com/llm-d/llm-d-inference-payload-processor/blob/main/pkg/framework/interface/plugin/cycle_state.go
+[requesthandling-src]: https://github.com/llm-d/llm-d-inference-payload-processor/blob/main/pkg/framework/interface/requesthandling/plugins.go
+[requesthandling-types-src]: https://github.com/llm-d/llm-d-inference-payload-processor/blob/main/pkg/framework/interface/requesthandling/types.go
+[modelselector-src]: https://github.com/llm-d/llm-d-inference-payload-processor/blob/main/pkg/framework/interface/modelselector/plugins.go
+[datalayer-src]: https://github.com/llm-d/llm-d-inference-payload-processor/blob/main/pkg/framework/interface/datalayer/datasource/types.go
+[body-field-to-header-src]: https://github.com/llm-d/llm-d-inference-payload-processor/blob/main/pkg/framework/plugins/requesthandling/bodyfieldtoheader/body_field_to_header.go
+[body-field-to-header-test-src]: https://github.com/llm-d/llm-d-inference-payload-processor/blob/main/pkg/framework/plugins/requesthandling/bodyfieldtoheader/body_field_to_header_test.go
+[costaware-src]: https://github.com/llm-d/llm-d-inference-payload-processor/blob/main/pkg/framework/plugins/modelselector/scorer/costaware/plugin.go
+[costaware-test-src]: https://github.com/llm-d/llm-d-inference-payload-processor/blob/main/pkg/framework/plugins/modelselector/scorer/costaware/plugin_test.go
+[runner-src]: https://github.com/llm-d/llm-d-inference-payload-processor/blob/main/cmd/runner/runner.go

--- a/docs/images/ipp-request-flow.svg
+++ b/docs/images/ipp-request-flow.svg
@@ -1,0 +1,71 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 750 320" font-family="Arial, Helvetica, sans-serif">
+  <defs>
+    <marker id="arr" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#000000"/>
+    </marker>
+    <marker id="arr-back" markerWidth="8" markerHeight="6" refX="0" refY="3" orient="auto">
+      <polygon points="8 0, 0 3, 8 6" fill="#666666"/>
+    </marker>
+  </defs>
+
+  <!-- White Canvas with Purple Border (llm-d branding) -->
+  <rect x="2" y="2" width="746" height="316" rx="0" fill="#ffffff" stroke="#9f659f" stroke-width="3"/>
+
+  <!-- Title -->
+  <text x="375" y="28" text-anchor="middle" font-size="13" font-weight="bold" fill="#000000">IPP Request Flow</text>
+
+  <!-- Client -->
+  <rect x="20" y="100" width="100" height="80" rx="3" fill="#f3f3f3" stroke="#d9d2e9" stroke-width="1"/>
+  <text x="70" y="125" text-anchor="middle" font-size="11" font-weight="bold" fill="#000000">Client</text>
+  <text x="70" y="145" text-anchor="middle" font-size="8" fill="#666666">POST /v1/completions</text>
+  <text x="70" y="160" text-anchor="middle" font-size="8" fill="#444444">{"model": "..."}</text>
+
+  <!-- Client to Gateway -->
+  <line x1="120" y1="140" x2="198" y2="140" stroke="#000000" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="159" y="132" text-anchor="middle" font-size="8" fill="#444444">1</text>
+
+  <!-- Proxy (central hub) -->
+  <rect x="200" y="80" width="180" height="120" rx="3" fill="#e6e6fa" stroke="#9f659f" stroke-width="2"/>
+  <text x="290" y="105" text-anchor="middle" font-size="12" font-weight="bold" fill="#000000">Proxy</text>
+  <text x="290" y="125" text-anchor="middle" font-size="8" fill="#666666">1. Receive request</text>
+  <text x="290" y="140" text-anchor="middle" font-size="8" fill="#666666">2. Call llm-d IPP (ext-proc)</text>
+  <text x="290" y="155" text-anchor="middle" font-size="8" fill="#666666">3. Route by header</text>
+  <text x="290" y="170" text-anchor="middle" font-size="8" fill="#666666">4. Call llm-d EPP (ext-proc)</text>
+  <text x="290" y="185" text-anchor="middle" font-size="8" fill="#666666">5. Forward to endpoint</text>
+
+  <!-- llm-d IPP (ext-proc service) - below proxy -->
+  <rect x="220" y="220" width="140" height="75" rx="3" fill="#e8f4e8" stroke="#82b366" stroke-width="1.5"/>
+  <text x="290" y="242" text-anchor="middle" font-size="10" font-weight="bold" fill="#000000">llm-d IPP</text>
+  <text x="290" y="256" text-anchor="middle" font-size="8" fill="#666666">Process payload</text>
+  <text x="290" y="270" text-anchor="middle" font-size="8" fill="#666666">(pluggable pipeline)</text>
+  <text x="290" y="284" text-anchor="middle" font-size="7" fill="#888888">(ext-proc)</text>
+
+  <!-- Gateway to IPP (bidirectional) -->
+  <line x1="270" y1="200" x2="270" y2="218" stroke="#000000" stroke-width="1.5" marker-end="url(#arr)"/>
+  <line x1="310" y1="218" x2="310" y2="200" stroke="#666666" stroke-width="1" stroke-dasharray="3,2" marker-end="url(#arr)"/>
+  <text x="253" y="212" text-anchor="middle" font-size="7" fill="#444444">2</text>
+
+  <!-- llm-d EPP (ext-proc service) - right of proxy -->
+  <rect x="430" y="110" width="100" height="60" rx="3" fill="#f3f3f3" stroke="#d9d2e9" stroke-width="1"/>
+  <text x="480" y="132" text-anchor="middle" font-size="10" font-weight="bold" fill="#000000">llm-d EPP</text>
+  <text x="480" y="148" text-anchor="middle" font-size="8" fill="#666666">Select endpoint</text>
+  <text x="480" y="161" text-anchor="middle" font-size="7" fill="#888888">(ext-proc)</text>
+
+  <!-- Gateway to EPP (bidirectional) -->
+  <line x1="380" y1="130" x2="428" y2="130" stroke="#000000" stroke-width="1.5" marker-end="url(#arr)"/>
+  <line x1="428" y1="150" x2="380" y2="150" stroke="#666666" stroke-width="1" stroke-dasharray="3,2" marker-end="url(#arr)"/>
+  <text x="404" y="122" text-anchor="middle" font-size="7" fill="#444444">4</text>
+
+  <!-- Model Server -->
+  <rect x="580" y="100" width="140" height="80" rx="3" fill="#f3f3f3" stroke="#d9d2e9" stroke-width="1"/>
+  <text x="650" y="125" text-anchor="middle" font-size="11" font-weight="bold" fill="#000000">Model Server</text>
+  <text x="650" y="145" text-anchor="middle" font-size="8" fill="#666666">vLLM / SGLang</text>
+  <text x="650" y="162" text-anchor="middle" font-size="8" fill="#444444">InferencePool</text>
+
+  <!-- Gateway to Model Server -->
+  <line x1="530" y1="140" x2="578" y2="140" stroke="#000000" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="554" y="132" text-anchor="middle" font-size="7" fill="#444444">5</text>
+
+  <!-- Caption -->
+  <text x="375" y="308" text-anchor="middle" font-size="9" fill="#888888">Proxy consults llm-d IPP and llm-d EPP via ext-proc, then forwards request to selected endpoint</text>
+</svg>

--- a/docs/images/multi-pool-routing.svg
+++ b/docs/images/multi-pool-routing.svg
@@ -1,0 +1,108 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 390" font-family="Arial, Helvetica, sans-serif">
+  <defs>
+    <marker id="arr" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#000000"/>
+    </marker>
+  </defs>
+
+  <!-- White Canvas with Purple Border (llm-d branding) -->
+  <rect x="2" y="2" width="816" height="386" rx="0" fill="#ffffff" stroke="#9f659f" stroke-width="3"/>
+
+  <!-- Title -->
+  <text x="410" y="28" text-anchor="middle" font-size="13" font-weight="bold" fill="#000000">Multi-Pool Routing Architecture</text>
+
+  <!-- Client -->
+  <rect x="20" y="145" width="85" height="70" rx="3" fill="#f3f3f3" stroke="#d9d2e9" stroke-width="1"/>
+  <text x="62" y="168" text-anchor="middle" font-size="11" font-weight="bold" fill="#000000">Client</text>
+  <text x="62" y="185" text-anchor="middle" font-size="8" fill="#666666">POST /v1/</text>
+  <text x="62" y="197" text-anchor="middle" font-size="8" fill="#666666">completions</text>
+
+  <!-- Client to Proxy -->
+  <line x1="105" y1="180" x2="143" y2="180" stroke="#000000" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- Proxy (central hub) -->
+  <rect x="145" y="115" width="120" height="130" rx="3" fill="#e6e6fa" stroke="#9f659f" stroke-width="2"/>
+  <text x="205" y="138" text-anchor="middle" font-size="11" font-weight="bold" fill="#000000">Proxy</text>
+  <text x="205" y="158" text-anchor="middle" font-size="8" fill="#666666">1. Receive request</text>
+  <text x="205" y="173" text-anchor="middle" font-size="8" fill="#666666">2. Call llm-d IPP</text>
+  <text x="205" y="188" text-anchor="middle" font-size="8" fill="#666666">3. Route by header</text>
+  <text x="205" y="203" text-anchor="middle" font-size="8" fill="#666666">4. Call llm-d EPP</text>
+  <text x="205" y="218" text-anchor="middle" font-size="8" fill="#666666">5. Forward request</text>
+  <text x="205" y="238" text-anchor="middle" font-size="7" fill="#888888">(HTTPRoute rules)</text>
+
+  <!-- llm-d IPP (below Proxy) -->
+  <rect x="145" y="270" width="120" height="60" rx="3" fill="#e8f4e8" stroke="#82b366" stroke-width="1.5"/>
+  <text x="205" y="292" text-anchor="middle" font-size="10" font-weight="bold" fill="#000000">llm-d IPP</text>
+  <text x="205" y="308" text-anchor="middle" font-size="8" fill="#666666">Process payload</text>
+  <text x="205" y="320" text-anchor="middle" font-size="7" fill="#888888">(ext-proc)</text>
+
+  <!-- Proxy to IPP (bidirectional) -->
+  <line x1="185" y1="245" x2="185" y2="268" stroke="#000000" stroke-width="1.5" marker-end="url(#arr)"/>
+  <line x1="225" y1="268" x2="225" y2="245" stroke="#666666" stroke-width="1" stroke-dasharray="3,2" marker-end="url(#arr)"/>
+
+  <!-- Routing arrows from Proxy to Pools -->
+  <!-- Proxy to Pool A -->
+  <line x1="265" y1="150" x2="343" y2="100" stroke="#000000" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="305" y="110" text-anchor="middle" font-size="7" fill="#444444">Qwen/...</text>
+
+  <!-- Proxy to Pool B -->
+  <line x1="265" y1="210" x2="343" y2="260" stroke="#000000" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="305" y="250" text-anchor="middle" font-size="7" fill="#444444">deepseek/...</text>
+
+  <!-- InferencePool A -->
+  <rect x="345" y="45" width="455" height="105" rx="5" fill="#e1d5e7" stroke="#9673a6" stroke-width="1.5"/>
+  <text x="572" y="63" text-anchor="middle" font-size="11" font-weight="bold" fill="#000000">InferencePool A (Qwen/Qwen3-32B)</text>
+  
+  <!-- llm-d EPP A inside Pool A -->
+  <rect x="360" y="75" width="85" height="50" rx="3" fill="#f3f3f3" stroke="#d9d2e9" stroke-width="1"/>
+  <text x="402" y="95" text-anchor="middle" font-size="9" font-weight="bold" fill="#000000">llm-d EPP</text>
+  <text x="402" y="110" text-anchor="middle" font-size="7" fill="#666666">Select endpoint</text>
+  <text x="402" y="120" text-anchor="middle" font-size="6" fill="#888888">(ext-proc)</text>
+
+  <!-- EPP A to pods -->
+  <line x1="445" y1="100" x2="483" y2="100" stroke="#000000" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- Pods in Pool A -->
+  <rect x="485" y="78" width="50" height="38" rx="2" fill="#ffffff" stroke="#d9d2e9" stroke-width="1"/>
+  <text x="510" y="100" text-anchor="middle" font-size="8" fill="#666666">vLLM</text>
+  <rect x="545" y="78" width="50" height="38" rx="2" fill="#ffffff" stroke="#d9d2e9" stroke-width="1"/>
+  <text x="570" y="100" text-anchor="middle" font-size="8" fill="#666666">vLLM</text>
+  <rect x="605" y="78" width="50" height="38" rx="2" fill="#ffffff" stroke="#d9d2e9" stroke-width="1"/>
+  <text x="630" y="100" text-anchor="middle" font-size="8" fill="#666666">vLLM</text>
+
+  <!-- LoRA label for Pool A -->
+  <text x="720" y="100" text-anchor="middle" font-size="7" fill="#888888">+ LoRA:</text>
+  <text x="720" y="112" text-anchor="middle" font-size="7" fill="#888888">food-review-1</text>
+
+  <!-- InferencePool B -->
+  <rect x="345" y="210" width="455" height="105" rx="5" fill="#f8cecc" stroke="#b85450" stroke-width="1.5"/>
+  <text x="572" y="228" text-anchor="middle" font-size="11" font-weight="bold" fill="#000000">InferencePool B (deepseek/DeepSeek-r1)</text>
+
+  <!-- llm-d EPP B inside Pool B -->
+  <rect x="360" y="240" width="85" height="50" rx="3" fill="#f3f3f3" stroke="#d9d2e9" stroke-width="1"/>
+  <text x="402" y="260" text-anchor="middle" font-size="9" font-weight="bold" fill="#000000">llm-d EPP</text>
+  <text x="402" y="275" text-anchor="middle" font-size="7" fill="#666666">Select endpoint</text>
+  <text x="402" y="285" text-anchor="middle" font-size="6" fill="#888888">(ext-proc)</text>
+
+  <!-- EPP B to pods -->
+  <line x1="445" y1="265" x2="483" y2="265" stroke="#000000" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- Pods in Pool B -->
+  <rect x="485" y="243" width="50" height="38" rx="2" fill="#ffffff" stroke="#d9d2e9" stroke-width="1"/>
+  <text x="510" y="265" text-anchor="middle" font-size="8" fill="#666666">vLLM</text>
+  <rect x="545" y="243" width="50" height="38" rx="2" fill="#ffffff" stroke="#d9d2e9" stroke-width="1"/>
+  <text x="570" y="265" text-anchor="middle" font-size="8" fill="#666666">vLLM</text>
+  <rect x="605" y="243" width="50" height="38" rx="2" fill="#ffffff" stroke="#d9d2e9" stroke-width="1"/>
+  <text x="630" y="265" text-anchor="middle" font-size="8" fill="#666666">vLLM</text>
+
+  <!-- LoRA label for Pool B -->
+  <text x="720" y="258" text-anchor="middle" font-size="7" fill="#888888">+ LoRA:</text>
+  <text x="720" y="270" text-anchor="middle" font-size="7" fill="#888888">ski-resorts,</text>
+  <text x="720" y="282" text-anchor="middle" font-size="7" fill="#888888">movie-critique</text>
+
+  <!-- Note -->
+  <text x="572" y="340" text-anchor="middle" font-size="8" fill="#666666" font-style="italic">1 InferencePool : 1 llm-d EPP : 1 base model</text>
+
+  <!-- Caption -->
+  <text x="410" y="375" text-anchor="middle" font-size="9" fill="#888888">Proxy routes to InferencePool based on headers from llm-d IPP; llm-d EPP selects endpoint within pool</text>
+</svg>

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,49 @@
+# Metrics
+
+The **Inference Payload Processor (IPP)** exposes [Prometheus] metrics for build information, request
+processing, per-plugin latency, and model selection. They are served on a dedicated endpoint (default
+port `9090`, path `/metrics`).
+
+All metric names carry the `ipp_` prefix (the `ipp` Prometheus subsystem). Every metric is published
+at the **ALPHA** stability level, reflected as an `[ALPHA]` annotation at the start of each metric's
+help text.
+
+## Metrics Reference
+
+| Name | Type | Labels | Description |
+|------|------|--------|-------------|
+| `ipp_info` | Gauge | `commit`, `build_ref` | Build information of the running IPP. |
+| `ipp_success_total` | Counter | _(none)_ | Requests processed successfully. |
+| `ipp_body_field_not_found_total` | Counter | `field` | Times a `field` was not found in a request body. |
+| `ipp_body_field_empty_total` | Counter | `field` | Times a `field` was found in a request body but was empty. |
+| `ipp_plugin_duration_seconds` | Histogram | `extension_point`, `plugin_type`, `plugin_name` | Per-plugin processing latency, by [pipeline][processing pipeline] extension point. |
+| `ipp_model_selector_e2e_duration_seconds` | Histogram | _(none)_ | End-to-end [model selection][ModelSelector] latency. |
+| `ipp_model_selector_attempt_total` | Counter | `status` | Model-selection attempts, by `status` (`success` / `failure`). |
+| `ipp_request_ttft_seconds` | Histogram | `model` | Time to first token, per `model`. |
+
+Notes:
+
+- `ipp_info` is emitted once at startup with a constant value of `1`; the build identity lives in its labels. Join on it to attribute other series to a build.
+- `ipp_body_field_empty_total` distinguishes a present-but-empty field from a missing one (`ipp_body_field_not_found_total`).
+- `status="failure"` on `ipp_model_selector_attempt_total` covers cases such as filtering leaving zero candidate models.
+- Histogram buckets: `ipp_plugin_duration_seconds` and `ipp_model_selector_e2e_duration_seconds` span `0.0001s`–`0.1s` (sub-second plugin work); `ipp_request_ttft_seconds` spans `0.05s`–`30s` (end-to-end serving latency).
+
+## Scraping
+
+Metrics are served by the controller-runtime metrics server on `--metrics-port` (default `9090`) at
+`/metrics`. Access is governed by `--metrics-endpoint-auth`, **enabled by default**: when on, scrapers
+must present Kubernetes credentials authorized to read the endpoint; set it to `false` to serve
+without authentication. See [Configuration] for how these flags are wired through the Helm chart.
+
+## References
+
+- [Configuration] — Metrics serving and CLI flags.
+- [Architecture] — ext-proc integration, the processing pipeline, and model selection.
+- [metrics.go] — Authoritative metric definitions in source.
+
+[Configuration]: configuration.md
+[Architecture]: architecture.md
+[processing pipeline]: architecture.md#processing-pipeline
+[ModelSelector]: architecture.md#model-selection
+[metrics.go]: https://github.com/llm-d/llm-d-inference-payload-processor/blob/main/pkg/metrics/metrics.go
+[Prometheus]: https://prometheus.io

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -56,8 +56,8 @@ config loader routes each plugin to the right extension point based on that inte
 | **Model Selector — Filter** | Remove candidate models that cannot serve the request. | First phase of the ModelSelector pipeline (inside `model-selector`). |
 | **Model Selector — Scorer** | Score the remaining candidate models, conventionally in `[0, 1]`. | Second phase of the ModelSelector pipeline; scores combine via per-reference `weight`. |
 | **Model Selector — Picker** | Select exactly one final model from the scored candidates. | Third phase of the ModelSelector pipeline; exactly one picker runs. |
-| **Profile Picker** | Choose which profile runs for a request. | Globally, after pre-processing and before the profile's request plugins. |
-| **Data Layer** | Maintain cross-request state (collectors, extractors, datasources) consumed by Filters and Scorers. | Event-driven and continuous, decoupled from any single request. |
+| **Profile Picker** | Choose which profile runs for a request. | Globally, before the profile's request plugins. |
+| **Data Layer** | Maintain cross-request state (collectors, extractors, datasources) consumed by Scorers (and Filters). | Continuously in the background, decoupled from any single request. |
 
 ---
 
@@ -66,8 +66,11 @@ config loader routes each plugin to the right extension point based on that inte
 IPP executes plugins in a fixed sequence of stages:
 
 ```
-PreProcessing → ProfilePicker → Profile Request Plugins → [Model Server] → Profile Response Plugins → PostProcessing
+ProfilePicker → Profile Request Plugins → [Model Server] → Profile Response Plugins
 ```
+
+(The config API also defines global `preProcessing` / `postProcessing` stages; these are reserved
+extension points and are not yet invoked by the request path — see [Architecture][Architecture].)
 
 Plugins are **declared once** under the top-level `plugins` list of the `PayloadProcessorConfig`
 (each with a `type`, an optional `name`, and optional `parameters`) and then **referenced by name**
@@ -252,8 +255,9 @@ falls back to `random-picker` for uniform selection.
 
 ## Data Layer Plugins
 
-Data-layer plugins maintain cross-request state consumed by Filters and Scorers. They are event-driven
-and run continuously, decoupled from any single request, and are referenced under the top-level
+Data-layer plugins maintain cross-request state consumed by Scorers (and Filters). They run
+continuously in the background (extractors on request/response events, collectors on a timer,
+datasources as watchers), decoupled from any single request, and are referenced under the top-level
 `datalayer` section as `collectors`, `extractors`, or `datasources` — **never** in a profile's
 request list. See [Data Layer][Architecture] for the conceptual model.
 
@@ -304,9 +308,9 @@ extension point. To add one, implement `ResponseProcessor` and register it (see
 
 ## Pre- and Post-Processors
 
-**PreProcessors** run before profile selection (logic common to all requests); **PostProcessors** run
-after the selected profile's response plugins. **There are no in-tree pre- or post-processors** —
-both are framework extension points for custom plugins.
+**PreProcessing** and **PostProcessing** are reserved global extension points in the config API
+(before profile selection and after the response plugins). They are **not yet invoked by the request
+path**, and there are no in-tree pre- or post-processors.
 
 ---
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,394 @@
+# IPP Plugins Reference
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Plugin Categories](#plugin-categories)
+- [Processing Pipeline](#processing-pipeline)
+- [Request Handling Plugins](#request-handling-plugins)
+  - [`body-field-to-header`](#body-field-to-header)
+  - [`base-model-to-header`](#base-model-to-header)
+  - [`model-selector`](#model-selector)
+- [Profile Picker Plugins](#profile-picker-plugins)
+  - [`single-profile-picker`](#single-profile-picker)
+- [Model Selector Plugins](#model-selector-plugins)
+  - [Filters](#filters)
+  - [Scorers](#scorers)
+    - [`cost-scorer`](#cost-scorer)
+    - [`inflight-requests-scorer`](#inflight-requests-scorer)
+  - [Pickers](#pickers)
+    - [`max-score-picker`](#max-score-picker)
+    - [`random-picker`](#random-picker)
+    - [`weighted-random-picker`](#weighted-random-picker)
+- [Data Layer Plugins](#data-layer-plugins)
+  - [`request-metadata-extractor`](#request-metadata-extractor)
+  - [`model-config-datasource`](#model-config-datasource)
+- [Response Handling Plugins](#response-handling-plugins)
+- [Pre- and Post-Processors](#pre--and-post-processors)
+- [Configuration Example](#configuration-example)
+- [References](#references)
+
+---
+
+## Overview
+
+All IPP behavior is implemented as **plugins**. The framework defines the pipeline and the extension
+points; concrete behavior lives in plugins that are selected, parameterized, and ordered in a
+[`PayloadProcessorConfig`][Configuration]. Each plugin has a **registered type name** (a constant in
+its source) and a configurable instance **name**; because instances are named, the same plugin type
+can be configured more than once with different parameters.
+
+This document lists every in-tree plugin, grouped by category, with its registered type name,
+purpose, parameters, and a link to its source. For the conceptual model — profiles, the ext-proc
+lifecycle, model selection, and the data layer — see the [Architecture][Architecture] document.
+
+---
+
+## Plugin Categories
+
+A plugin belongs to exactly one category, determined by the framework interface it implements. The
+config loader routes each plugin to the right extension point based on that interface.
+
+| Category | Purpose | When executed |
+|----------|---------|---------------|
+| **Request Handling** | Inspect and mutate the request (headers, body) before it is routed. | During a profile's `request` stage, before the model server is reached. |
+| **Response Handling** | Inspect and mutate the response on its way back to the client. | During a profile's `response` stage, after the model server replies. |
+| **Model Selector — Filter** | Remove candidate models that cannot serve the request. | First phase of the ModelSelector pipeline (inside `model-selector`). |
+| **Model Selector — Scorer** | Score the remaining candidate models, conventionally in `[0, 1]`. | Second phase of the ModelSelector pipeline; scores combine via per-reference `weight`. |
+| **Model Selector — Picker** | Select exactly one final model from the scored candidates. | Third phase of the ModelSelector pipeline; exactly one picker runs. |
+| **Profile Picker** | Choose which profile runs for a request. | Globally, after pre-processing and before the profile's request plugins. |
+| **Data Layer** | Maintain cross-request state (collectors, extractors, datasources) consumed by Filters and Scorers. | Event-driven and continuous, decoupled from any single request. |
+
+---
+
+## Processing Pipeline
+
+IPP executes plugins in a fixed sequence of stages:
+
+```
+PreProcessing → ProfilePicker → Profile Request Plugins → [Model Server] → Profile Response Plugins → PostProcessing
+```
+
+Plugins are **declared once** under the top-level `plugins` list of the `PayloadProcessorConfig`
+(each with a `type`, an optional `name`, and optional `parameters`) and then **referenced by name**
+elsewhere in the config via `pluginRef`:
+
+- `profiles[].plugins.request[]` and `profiles[].plugins.response[]` reference request- and
+  response-handling plugins. A profile's `request` list may also reference model-selector plugins
+  (Filter / Scorer / Picker); the loader routes each reference by the interface the plugin
+  implements. Scorer references carry a `weight`.
+- `profilePicker.pluginRef` references the profile picker. When exactly one profile is defined and no
+  picker is configured, [`single-profile-picker`](#single-profile-picker) is enabled automatically.
+- `preProcessing.plugins[]` and `postProcessing.plugins[]` reference pre- and post-processors.
+- `datalayer.collectors[]`, `datalayer.extractors[]`, and `datalayer.datasources[]` reference
+  data-layer plugins. These are **not** part of any profile's request list.
+
+For the conceptual model behind profiles, model selection, and the data layer, see
+[Architecture][Architecture]. For the full configuration schema, see [Configuration][Configuration].
+
+---
+
+## Request Handling Plugins
+
+Request-handling plugins implement the `RequestProcessor` interface and process the request body and
+headers before routing.
+
+### `body-field-to-header`
+
+Extracts a single field from the JSON request body and sets its value as an HTTP header. If the
+field is absent or empty, the plugin records a metric and skips without error. This is the generic
+building block behind model-aware routing — for example, copying the `model` body field into the
+`X-Gateway-Model-Name` header.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `fieldName` | string | yes | Name of the request-body field to extract. |
+| `headerName` | string | yes | Name of the HTTP header to set with the extracted value. |
+
+**Source:** [`pkg/framework/plugins/requesthandling/bodyfieldtoheader/`][src-bodyfieldtoheader]
+
+### `base-model-to-header`
+
+Maps the request's `model` name — including LoRA adapter names — to its **base model** and writes the
+result to the `X-Gateway-Base-Model-Name` routing header. The adapter-to-base-model mapping is
+maintained by a ConfigMap reconciler that watches IPP-managed model-mapping ConfigMaps, so the
+mapping updates at runtime without restarts. If the request has no `model` field the plugin skips; if
+the model is neither a known adapter nor a registered base model, the header is set to the empty
+string. This plugin powers [multi-pool routing][Architecture].
+
+**Parameters:** None. The plugin is wired to the controller-runtime client and reconciler via its
+plugin handle; the model mappings come from labeled ConfigMaps (see [Configuration][Configuration]),
+not from plugin parameters.
+
+**Source:** [`pkg/framework/plugins/requesthandling/basemodelextractor/`][src-basemodelextractor]
+
+### `model-selector`
+
+Entry point for the **ModelSelector** framework. When present in a profile's `request` list, it runs
+the `Filter → Score → Pick` pipeline over the candidate models in the datastore, then writes the
+selected model name back into the request body's `model` field so the rest of the pipeline proceeds
+as if the client had requested that model directly. The Filter, Scorer, and Picker plugins for this
+profile are declared in the same profile `request` list and wired into the selector by the config
+loader; if no picker is referenced, [`max-score-picker`](#max-score-picker) is used by default. If no
+candidate models are available, the plugin returns an error.
+
+**Parameters:** None. The pipeline is assembled from the profile's other model-selector references,
+not from parameters on this plugin.
+
+**Source:** [`pkg/framework/plugins/requesthandling/modelselector/`][src-modelselector]
+
+---
+
+## Profile Picker Plugins
+
+A profile picker chooses which profile runs for a request. It implements the `ProfilePicker`
+interface and is referenced via the top-level `profilePicker` field.
+
+### `single-profile-picker`
+
+Selects the single configured profile for every request. It is **enabled by default** when exactly
+one profile is defined and no profile picker is configured, so you typically do not declare it
+explicitly. Useful when an IPP deployment runs a single processing path.
+
+**Parameters:** None.
+
+**Source:** [README][readme-single]
+
+---
+
+## Model Selector Plugins
+
+Model-selector plugins implement the ModelSelector framework's `Filter`, `Scorer`, and `Picker`
+interfaces. They are referenced inside a profile's `request` list alongside the
+[`model-selector`](#model-selector) plugin, and the loader routes each reference to the correct phase
+by interface. See the [ModelSelector proposal][ModelSelector proposal] for the framework design.
+
+### Filters
+
+Filters remove candidate models that cannot serve a request; if filtering leaves zero candidates the
+framework returns an error to the client.
+
+**There are no in-tree filter plugins.** Filtering is a framework extension point — implement the
+`Filter` interface and register it to add one (see [Creating a Plugin][Creating a Plugin]).
+
+### Scorers
+
+Scorers assign each remaining candidate model a score, conventionally in `[0, 1]`. Multiple scorers
+combine via the per-reference `weight` set in the profile (a scorer reference **requires** a
+`weight`).
+
+#### `cost-scorer`
+
+Scores candidate models by price so that cheaper models score higher. Each model carries a `price`
+attribute (USD per 1M tokens); the score is computed with inverted sum normalization,
+`1 - price / sum(prices)`. A single candidate receives a neutral score of `0.5`, and when every
+candidate's price is zero all candidates receive `1.0`. Use it for cost-aware model selection.
+
+**Parameters:** None. Prices are read from each model's `price` attribute in the datastore, not from
+plugin parameters.
+
+**Source:** [`pkg/framework/plugins/modelselector/scorer/costaware/`][src-costscorer]
+
+> [!NOTE]
+> `cost-scorer` ships in-tree as a reference implementation but is **not registered in the default
+> runner**. To use it, register its factory in `registerInTreePlugins` (see
+> [Creating a Plugin][Creating a Plugin]) or register it from your own runner build.
+
+#### `inflight-requests-scorer`
+
+Scores candidate models by current in-flight request load so that the least-loaded model scores
+highest. With per-model in-flight counts `count`, the score is `(max - count) / (max - min)`; the
+least-loaded model scores `1.0` and the most-loaded scores `0.0`. Models with no in-flight-request
+attribute are treated as idle (zero), and if all candidates share the same count they all score
+`1.0`. It consumes the in-flight counts produced by
+[`request-metadata-extractor`](#request-metadata-extractor), so configure that data-layer extractor
+alongside this scorer.
+
+**Parameters:** None. In-flight counts are read from each model's `request-metadata` attribute in the
+datastore.
+
+**Source:** [`pkg/framework/plugins/modelselector/scorer/inflightrequests/`][src-inflightscorer]
+
+### Pickers
+
+A picker selects the single final model from the scored candidates. Exactly one picker runs per
+model-selection profile; if none is referenced, [`max-score-picker`](#max-score-picker) is added by
+default.
+
+#### `max-score-picker`
+
+Selects the candidate with the highest score, shuffling first so that ties are broken at random. It
+maximizes adherence to the scoring objective (e.g. lowest cost or lowest load) but is susceptible to
+**hot-spotting** when many concurrent requests produce identical scores for the same model.
+
+**Parameters:** None.
+
+**Source:** [README][readme-maxscore]
+
+#### `random-picker`
+
+Selects a candidate uniformly at random, ignoring all scores. It gives a strictly uniform load
+distribution — immune to hot-spotting, but unable to leverage cost or load signals.
+
+**Parameters:** None.
+
+**Source:** [README][readme-random]
+
+#### `weighted-random-picker`
+
+Selects a candidate at random with probability proportional to its score, using the **A-Res**
+(Algorithm for Reservoir Sampling) algorithm for mathematically correct weighted sampling. It
+balances the trade-off between `max-score-picker` and `random-picker`, favoring higher-scoring models
+while retaining exploration to avoid extreme hot-spotting. If every candidate scores zero or less, it
+falls back to `random-picker` for uniform selection.
+
+**Parameters:** None.
+
+**Source:** [README][readme-weightedrandom]
+
+---
+
+## Data Layer Plugins
+
+Data-layer plugins maintain cross-request state consumed by Filters and Scorers. They are event-driven
+and run continuously, decoupled from any single request, and are referenced under the top-level
+`datalayer` section as `collectors`, `extractors`, or `datasources` — **never** in a profile's
+request list. See [Data Layer][Architecture] for the conceptual model.
+
+### `request-metadata-extractor`
+
+An **extractor** that tracks in-flight request counts and token sums per model. On each request event
+it increments the model's request count and adds the request's `max_tokens` to its token sum; on the
+corresponding response event it decrements both (flooring at zero). The result is written to each
+model's `request-metadata` attribute, which [`inflight-requests-scorer`](#inflight-requests-scorer)
+consumes. Reference it under `datalayer.extractors`.
+
+**Parameters:** None. The extractor is wired to the shared datastore via its plugin handle.
+
+**Source:** [`pkg/framework/plugins/datalayer/requestmetadata/`][src-requestmetadata]
+
+### `model-config-datasource`
+
+A **datasource** that imports the set of known model names into the datastore from a JSON config
+file, keeping the datastore in sync as the file changes. It watches the file's parent directory (to
+handle atomic, rename-based replacements such as Kubernetes ConfigMap remounts), registers every
+listed model, and removes any datastore model no longer present in the file. This populates the
+candidate-model set that [`model-selector`](#model-selector) reads. Reference it under
+`datalayer.datasources`.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `modelsPath` | string | yes | Path to a JSON file with the schema `{"models": [{"name": "..."}]}`. Must be an existing file (not a directory). |
+
+**Source:** [`pkg/framework/plugins/datalayer/modelconfigcollector/`][src-modelconfig]
+
+> [!NOTE]
+> `model-config-datasource` ships in-tree as a reference implementation but is **not registered in the
+> default runner**. To use it, register its factory in `registerInTreePlugins` (see
+> [Creating a Plugin][Creating a Plugin]) or register it from your own runner build.
+
+---
+
+## Response Handling Plugins
+
+Response-handling plugins implement the `ResponseProcessor` interface and run during a profile's
+`response` stage. **There are no in-tree response-handling plugins** — this is a framework
+extension point. To add one, implement `ResponseProcessor` and register it (see
+[Creating a Plugin][Creating a Plugin]).
+
+---
+
+## Pre- and Post-Processors
+
+**PreProcessors** run before profile selection (logic common to all requests); **PostProcessors** run
+after the selected profile's response plugins. **There are no in-tree pre- or post-processors** —
+both are framework extension points for custom plugins.
+
+---
+
+## Configuration Example
+
+A complete `PayloadProcessorConfig` that performs cost- and load-aware model selection. Plugins are
+declared once under the top-level `plugins` list and referenced by name. The model-selection profile
+references `model-selector` together with two weighted scorers and the `weighted-random-picker`, plus
+the two header plugins. The `request-metadata-extractor` and `model-config-datasource` are wired under
+the top-level `datalayer` section — not in the profile's request list.
+
+> [!NOTE]
+> This example uses `cost-scorer` and `model-config-datasource`, which are in-tree but not registered
+> in the default runner (see their notes above). Register their factories before applying this config,
+> or drop them to run with the default plugin set.
+
+```yaml
+apiVersion: llm-d.ai/v1alpha1
+kind: PayloadProcessorConfig
+plugins:
+- type: body-field-to-header
+  parameters:
+    fieldName: model
+    headerName: X-Gateway-Model-Name
+- type: base-model-to-header
+- type: model-selector
+- type: cost-scorer
+- type: inflight-requests-scorer
+- type: weighted-random-picker
+- type: request-metadata-extractor
+- type: model-config-datasource
+  parameters:
+    modelsPath: /etc/ipp/models.json
+profiles:
+- name: model-selection
+  plugins:
+    request:
+    - pluginRef: body-field-to-header
+    - pluginRef: base-model-to-header
+    - pluginRef: model-selector
+    - pluginRef: cost-scorer
+      weight: 1.0
+    - pluginRef: inflight-requests-scorer
+      weight: 2.0
+    - pluginRef: weighted-random-picker
+datalayer:
+  extractors:
+  - pluginRef: request-metadata-extractor
+  datasources:
+  - pluginRef: model-config-datasource
+```
+
+With a single profile and no `profilePicker` configured, IPP auto-enables
+[`single-profile-picker`](#single-profile-picker). The `model-config-datasource` populates the
+candidate models, `request-metadata-extractor` maintains their in-flight counts, and the two scorers
+combine by weight (here the load signal is weighted twice the cost signal) before
+`weighted-random-picker` chooses the final model.
+
+For the full schema, Helm values, ConfigMaps, and proxy integration, see [Configuration][Configuration].
+
+---
+
+## References
+
+- [Architecture][Architecture] — The conceptual model: ext-proc, profiles, model selection, and the data layer.
+- [Configuration][Configuration] — Full configuration reference for the `PayloadProcessorConfig` API.
+- [Creating a Plugin][Creating a Plugin] — Tutorial for writing and registering a custom plugin.
+- [ModelSelector proposal][ModelSelector proposal] — Design of the model-selection framework.
+
+[Architecture]: architecture.md
+[Configuration]: configuration.md
+[Creating a Plugin]: create_new_plugin.md
+[ModelSelector proposal]: proposals/043-model-selection-framework/README.md
+
+[src-bodyfieldtoheader]: https://github.com/llm-d/llm-d-inference-payload-processor/tree/main/pkg/framework/plugins/requesthandling/bodyfieldtoheader
+[src-basemodelextractor]: https://github.com/llm-d/llm-d-inference-payload-processor/tree/main/pkg/framework/plugins/requesthandling/basemodelextractor
+[src-modelselector]: https://github.com/llm-d/llm-d-inference-payload-processor/tree/main/pkg/framework/plugins/requesthandling/modelselector
+[src-costscorer]: https://github.com/llm-d/llm-d-inference-payload-processor/tree/main/pkg/framework/plugins/modelselector/scorer/costaware
+[src-inflightscorer]: https://github.com/llm-d/llm-d-inference-payload-processor/tree/main/pkg/framework/plugins/modelselector/scorer/inflightrequests
+[src-requestmetadata]: https://github.com/llm-d/llm-d-inference-payload-processor/tree/main/pkg/framework/plugins/datalayer/requestmetadata
+[src-modelconfig]: https://github.com/llm-d/llm-d-inference-payload-processor/tree/main/pkg/framework/plugins/datalayer/modelconfigcollector
+[readme-single]: https://github.com/llm-d/llm-d-inference-payload-processor/blob/main/pkg/framework/plugins/requesthandling/profilepicker/single/README.md
+[readme-maxscore]: https://github.com/llm-d/llm-d-inference-payload-processor/blob/main/pkg/framework/plugins/modelselector/picker/maxscore/README.md
+[readme-random]: https://github.com/llm-d/llm-d-inference-payload-processor/blob/main/pkg/framework/plugins/modelselector/picker/random/README.md
+[readme-weightedrandom]: https://github.com/llm-d/llm-d-inference-payload-processor/blob/main/pkg/framework/plugins/modelselector/picker/weightedrandom/README.md


### PR DESCRIPTION
## What

Establishes a coherent documentation set for the Inference Payload Processor (IPP):
rewrites the README and adds a `docs/` set so the detailed IPP material lives in-repo
and can be pointed to from the llm-d well-lit-paths / guides.

Brought in line with llm-d project conventions (aligned with llm-d-router): same README
structure and badges, `Modes of Operation` / `Terminology` / `Contributing` sections,
reference-style links, and a `create_new_*.md` tutorial.

## Contents

- **README** — overview, core capabilities, modes of operation, terminology, and a doc index.
- **docs/architecture.md** — ext-proc integration, the processing pipeline, profiles,
  model selection, the data layer, multi-pool routing, and the IPP↔EPP (llm-d Router) relationship.
- **docs/configuration.md** — the `PayloadProcessorConfig` API, model-mapping ConfigMaps,
  Helm values, CLI flags, env vars, and Istio/GKE/HTTPRoute proxy integration.
- **docs/plugins.md** — reference for every in-tree plugin and how the pipeline composes them.
- **docs/create_new_plugin.md** — tutorial for writing and registering a custom plugin.
- **docs/metrics.md** — Prometheus metrics reference.
- **docs/images/** — request-flow and multi-pool routing diagrams.

## Accuracy

The set was reviewed against the code: metrics, CLI flags/defaults, the config schema,
the scorer/picker math, plugin registration, Helm values, and the proxy-integration
templates were each checked against source. Notable corrections folded in:

- PreProcessing/PostProcessing are documented as **reserved** config-API extension points
  (defined but not yet wired into the request path), rather than executed stages.
- A scorer `weight` is **required** for scorer references (the loader errors when omitted).
- The `customConfig` Helm example omits `apiVersion`/`kind` (the chart injects the GVK
  header — verified with `helm template` that it renders a single header).
- `-v` default is `2`; `--secure-serving` TLS behavior, the extra `--zap-*` flags, and the
  shipped default config (`deploy/config/ipp-config.yaml`) are documented.
- `provider=none` renders config + RBAC (not only Deployment + Service).

## Notes

- The `HTTPRoute` resources for multi-pool routing are user-supplied, not chart-generated
  (documented as such).
- The end-to-end deployment walkthrough is expected to live in the llm-d project guides.