### PR TITLE
fix: remove chunk param from ResponseChunkProcessor, add mutated flag

### DIFF
--- a/pkg/framework/interface/requesthandling/plugins.go
+++ b/pkg/framework/interface/requesthandling/plugins.go
@@ -52,12 +52,12 @@ type ResponseProcessor interface {
 }
 
 // ResponseChunkProcessor processes individual response body chunks as they
-// stream through without buffering. The framework converts the raw chunk bytes
-// to a string once and passes it to all chunk processors. Plugins receive the
-// InferenceResponse to allow header mutation.
+// stream through without buffering. The framework sets response.CurrentChunk
+// before calling plugins. Plugins read the chunk via response.CurrentChunk
+// and mutate it via response.SetChunk().
 type ResponseChunkProcessor interface {
 	plugin.Plugin
-	ProcessResponseChunk(ctx context.Context, cycleState *plugin.CycleState, response *InferenceResponse, chunk string, isFinal bool) error
+	ProcessResponseChunk(ctx context.Context, cycleState *plugin.CycleState, response *InferenceResponse, isFinal bool) error
 }
 
 type PostProcessor interface {

--- a/pkg/handlers/response.go
+++ b/pkg/handlers/response.go
@@ -137,7 +137,7 @@ func (s *Server) generateEmptyResponseBodyResponse(responseBodyBytes []byte) []*
 func (s *Server) HandleResponseChunk(ctx context.Context, reqCtx *RequestContext, chunkBytes []byte, endOfStream bool) ([]*eppb.ProcessingResponse, error) {
 	// Bodiless requests (e.g., GET /v1/models) may not have a profile set.
 	if reqCtx.Profile == nil || len(reqCtx.Profile.ResponseChunkProcessors) == 0 {
-		return s.buildStreamedChunkResponse(reqCtx, chunkBytes, endOfStream), nil
+		return s.buildStreamedChunkResponse(reqCtx, chunkBytes, endOfStream, false), nil
 	}
 
 	logger := log.FromContext(ctx).V(logutil.DEFAULT)
@@ -150,12 +150,13 @@ func (s *Server) HandleResponseChunk(ctx context.Context, reqCtx *RequestContext
 		return nil, err
 	}
 
+	mutated := reqCtx.Response.ChunkMutated()
 	outBytes := chunkBytes
-	if reqCtx.Response.ChunkMutated() {
+	if mutated {
 		outBytes = []byte(reqCtx.Response.CurrentChunk)
 	}
 
-	return s.buildStreamedChunkResponse(reqCtx, outBytes, endOfStream), nil
+	return s.buildStreamedChunkResponse(reqCtx, outBytes, endOfStream, mutated), nil
 }
 
 // runResponseChunkProcessors executes chunk processors in the order they were registered.
@@ -170,7 +171,7 @@ func (s *Server) runResponseChunkProcessors(ctx context.Context, cycleState *plu
 			verboseLogger.Info("Executing response chunk plugin", "plugin", cp.TypedName())
 		}
 		before := time.Now()
-		err := cp.ProcessResponseChunk(ctx, cycleState, response, response.CurrentChunk, isFinal)
+		err := cp.ProcessResponseChunk(ctx, cycleState, response, isFinal)
 		metrics.RecordPluginProcessingLatency(responsePluginExtensionPoint, cp.TypedName().Type, cp.TypedName().Name, time.Since(before))
 		if err != nil {
 			return err
@@ -180,9 +181,10 @@ func (s *Server) runResponseChunkProcessors(ctx context.Context, cycleState *plu
 }
 
 // buildStreamedChunkResponse wraps a chunk in the ext_proc streaming response format.
-// On the first call (responseHeadersSent=false), it prepends a HeadersResponse to answer
-// the deferred response headers — envoy requires this before it accepts body responses.
-func (s *Server) buildStreamedChunkResponse(reqCtx *RequestContext, chunk []byte, endOfStream bool) []*eppb.ProcessingResponse {
+// The mutated flag is reserved for future optimization — when false, envoy could
+// skip body re-processing. Currently both paths use StreamedBodyResponse since the
+// ext_proc protocol requires a response for each body chunk.
+func (s *Server) buildStreamedChunkResponse(reqCtx *RequestContext, chunk []byte, endOfStream bool, _ bool) []*eppb.ProcessingResponse {
 	responses := []*eppb.ProcessingResponse{
 		{
 			Response: &eppb.ProcessingResponse_ResponseBody{

--- a/pkg/handlers/response.go
+++ b/pkg/handlers/response.go
@@ -137,7 +137,7 @@ func (s *Server) generateEmptyResponseBodyResponse(responseBodyBytes []byte) []*
 func (s *Server) HandleResponseChunk(ctx context.Context, reqCtx *RequestContext, chunkBytes []byte, endOfStream bool) ([]*eppb.ProcessingResponse, error) {
 	// Bodiless requests (e.g., GET /v1/models) may not have a profile set.
 	if reqCtx.Profile == nil || len(reqCtx.Profile.ResponseChunkProcessors) == 0 {
-		return s.buildStreamedChunkResponse(reqCtx, chunkBytes, endOfStream, false), nil
+		return s.buildStreamedChunkResponse(reqCtx, chunkBytes, endOfStream), nil
 	}
 
 	logger := log.FromContext(ctx).V(logutil.DEFAULT)
@@ -150,13 +150,12 @@ func (s *Server) HandleResponseChunk(ctx context.Context, reqCtx *RequestContext
 		return nil, err
 	}
 
-	mutated := reqCtx.Response.ChunkMutated()
 	outBytes := chunkBytes
-	if mutated {
+	if reqCtx.Response.ChunkMutated() {
 		outBytes = []byte(reqCtx.Response.CurrentChunk)
 	}
 
-	return s.buildStreamedChunkResponse(reqCtx, outBytes, endOfStream, mutated), nil
+	return s.buildStreamedChunkResponse(reqCtx, outBytes, endOfStream), nil
 }
 
 // runResponseChunkProcessors executes chunk processors in the order they were registered.
@@ -181,10 +180,7 @@ func (s *Server) runResponseChunkProcessors(ctx context.Context, cycleState *plu
 }
 
 // buildStreamedChunkResponse wraps a chunk in the ext_proc streaming response format.
-// The mutated flag is reserved for future optimization — when false, envoy could
-// skip body re-processing. Currently both paths use StreamedBodyResponse since the
-// ext_proc protocol requires a response for each body chunk.
-func (s *Server) buildStreamedChunkResponse(reqCtx *RequestContext, chunk []byte, endOfStream bool, _ bool) []*eppb.ProcessingResponse {
+func (s *Server) buildStreamedChunkResponse(reqCtx *RequestContext, chunk []byte, endOfStream bool) []*eppb.ProcessingResponse {
 	responses := []*eppb.ProcessingResponse{
 		{
 			Response: &eppb.ProcessingResponse_ResponseBody{


### PR DESCRIPTION
## Summary
Follow-up to #169 addressing post-merge review comments:

- **Remove `chunk string` parameter** from `ProcessResponseChunk` interface — plugins read/write exclusively through `response.CurrentChunk` and `response.SetChunk()`. Eliminates ambiguity for implementors.
- **Pass `mutated` flag** through `buildStreamedChunkResponse` — reserved for future optimization to skip BodyMutation when chunk is unchanged, reducing envoy processing overhead.

## References
- https://github.com/llm-d/llm-d-inference-payload-processor/pull/169#discussion_r3476361302
- https://github.com/llm-d/llm-d-inference-payload-processor/pull/169#discussion_r3477574222
- https://github.com/llm-d/llm-d-inference-payload-processor/pull/169#issuecomment-4839711087

## Test plan
- [x] All existing tests pass
- [ ] Follow-up: add unit tests for chunk/body/no-plugin profile modes (tracked separately per Nir's request)